### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/astro/src/content/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/configuration/in-file.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 File configurations are main way of configuration.
-However many options can be overriden in runtime using the API in Plugins.
+However many options can be overridden in runtime using the API in Plugins.
 
 ## Proxy
 


### PR DESCRIPTION
## Summary
- fix a typo in docs/astro `in-file.md`

## Testing
- `dotnet --version`

------
https://chatgpt.com/codex/tasks/task_e_6861cba0c5bc832baf06244c05a6b47f