### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/astro/src/content/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/configuration/environment-variables.md
@@ -11,7 +11,7 @@ However, they might be used terminal directly as well.
 ## Plugins
 - `VOID_PLUGINS`
   Defines the list of URL's or Path's to load plugins from.  
-  Example: `https://example.org/download/YoutPlugin1.dll;/home/YourPlugin2.dll` 
+  Example: `https://example.org/download/YourPlugin1.dll;/home/YourPlugin2.dll`
  
 ## NuGet
 - `VOID_NUGET_REPOSITORIES`  

--- a/docs/astro/src/content/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/configuration/in-file.md
@@ -72,15 +72,15 @@ Plugins are compiled with the *.dll extension in any .NET compatible language.
 See the [**Plugin Development Kit**](/developing-plugins/development-kit) section for more details.
 
 - Directory `plugins` is the default location for plugins.
-- [**Environment variable**](/configuration/environment-variables) `VOID_PLUGINS` might be used to include URLs or Local Paths to plugins, separated by coma or semicolon.
+- [**Environment variable**](/configuration/environment-variables) `VOID_PLUGINS` might be used to include URLs or Local Paths to plugins, separated by comma or semicolon.
 - [**Program argument**](/configuration/program-arguments) `--plugin` (short `-p`) might be used to include URL or Local Path to plugin.
 
 Examples:
 ```bash
-$ ./void-linux-x64 --plugin "/home/YourPlugin1.dll" --plugin "https://example.org/download/YoutPlugin2.dll"
+$ ./void-linux-x64 --plugin "/home/YourPlugin1.dll" --plugin "https://example.org/download/YourPlugin2.dll"
 ```
 ```bash
-$ VOID_PLUGINS="https://example.org/download/YoutPlugin1.dll;/home/YourPlugin2.dll" ./void-linux-x64
+$ VOID_PLUGINS="https://example.org/download/YourPlugin1.dll;/home/YourPlugin2.dll" ./void-linux-x64
 ```
 
 ## Plugins Configurations (configs/\<Plugin\>/*.toml)

--- a/docs/astro/src/content/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/configuration/program-arguments.md
@@ -10,7 +10,7 @@ Program arguments make configuration in terminal easier.
 ## Help
 Provides a list of all available program arguments.
 ```bash
-./void-liux-x64 --help
+./void-linux-x64 --help
 Description:
   Runs the proxy
 
@@ -29,14 +29,14 @@ Options:
 ## Plugins
 - `--plugin`  
   Allows you to specify additional plugins to load.  
-  Example: `./void-liux-x64 --plugin https://example.org/download/YoutPlugin1.dll --plugin /home/YourPlugin2.dll`
+  Example: `./void-linux-x64 --plugin https://example.org/download/YourPlugin1.dll --plugin /home/YourPlugin2.dll`
 
 ## NuGet
 - `--repository`  
   Allows you to specify additional NuGet repositories to use.  
-  Example: `./void-liux-x64 --repository https://nuget.example.com/v3/index.json`
+  Example: `./void-linux-x64 --repository https://nuget.example.com/v3/index.json`
 
 ## Version
 - `--version`  
   Displays the current version of Void Proxy.  
-  Example: `./void-liux-x64 --version`
+  Example: `./void-linux-x64 --version`

--- a/docs/astro/src/content/docs/containers.md
+++ b/docs/astro/src/content/docs/containers.md
@@ -43,13 +43,13 @@ spec:
           containerPort: 25565
         env:
         - name: VOID_PLUGINS
-          value: "https://example.org/download/YoutPlugin1.dll"
+          value: "https://example.org/download/YourPlugin1.dll"
         - name: VOID_WATCHDOG_ENABLE
           value: "true"
 ```
 
 ## Configuring Void in Containers
-Use [**enviroment variables**](/configuration/environment-variables/) or [**mount volumes**](/configuration/in-file/) to configure Void.
+Use [**environment variables**](/configuration/environment-variables/) or [**mount volumes**](/configuration/in-file/) to configure Void.
 
 
 ## Image Tags

--- a/docs/astro/src/content/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/links.md
@@ -25,7 +25,7 @@ So separate `INetworkChannel` is created for `IPlayer` and separate `INetworkCha
 [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) saves references to both sides: `ILink.Player` and `ILink.Server`.
 
 ## Custom Implementation
-Void uses internal implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) if not overriden by plugin.
+Void uses internal implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) if not overridden by plugin.
 
 Plugin can override it by providing custom implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) with `CreateLinkEvent` event.
 ```csharp


### PR DESCRIPTION
## Summary
- fix typos in documentation

## Testing
- `codespell docs -q 3 -L ans,Nin -S package-lock.json`

------
https://chatgpt.com/codex/tasks/task_e_6861dc1cdc04832b8aba757e07c5ba0d