### PR TITLE
Feature/register transformators

### DIFF
--- a/src/Api/Network/IO/Streams/Packet/Registries/IMinecraftPacketRegistry.cs
+++ b/src/Api/Network/IO/Streams/Packet/Registries/IMinecraftPacketRegistry.cs
@@ -14,7 +14,9 @@ public interface IMinecraftPacketRegistry
     public bool Contains(IMinecraftMessage message);
     public bool Contains(Type type);
     public bool TryCreateDecoder(int id, [MaybeNullWhen(false)] out MinecraftPacketDecoder<IMinecraftPacket> packet);
+    public bool TryCreateDecoder(int id, [MaybeNullWhen(false)] out Type packetType, [MaybeNullWhen(false)] out MinecraftPacketDecoder<IMinecraftPacket> packet);
     public bool TryGetPacketId(IMinecraftPacket packet, [MaybeNullWhen(false)] out int id);
+    public bool TryGetType(int id, [MaybeNullWhen(false)] out Type packetType);
     public IMinecraftPacketRegistry ReplacePackets(IReadOnlyDictionary<MinecraftPacketIdMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public IMinecraftPacketRegistry AddPackets(IReadOnlyDictionary<MinecraftPacketIdMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public void Clear();

--- a/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketPluginsTransformations.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketPluginsTransformations.cs
@@ -14,9 +14,9 @@ public interface IMinecraftPacketPluginsTransformations
 
     public IMinecraftPacketTransformations Get(IPlugin plugin);
     public void Remove(IPlugin plugin);
-    public bool Contains<T>() where T : IMinecraftPacket;
-    public bool Contains(IMinecraftMessage message);
-    public bool Contains(Type type);
+    public bool Contains<T>(TransformationType type) where T : IMinecraftPacket;
+    public bool Contains(IMinecraftMessage message, TransformationType type);
+    public bool Contains(Type packetType, TransformationType transformationType);
     public void Clear();
     public void Reset();
 }

--- a/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketTransformations.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketTransformations.cs
@@ -13,7 +13,7 @@ public interface IMinecraftPacketTransformations
     public bool Contains<T>(TransformationType type) where T : IMinecraftPacket;
     public bool Contains(IMinecraftMessage message, TransformationType type);
     public bool Contains(Type packetType, TransformationType transformationType);
-    public bool TryGetTransformation(IMinecraftPacket packet, TransformationType type, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformations);
+    public bool TryGetTransformation(Type packetType, TransformationType type, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation);
     public IMinecraftPacketTransformations ReplaceTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public IMinecraftPacketTransformations AddTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public void Clear();

--- a/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketTransformations.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketTransformations.cs
@@ -10,10 +10,10 @@ public interface IMinecraftPacketTransformations
     public IEnumerable<Type> PacketTypes { get; }
     public bool IsEmpty { get; }
 
-    public bool Contains<T>() where T : IMinecraftPacket;
-    public bool Contains(IMinecraftMessage message);
-    public bool Contains(Type type);
-    public bool TryGetTransformation(IMinecraftPacket packet, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformations);
+    public bool Contains<T>(TransformationType type) where T : IMinecraftPacket;
+    public bool Contains(IMinecraftMessage message, TransformationType type);
+    public bool Contains(Type packetType, TransformationType transformationType);
+    public bool TryGetTransformation(IMinecraftPacket packet, TransformationType type, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformations);
     public IMinecraftPacketTransformations ReplaceTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public IMinecraftPacketTransformations AddTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> mappings, ProtocolVersion protocolVersion);
     public void Clear();

--- a/src/Api/Network/IO/Streams/Packet/Transformations/TransformationType.cs
+++ b/src/Api/Network/IO/Streams/Packet/Transformations/TransformationType.cs
@@ -1,0 +1,8 @@
+﻿namespace Void.Proxy.Api.Network.IO.Streams.Packet.Transformations;
+
+public enum TransformationType
+{
+    None,
+    Upgrade,
+    Downgrade
+}

--- a/src/Plugins/Common/Network/IO/Messages/Binary/MinecraftBinaryPacket.cs
+++ b/src/Plugins/Common/Network/IO/Messages/Binary/MinecraftBinaryPacket.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.IO;
-using Void.Minecraft.Buffers;
+﻿using Void.Minecraft.Buffers;
 using Void.Minecraft.Network;
 using Void.Proxy.Api.Network.IO.Messages.Binary;
 using Void.Proxy.Api.Network.IO.Messages.Packets;
 
 namespace Void.Proxy.Plugins.Common.Network.IO.Messages.Binary;
 
-public class MinecraftBinaryPacket(int id, RecyclableMemoryStream stream) : IMinecraftBinaryMessage, IMinecraftServerboundPacket, IMinecraftClientboundPacket, IMinecraftPacket
+public class MinecraftBinaryPacket(int id, MemoryStream stream) : IMinecraftBinaryMessage, IMinecraftServerboundPacket, IMinecraftClientboundPacket, IMinecraftPacket
 {
     public int Id => id;
     public MemoryStream Stream => stream;

--- a/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketPluginsTransformations.cs
+++ b/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketPluginsTransformations.cs
@@ -31,19 +31,19 @@ public class MinecraftPacketPluginsTransformations : IMinecraftPacketPluginsTran
         _map.Remove(plugin);
     }
 
-    public bool Contains<T>() where T : IMinecraftPacket
+    public bool Contains<T>(TransformationType type) where T : IMinecraftPacket
     {
-        return All.Any(registry => registry.Contains<T>());
+        return All.Any(registry => registry.Contains<T>(type));
     }
 
-    public bool Contains(IMinecraftMessage message)
+    public bool Contains(IMinecraftMessage message, TransformationType type)
     {
-        return All.Any(registry => registry.Contains(message));
+        return All.Any(registry => registry.Contains(message, type));
     }
 
-    public bool Contains(Type type)
+    public bool Contains(Type packetType, TransformationType transformationType)
     {
-        return All.Any(registry => registry.Contains(type));
+        return All.Any(registry => registry.Contains(packetType, transformationType));
     }
 
     public void Clear()

--- a/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
+++ b/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
@@ -9,30 +9,50 @@ namespace Void.Proxy.Plugins.Common.Network.IO.Streams.Packet.Transformations;
 
 public class MinecraftPacketTransformations : IMinecraftPacketTransformations
 {
-    private readonly Dictionary<MinecraftPacketTransformation[], Type> _mappings = [];
-    private readonly Dictionary<Type, MinecraftPacketTransformation[]> _reverseMappings = [];
+    private readonly Dictionary<Type, MinecraftPacketTransformation[]> _upgradeMappings = [];
+    private readonly Dictionary<Type, MinecraftPacketTransformation[]> _downgradeMappings = [];
 
-    public IEnumerable<Type> PacketTypes => _mappings.Values;
-    public bool IsEmpty => this is { _mappings.Count: 0, _reverseMappings.Count: 0 };
+    public IEnumerable<Type> PacketTypes => _upgradeMappings.Keys;
+    public bool IsEmpty => this is { _upgradeMappings.Count: 0, _downgradeMappings.Count: 0 };
 
-    public bool Contains<T>() where T : IMinecraftPacket
+    public bool UpgradeContains<T>() where T : IMinecraftPacket
     {
-        return Contains(typeof(T));
+        return UpgradeContains(typeof(T));
     }
 
-    public bool Contains(IMinecraftMessage message)
+    public bool UpgradeContains(IMinecraftMessage message)
     {
-        return Contains(message.GetType());
+        return UpgradeContains(message.GetType());
     }
 
-    public bool Contains(Type type)
+    public bool UpgradeContains(Type type)
     {
-        return _reverseMappings.Keys.Any(type.IsAssignableFrom);
+        return _upgradeMappings.Keys.Any(type.IsAssignableFrom);
     }
 
-    public bool TryGetTransformation(IMinecraftPacket packet, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation)
+    public bool DowngradeContains<T>() where T : IMinecraftPacket
     {
-        return _reverseMappings.TryGetValue(packet.GetType(), out transformation);
+        return DowngradeContains(typeof(T));
+    }
+
+    public bool DowngradeContains(IMinecraftMessage message)
+    {
+        return DowngradeContains(message.GetType());
+    }
+
+    public bool DowngradeContains(Type type)
+    {
+        return _downgradeMappings.Keys.Any(type.IsAssignableFrom);
+    }
+
+    public bool TryGetUpgradeTransformation(IMinecraftPacket packet, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation)
+    {
+        return _upgradeMappings.TryGetValue(packet.GetType(), out transformation);
+    }
+
+    public bool TryGetDowngradeTransformation(IMinecraftPacket packet, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation)
+    {
+        return _downgradeMappings.TryGetValue(packet.GetType(), out transformation);
     }
 
     public IMinecraftPacketTransformations ReplaceTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> transformations, ProtocolVersion protocolVersion)
@@ -43,28 +63,46 @@ public class MinecraftPacketTransformations : IMinecraftPacketTransformations
         return this;
     }
 
-    public IMinecraftPacketTransformations AddTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> transformations, ProtocolVersion protocolVersion)
+    public IMinecraftPacketTransformations AddTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> transformationMappings, ProtocolVersion protocolVersion)
     {
         // Dictionary<Type, MinecraftPacketTransformation[]> _reverseMappings
-
-        foreach (var (mappings, type) in transformations)
+        
+        foreach (var (mappings, type) in transformationMappings)
         {
+            var mappingsToUpgrade = new List<MinecraftPacketTransformationMapping>();
+            var mappingsToDowngrate = new List<MinecraftPacketTransformationMapping>();
+            
             foreach (var mapping in mappings)
             {
-                // if (!ProtocolVersion.Range(mapping.From, mapping.To).Contains(protocolVersion))
-                //     continue;
-                // 
-                // if (!_mappings.TryAdd(mapping.Transformation, type) || !_reverseMappings.TryAdd(type, mapping.Transformation))
-                //     throw new ArgumentException($"{type} cannot be registered with packet Transformation {mapping.Transformation}, because there is already {_mappings[mapping.Transformation].FullName}");
+                if (mapping.From < protocolVersion || mapping.To < protocolVersion)
+                    continue;
+                
+                if (mapping.From > mapping.To)
+                    mappingsToUpgrade.Add(mapping);
+                else 
+                    mappingsToDowngrate.Add(mapping);
             }
-        }
+            
+            mappingsToUpgrade.Sort((a, b) => a.From > b.From ? 1 : -1);
+            mappingsToDowngrate.Sort((a, b) => a.From > b.From ? -1 : 1);
+        
+            var upgrateTransformers = mappingsToUpgrade.Select(i => i.Transformation);
+            var downgradeTransformers = mappingsToDowngrate.Select(i => i.Transformation);
 
+            if (!_upgradeMappings.TryAdd(type, upgrateTransformers.ToArray()))
+                throw new ArgumentException($"{type} cannot be registered with packet upgrade transformations, because it is already registered");
+
+            if (!_downgradeMappings.TryAdd(type, downgradeTransformers.ToArray()))
+                throw new ArgumentException($"{type} cannot be registered with packet downgrade transformations, because it is already registered");
+        }
+        
+        
         return this;
     }
 
     public void Clear()
     {
-        _mappings.Clear();
-        _reverseMappings.Clear();
+        _upgradeMappings.Clear();
+        _downgradeMappings.Clear();
     }
 }

--- a/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
+++ b/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
@@ -45,8 +45,6 @@ public class MinecraftPacketTransformations : IMinecraftPacketTransformations
 
     public IMinecraftPacketTransformations AddTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> transformationMappings, ProtocolVersion protocolVersion)
     {
-        // Dictionary<Type, MinecraftPacketTransformation[]> _reverseMappings
-
         foreach (var (mappings, type) in transformationMappings)
         {
             var mappingsToUpgrade = new List<MinecraftPacketTransformationMapping>();
@@ -69,10 +67,10 @@ public class MinecraftPacketTransformations : IMinecraftPacketTransformations
             var upgrateTransformers = mappingsToUpgrade.Select(i => i.Transformation);
             var downgradeTransformers = mappingsToDowngrate.Select(i => i.Transformation);
 
-            if (!_upgradeMappings.TryAdd(type, upgrateTransformers.ToArray()))
+            if (!_upgradeMappings.TryAdd(type, [.. upgrateTransformers]))
                 throw new ArgumentException($"{type} cannot be registered with packet upgrade transformations, because it is already registered");
 
-            if (!_downgradeMappings.TryAdd(type, downgradeTransformers.ToArray()))
+            if (!_downgradeMappings.TryAdd(type, [.. downgradeTransformers]))
                 throw new ArgumentException($"{type} cannot be registered with packet downgrade transformations, because it is already registered");
         }
 

--- a/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
+++ b/src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs
@@ -30,9 +30,9 @@ public class MinecraftPacketTransformations : IMinecraftPacketTransformations
         return GetMappings(transformationType).Keys.Any(packetType.IsAssignableFrom);
     }
 
-    public bool TryGetTransformation(IMinecraftPacket packet, TransformationType type, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation)
+    public bool TryGetTransformation(Type packetType, TransformationType type, [MaybeNullWhen(false)] out MinecraftPacketTransformation[] transformation)
     {
-        return GetMappings(type).TryGetValue(packet.GetType(), out transformation);
+        return GetMappings(type).TryGetValue(packetType, out transformation);
     }
 
     public IMinecraftPacketTransformations ReplaceTransformations(IReadOnlyDictionary<MinecraftPacketTransformationMapping[], Type> transformations, ProtocolVersion protocolVersion)


### PR DESCRIPTION
This pull request introduces several changes to the packet transformation and registry systems in the Minecraft network API. The main focus is on adding support for different transformation types (Upgrade and Downgrade) and updating various interfaces and classes to accommodate these changes.

### Transformation Types Addition:
* [`src/Api/Network/IO/Streams/Packet/Transformations/TransformationType.cs`](diffhunk://#diff-a84833a2dbfe82823b5479aab902886023f0b5e1557f8bced044d42536b4c6e5R1-R8): Introduced a new `TransformationType` enum to define different types of transformations (None, Upgrade, Downgrade).

### Interface Updates:
* [`src/Api/Network/IO/Streams/Packet/Registries/IMinecraftPacketRegistry.cs`](diffhunk://#diff-8ce313091e8077735d6c1d267608c4f4487c1705f1b7d34e4d9e1af0fbd142bfR17-R19): Added methods `TryCreateDecoder` and `TryGetType` to handle packet type retrieval and decoder creation.
* [`src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketPluginsTransformations.cs`](diffhunk://#diff-45c78e54d773d9f4f2fd9942d31eb8689a1ba7b75fcd4da8d23c22bf04f1f2d2L17-R19): Updated `Contains` methods to include `TransformationType` as a parameter.
* [`src/Api/Network/IO/Streams/Packet/Transformations/IMinecraftPacketTransformations.cs`](diffhunk://#diff-d7b6a83a1165feea4b24fdbc7cfb1a89db38781bbabb6db174ecbcd07574f601L13-R16): Modified `Contains` and `TryGetTransformation` methods to use `TransformationType`.

### Class Modifications:
* [`src/Plugins/Common/Network/IO/Streams/Packet/MinecraftPacketMessageStream.cs`](diffhunk://#diff-fde5e015bc40223727c243c0364893ce38ab92bccf2936ea104ed349d5bf2cf1R247-R261): Implemented packet transformations during encoding, including handling of different transformation types.
* [`src/Plugins/Common/Network/IO/Streams/Packet/Registries/MinecraftPacketRegistry.cs`](diffhunk://#diff-8e240bc69fe80c1b5534cd819bddd5e02a7dbb2dccfa95193cecbbcb1ec745caL37-R55): Refactored to use the new `TryCreateDecoder` method and added a private helper method for decoder creation. [[1]](diffhunk://#diff-8e240bc69fe80c1b5534cd819bddd5e02a7dbb2dccfa95193cecbbcb1ec745caL37-R55) [[2]](diffhunk://#diff-8e240bc69fe80c1b5534cd819bddd5e02a7dbb2dccfa95193cecbbcb1ec745caR105-R117)
* [`src/Plugins/Common/Network/IO/Streams/Packet/Transformations/MinecraftPacketTransformations.cs`](diffhunk://#diff-bd1fe721fcc6d5b00f26d659a568e29e040df8f5ac6b541a50637eecf3fbb756L12-R35): Separated mappings into upgrade and downgrade transformations and updated methods to handle these mappings. [[1]](diffhunk://#diff-bd1fe721fcc6d5b00f26d659a568e29e040df8f5ac6b541a50637eecf3fbb756L12-R35) [[2]](diffhunk://#diff-bd1fe721fcc6d5b00f26d659a568e29e040df8f5ac6b541a50637eecf3fbb756L46-R92)

### Service Adjustments:
* [`src/Plugins/Common/Services/Registries/AbstractRegistryService.cs`](diffhunk://#diff-7bcea70c23f65a08ebfa7fcb3da4e848d130091163dfed215ce232dbbb53ebb2R68-R75): Updated message handling methods to incorporate packet transformations based on the new `TransformationType`. [[1]](diffhunk://#diff-7bcea70c23f65a08ebfa7fcb3da4e848d130091163dfed215ce232dbbb53ebb2R68-R75) [[2]](diffhunk://#diff-7bcea70c23f65a08ebfa7fcb3da4e848d130091163dfed215ce232dbbb53ebb2R105-R112) [[3]](diffhunk://#diff-7bcea70c23f65a08ebfa7fcb3da4e848d130091163dfed215ce232dbbb53ebb2L143-R170) [[4]](diffhunk://#diff-7bcea70c23f65a08ebfa7fcb3da4e848d130091163dfed215ce232dbbb53ebb2L161-R181)