### PR TITLE
feat: base transformation property types

### DIFF
--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/BoolType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/BoolType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record BoolType : IPropertyType<BoolValue>
+{
+    public BoolValue Read(ref MinecraftBuffer buffer)
+    {
+        return BoolValue.FromPrimitive(buffer.ReadBoolean());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, BoolValue value)
+    {
+        buffer.WriteBoolean(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ByteType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ByteType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record ByteType : IPropertyType<ByteValue>
+{
+    public ByteValue Read(ref MinecraftBuffer buffer)
+    {
+        return ByteValue.FromPrimitive(buffer.ReadUnsignedByte());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, ByteValue value)
+    {
+        buffer.WriteUnsignedByte(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/DoubleType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/DoubleType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record DoubleType : IPropertyType<DoubleValue>
+{
+    public DoubleValue Read(ref MinecraftBuffer buffer)
+    {
+        return DoubleValue.FromPrimitive(buffer.ReadDouble());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, DoubleValue value)
+    {
+        buffer.WriteDouble(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/FloatType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/FloatType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record FloatType : IPropertyType<FloatValue>
+{
+    public FloatValue Read(ref MinecraftBuffer buffer)
+    {
+        return FloatValue.FromPrimitive(buffer.ReadFloat());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, FloatValue value)
+    {
+        buffer.WriteFloat(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IListPropertyType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IListPropertyType.cs
@@ -1,0 +1,10 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public interface IListPropertyType<TPropertyValue> : IPropertyType where TPropertyValue : IPropertyValue
+{
+    public List<TPropertyValue> Read(ref MinecraftBuffer buffer);
+    public void Write(ref MinecraftBuffer buffer, List<TPropertyValue> value);
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IOptionalPropertyType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IOptionalPropertyType.cs
@@ -1,0 +1,10 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public interface IOptionalPropertyType<TPropertyValue> : IPropertyType where TPropertyValue : IPropertyValue
+{
+    public TPropertyValue? Read(ref MinecraftBuffer buffer);
+    public void Write(ref MinecraftBuffer buffer, TPropertyValue? value);
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IntType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/IntType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record IntType : IPropertyType<IntValue>
+{
+    public IntValue Read(ref MinecraftBuffer buffer)
+    {
+        return IntValue.FromPrimitive(buffer.ReadInt());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, IntValue value)
+    {
+        buffer.WriteInt(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ListType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ListType.cs
@@ -1,0 +1,31 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record ListType<TPropertyValue>(IPropertyType<TPropertyValue> Type) : IListPropertyType<TPropertyValue> where TPropertyValue : IPropertyValue
+{
+    public List<TPropertyValue> Read(ref MinecraftBuffer buffer)
+    {
+        var size = buffer.ReadVarInt();
+        if (size == 0)
+            return [];
+        
+        var list = new List<TPropertyValue>(size);
+        
+        for (var i = 0; i < size; i++)
+        {
+            var value = Type.Read(ref buffer);
+            list.Add(value);
+        }
+
+        return list;
+    }
+
+    public void Write(ref MinecraftBuffer buffer, List<TPropertyValue> value)
+    {
+        buffer.WriteVarInt(value.Count);
+        foreach (var item in value)
+            Type.Write(ref buffer, item);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/LongType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/LongType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record LongType : IPropertyType<LongValue>
+{
+    public LongValue Read(ref MinecraftBuffer buffer)
+    {
+        return LongValue.FromPrimitive(buffer.ReadLong());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, LongValue value)
+    {
+        buffer.WriteLong(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/NbtType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/NbtType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record NbtType : IPropertyType<NbtValue>
+{
+    public NbtValue Read(ref MinecraftBuffer buffer)
+    {
+        return NbtValue.FromPrimitive(buffer.ReadTag());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, NbtValue value)
+    {
+        buffer.WriteTag(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/NbtType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/NbtType.cs
@@ -7,11 +7,11 @@ public record NbtType : IPropertyType<NbtValue>
 {
     public NbtValue Read(ref MinecraftBuffer buffer)
     {
-        return NbtValue.FromPrimitive(buffer.ReadTag());
+        return NbtValue.FromNbtTag(buffer.ReadTag());
     }
 
     public void Write(ref MinecraftBuffer buffer, NbtValue value)
     {
-        buffer.WriteTag(value.AsPrimitive);
+        buffer.WriteTag(value.AsNbtTag);
     }
 }

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/OptionalType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/OptionalType.cs
@@ -1,0 +1,25 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record OptionalType<TPropertyValue>(IPropertyType<TPropertyValue> Type) : IOptionalPropertyType<TPropertyValue> where TPropertyValue : IPropertyValue
+{
+    public TPropertyValue? Read(ref MinecraftBuffer buffer)
+    {
+        var isPresent = buffer.ReadBoolean();
+        if (!isPresent)
+            return default;
+        
+        return Type.Read(ref buffer);
+    }
+
+    public void Write(ref MinecraftBuffer buffer, TPropertyValue? value)
+    {
+        buffer.WriteBoolean(value is not null);
+        if (value is null)
+            return;
+        
+        Type.Write(ref buffer, value);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ShortType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/ShortType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record ShortType : IPropertyType<ShortValue>
+{
+    public ShortValue Read(ref MinecraftBuffer buffer)
+    {
+        return ShortValue.FromPrimitive(buffer.ReadUnsignedShort());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, ShortValue value)
+    {
+        buffer.WriteUnsignedShort(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/StringType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/StringType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record StringType : IPropertyType<StringValue>
+{
+    public StringValue Read(ref MinecraftBuffer buffer)
+    {
+        return StringValue.FromPrimitive(buffer.ReadString());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, StringValue value)
+    {
+        buffer.WriteString(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/UuidType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/UuidType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record UuidType : IPropertyType<UuidValue>
+{
+    public UuidValue Read(ref MinecraftBuffer buffer)
+    {
+        return UuidValue.FromPrimitive(buffer.ReadUuid());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, UuidValue value)
+    {
+        buffer.WriteUuid(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/UuidType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/UuidType.cs
@@ -7,11 +7,11 @@ public record UuidType : IPropertyType<UuidValue>
 {
     public UuidValue Read(ref MinecraftBuffer buffer)
     {
-        return UuidValue.FromPrimitive(buffer.ReadUuid());
+        return UuidValue.FromUuid(buffer.ReadUuid());
     }
 
     public void Write(ref MinecraftBuffer buffer, UuidValue value)
     {
-        buffer.WriteUuid(value.AsPrimitive);
+        buffer.WriteUuid(value.AsUuid);
     }
 }

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/VarLongType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Types/VarLongType.cs
@@ -1,0 +1,17 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Types;
+
+public record VarLongType : IPropertyType<VarLongValue>
+{
+    public VarLongValue Read(ref MinecraftBuffer buffer)
+    {
+        return VarLongValue.FromPrimitive(buffer.ReadVarInt());
+    }
+
+    public void Write(ref MinecraftBuffer buffer, VarLongValue value)
+    {
+        buffer.WriteVarLong(value.AsPrimitive);
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/BoolValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/BoolValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record BoolValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public bool AsPrimitive => new MinecraftBuffer(Value.Span).ReadBoolean();
+
+    public static BoolValue FromPrimitive(bool value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteBoolean(value);
+        
+        return new BoolValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/ByteValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/ByteValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record ByteValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public byte AsPrimitive => new MinecraftBuffer(Value.Span).ReadUnsignedByte();
+
+    public static ByteValue FromPrimitive(byte value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteUnsignedByte(value);
+        
+        return new ByteValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/DoubleValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/DoubleValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record DoubleValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public double AsPrimitive => new MinecraftBuffer(Value.Span).ReadDouble();
+
+    public static DoubleValue FromPrimitive(double value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteDouble(value);
+        
+        return new DoubleValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/FloatValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/FloatValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record FloatValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public float AsPrimitive => new MinecraftBuffer(Value.Span).ReadFloat();
+
+    public static FloatValue FromPrimitive(float value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteFloat(value);
+        
+        return new FloatValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/IntValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/IntValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record IntValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public int AsPrimitive => new MinecraftBuffer(Value.Span).ReadInt();
+
+    public static IntValue FromPrimitive(int value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteInt(value);
+        
+        return new IntValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/LongValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/LongValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record LongValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public long AsPrimitive => new MinecraftBuffer(Value.Span).ReadLong();
+
+    public static LongValue FromPrimitive(long value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteLong(value);
+        
+        return new LongValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/NbtValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/NbtValue.cs
@@ -1,0 +1,18 @@
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Nbt;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record NbtValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public NbtTag AsPrimitive => new MinecraftBuffer(Value.Span).ReadTag();
+
+    public static NbtValue FromPrimitive(NbtTag value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteTag(value);
+        
+        return new NbtValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/NbtValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/NbtValue.cs
@@ -5,9 +5,9 @@ namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Va
 
 public record NbtValue(ReadOnlyMemory<byte> Value) : IPropertyValue
 {
-    public NbtTag AsPrimitive => new MinecraftBuffer(Value.Span).ReadTag();
+    public NbtTag AsNbtTag => new MinecraftBuffer(Value.Span).ReadTag();
 
-    public static NbtValue FromPrimitive(NbtTag value)
+    public static NbtValue FromNbtTag(NbtTag value)
     {
         using var stream = new MemoryStream();
         var buffer = new MinecraftBuffer(stream);

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/ShortValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/ShortValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record ShortValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public ushort AsPrimitive => new MinecraftBuffer(Value.Span).ReadUnsignedShort();
+
+    public static ShortValue FromPrimitive(ushort value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteUnsignedShort(value);
+        
+        return new ShortValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/StringValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/StringValue.cs
@@ -1,0 +1,17 @@
+using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record StringValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public string AsPrimitive => new MinecraftBuffer(Value.Span).ReadString();
+
+    public static StringValue FromPrimitive(string value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteString(value);
+        
+        return new StringValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/UuidValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/UuidValue.cs
@@ -1,0 +1,18 @@
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Profiles;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record UuidValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public Uuid AsPrimitive => new MinecraftBuffer(Value.Span).ReadUuid();
+
+    public static UuidValue FromPrimitive(Uuid value)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteUuid(value);
+        
+        return new UuidValue(stream.ToArray());
+    }
+}

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/UuidValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/UuidValue.cs
@@ -5,9 +5,9 @@ namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Va
 
 public record UuidValue(ReadOnlyMemory<byte> Value) : IPropertyValue
 {
-    public Uuid AsPrimitive => new MinecraftBuffer(Value.Span).ReadUuid();
+    public Uuid AsUuid => new MinecraftBuffer(Value.Span).ReadUuid();
 
-    public static UuidValue FromPrimitive(Uuid value)
+    public static UuidValue FromUuid(Uuid value)
     {
         using var stream = new MemoryStream();
         var buffer = new MinecraftBuffer(stream);

--- a/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/VarLongValue.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/Properties/Values/VarLongValue.cs
@@ -1,0 +1,13 @@
+﻿using Void.Minecraft.Buffers;
+
+namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties.Values;
+
+public record VarLongValue(ReadOnlyMemory<byte> Value) : IPropertyValue
+{
+    public long AsPrimitive => new MinecraftBuffer(Value.Span).ReadVarInt();
+
+    public static VarLongValue FromPrimitive(int value)
+    {
+        return new VarLongValue(MinecraftBuffer.EnumerateVarInt(value).ToArray());
+    }
+}

--- a/src/Minecraft/Buffers/MinecraftBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBuffer.cs
@@ -112,6 +112,16 @@ public ref struct MinecraftBuffer
         _backingBuffer.WriteVarInt(value);
     }
 
+    public long ReadVarLong()
+    {
+        return _backingBuffer.ReadVarLong();
+    }
+
+    public void WriteVarLong(long value)
+    {
+        _backingBuffer.WriteVarLong(value);
+    }
+
     public int ReadInt()
     {
         return _backingBuffer.ReadInt();
@@ -130,6 +140,16 @@ public ref struct MinecraftBuffer
     public void WriteFloat(float value)
     {
         _backingBuffer.WriteFloat(value);
+    }
+
+    public double ReadDouble()
+    {
+        return _backingBuffer.ReadDouble();
+    }
+
+    public void WriteDouble(double value)
+    {
+        _backingBuffer.WriteDouble(value);
     }
 
     public long ReadLong()

--- a/src/Minecraft/Buffers/ReadOnly/ReadOnlySequenceBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadOnly/ReadOnlySequenceBackingBuffer.cs
@@ -49,6 +49,11 @@ internal ref struct ReadOnlySequenceBackingBuffer
         return BinaryPrimitives.ReadSingleBigEndian(Read(4));
     }
 
+    public double ReadDouble()
+    {
+        return BinaryPrimitives.ReadDoubleBigEndian(Read(8));
+    }
+
     public long ReadLong()
     {
         return BinaryPrimitives.ReadInt64BigEndian(Read(8));

--- a/src/Minecraft/Buffers/ReadOnly/ReadOnlySpanBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadOnly/ReadOnlySpanBackingBuffer.cs
@@ -31,6 +31,11 @@ internal ref struct ReadOnlySpanBackingBuffer(ReadOnlySpan<byte> span)
         return BinaryPrimitives.ReadSingleBigEndian(Read(4));
     }
 
+    public double ReadDouble()
+    {
+        return BinaryPrimitives.ReadDoubleBigEndian(Read(8));
+    }
+
     public long ReadLong()
     {
         return BinaryPrimitives.ReadInt64BigEndian(Read(8));

--- a/src/Minecraft/Buffers/ReadWrite/MemoryStreamBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadWrite/MemoryStreamBackingBuffer.cs
@@ -91,6 +91,29 @@ internal ref struct MemoryStreamBackingBuffer(MemoryStream memoryStream)
         }
     }
 
+
+    public readonly double ReadDouble()
+    {
+        return BinaryPrimitives.ReadDoubleBigEndian(Read(8));
+    }
+
+    public readonly void WriteDouble(double value)
+    {
+        // TODO may be unsafe stackalloc?
+        var block = ArrayPool<byte>.Shared.Rent(8);
+        var span = block.AsSpan(0, 8);
+
+        try
+        {
+            BinaryPrimitives.WriteDoubleBigEndian(span, value);
+            memoryStream.Write(span);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(block);
+        }
+    }
+
     public readonly long ReadLong()
     {
         return BinaryPrimitives.ReadInt64BigEndian(Read(8));

--- a/src/Minecraft/Buffers/ReadWrite/SpanBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadWrite/SpanBackingBuffer.cs
@@ -51,6 +51,16 @@ internal ref struct SpanBackingBuffer(Span<byte> span)
         BinaryPrimitives.WriteSingleBigEndian(Slice(4), value);
     }
 
+    public double ReadDouble()
+    {
+        return BinaryPrimitives.ReadDoubleBigEndian(Read(8));
+    }
+
+    public void WriteDouble(double value)
+    {
+        BinaryPrimitives.WriteDoubleBigEndian(Slice(8), value);
+    }
+
     public long ReadLong()
     {
         return BinaryPrimitives.ReadInt64BigEndian(Read(8));


### PR DESCRIPTION
This pull request introduces several new property types and value types to the `Void.Proxy.Api.Network.IO.Streams.Packet.Transformations.Properties` namespace. These changes enhance the ability to read and write various data types to and from a `MinecraftBuffer`.

New property types:

* [`BoolType`](diffhunk://#diff-28bad3abf7f34685740fbddc7cfcd5558f7219e04eaea2ce90a2277612de23afR1-R17): Implements `IPropertyType<BoolValue>` to handle boolean values.
* [`ByteType`](diffhunk://#diff-d2e028790bf76f58c84ed01f2faef13713309020890882e5215c87ac1cd208d8R1-R17): Implements `IPropertyType<ByteValue>` to handle byte values.
* [`DoubleType`](diffhunk://#diff-bb62b9b8c985ec76b655058758a73079cac8b61f11c65387d7dd83d4224b777fR1-R17): Implements `IPropertyType<DoubleValue>` to handle double values.
* [`FloatType`](diffhunk://#diff-b94f760a7f55532dcfbb09f7005f419b8ab46338964937aa1bb7c4cb207573efR1-R17): Implements `IPropertyType<FloatValue>` to handle float values.
* [`IntType`](diffhunk://#diff-921e03e7c2aa128262c7767697d4488dd5d30ecc6c45c89adab06c851396f802R1-R17): Implements `IPropertyType<IntValue>` to handle integer values.
* [`LongType`](diffhunk://#diff-2b78f567c42b6ee8df544d43e23866cb2dcd05a4612744e2cd5e2722ce06eb26R1-R17): Implements `IPropertyType<LongValue>` to handle long values.
* [`ShortType`](diffhunk://#diff-1f4bb2318d549d0a80cc401f0ba4687f6147ecea67544c5efccef89006249e35R1-R17): Implements `IPropertyType<ShortValue>` to handle short values.
* [`StringType`](diffhunk://#diff-b214d9e98a0613ebacee06e60c5142cf11a3529cc8636635d9593c8efa5967b0R1-R17): Implements `IPropertyType<StringValue>` to handle string values.
* [`UuidType`](diffhunk://#diff-0ffd95a58245cd2d64ed0e0a3a2f26d5ba11ba1d8f467446a9efedc678c43016R1-R17): Implements `IPropertyType<UuidValue>` to handle UUID values.
* [`VarLongType`](diffhunk://#diff-f524519ea7e97b7c3c6939653da8653cca7a9f0c3dfeea62a8b35a609d02c9f3R1-R17): Implements `IPropertyType<VarLongValue>` to handle variable long values.
* [`NbtType`](diffhunk://#diff-492b166717109bb3ca47556a79ba628cccb03373b149a54d0f911ecd6829b748R1-R17): Implements `IPropertyType<NbtValue>` to handle NBT tag values.
* [`ListType<TPropertyValue>`](diffhunk://#diff-9e834c82d695013473d1d5f74eef27303a5684ad1e6cf410a0bab8b2bf979d74R1-R31): Implements `IListPropertyType<TPropertyValue>` to handle lists of property values.
* [`OptionalType<TPropertyValue>`](diffhunk://#diff-6b8cc5805204a4e927975dc4613343ff413e7361df67ef95752051d8184d575bR1-R25): Implements `IOptionalPropertyType<TPropertyValue>` to handle optional property values.

New value types:

* [`BoolValue`](diffhunk://#diff-8e2c286b2913a5270fddb87011f293b2dfe3995b4dee1dd38608cfcf675b7633R1-R17): Represents a boolean value and provides methods to read from and write to a `MinecraftBuffer`.
* [`ByteValue`](diffhunk://#diff-1e106cb7a994dbb3e938a528cc3c224d9ff9bdd3cb17a09656b03c598987b11eR1-R17): Represents a byte value and provides methods to read from and write to a `MinecraftBuffer`.
* [`DoubleValue`](diffhunk://#diff-4122cbf9934092302f57d71a5c1567b4cbc7ca657bf4d97ad9727f771bc3341dR1-R17): Represents a double value and provides methods to read from and write to a `MinecraftBuffer`.
* [`FloatValue`](diffhunk://#diff-24370144849a6b785dcf83c52315cad78aebb9ffbb568fdb519fbc40ab0f314fR1-R17): Represents a float value and provides methods to read from and write to a `MinecraftBuffer`.
* [`IntValue`](diffhunk://#diff-4e634bdfe2bc59957d6ed066f99e72339ba28134e61ffdc891445e481e4e0bc0R1-R17): Represents an integer value and provides methods to read from and write to a `MinecraftBuffer`.