### PR TITLE
Fix Guid variant comparison

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -123,9 +123,9 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
         return (i128.variant >> 4) switch
         {
             <= 0b0111 => 0,
-            <= 1011 => 1,
-            <= 1101 => 2,
-            1110 => 3,
+            <= 0b1011 => 1,
+            <= 0b1101 => 2,
+            <= 0b1111 => 3,
             _ => -1
         };
     }

--- a/src/Platform/Utils/GuidHelper.cs
+++ b/src/Platform/Utils/GuidHelper.cs
@@ -66,9 +66,9 @@ public static class GuidHelper
         return (i128.variant >> 4) switch
         {
             <= 0b0111 => 0,
-            <= 1011 => 1,
-            <= 1101 => 2,
-            1110 => 3,
+            <= 0b1011 => 1,
+            <= 0b1101 => 2,
+            <= 0b1111 => 3,
             _ => -1
         };
     }


### PR DESCRIPTION
## Summary
- ensure `GetVariant` compares binary values correctly across implementations

## Testing
- `dotnet build src/Platform/Void.Proxy.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cbca49a4832b8e4a9762935eaad7