### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/astro/src/content/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/configuration/in-file.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-File configurations are main way of configuration.
+File configurations are the main way of configuration.
 However many options can be overridden in runtime using the API in Plugins.
 
 ## Proxy

--- a/docs/astro/src/content/docs/containers.md
+++ b/docs/astro/src/content/docs/containers.md
@@ -88,7 +88,7 @@ Other `dev` versions:
 - caunt/void:dev-android-linux-bionic-x64
 
 :::caution
-Versions below are historical and are not longer maintained
+Versions below are historical and are no longer maintained
 :::
 
 - caunt/void:**`<version>`** - Specific version of Void release, e.g. **`caunt/void:0.5.1`**.

--- a/docs/astro/src/content/docs/developing-plugins/events/creating-your-events.md
+++ b/docs/astro/src/content/docs/developing-plugins/events/creating-your-events.md
@@ -39,7 +39,7 @@ public record MyEvent(string SomeValue) : IEventWithResult<bool>
 Your event can be scoped to a specific player. You can do this by implementing the `IScopedEvent` interface.
 With this interface you are required to specify the Player to which this event is scoped.
 This event will be filtered across scoped listeners and passed to all non-scoped listeners.
-Howerer, scoped listeners can still receive that event out of their scope, by applying `bypassScopedFilter: true` to the `Subscribe` attribute.
+However, scoped listeners can still receive that event out of their scope, by applying `bypassScopedFilter: true` to the `Subscribe` attribute.
 ```csharp
 public record MyEvent(IPlayer Player, string SomeValue) : IScopedEvent;
 ```

--- a/docs/astro/src/content/docs/developing-plugins/serializers.md
+++ b/docs/astro/src/content/docs/developing-plugins/serializers.md
@@ -1,6 +1,6 @@
 ---
 title: Serializers
-description: Learn about serializes in Void.
+description: Learn about serializers in Void.
 ---
 
 Serializers are used to convert structured data between different formats. 
@@ -22,7 +22,7 @@ Helpful to convert Json or Snbt to Nbt and vice versa.
   - Converts **[Nbt](/developing-plugins/nbt) to [Snbt](/developing-plugins/nbt/#snbt)** or **[Snbt](/developing-plugins/nbt/#snbt) to [Nbt](/developing-plugins/nbt)**.
 
 :::caution[Prefer deserializing from Snbt]
-Json is not recommended because it's properties types conversion is guessed by bounds of the value.  
+Json is not recommended because its properties' type conversion is guessed by bounds of the value.  
 
 ```json
 {
@@ -31,7 +31,7 @@ Json is not recommended because it's properties types conversion is guessed by b
 ```
 This 'value' number does not specify if it is a byte, short, int or long. So in deserialization time, parser checks if it fits in byte, short, int or long, and uses the first Nbt Tag Type that fits.
 
-On other hand, Snbt specifies concrete type of the value. 
+On the other hand, Snbt specifies concrete type of the value. 
 ```json
 {
 	value: 1b

--- a/docs/astro/src/content/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/forwardings/legacy.md
@@ -6,13 +6,13 @@ sidebar:
 ---
 
 :::danger[IN DEVELOPMENT]
-This forwarding currently not implemented in Void.
+This forwarding is currently not implemented in Void.
 :::
 
 BungeeCord also known as Legacy forwarding is a type of forwarding player data developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).
 
 :::tip
-It is an easiest way to pass player's information from proxy to server in Handshake packet, supported by many server implementations.
+It is the easiest way to pass player's information from proxy to server in Handshake packet, supported by many server implementations.
 Legacy forwarding may include additional data, such as forge FML markers.
 :::
 

--- a/docs/astro/src/content/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/forwardings/modern.md
@@ -13,7 +13,7 @@ Modern forwarding was updated multiple times, enabling new features and fixing b
 :::
 
 :::note[Mods]
-Velocity forwarding is not supported by mod loaders, however community has created some mods implementing it's protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
+Velocity forwarding is not supported by mod loaders, however community has created some mods implementing its protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
 :::
 
 :::caution[Limitations]

--- a/docs/astro/src/content/docs/forwardings/online.md
+++ b/docs/astro/src/content/docs/forwardings/online.md
@@ -8,12 +8,12 @@ sidebar:
 Online (Private Key) forwarding is a type of forwarding player data developed by [**Void**](https://github.com/caunt/Void).
 
 :::tip
-This forwarding is the hardest to setup, but does not break official Mojang authentication and enables Minecraft Encryption with the server.
+This forwarding is the hardest to set up, but does not break official Mojang authentication and enables Minecraft Encryption with the server.
 :::
 
 :::note[Mods]
-Online (Private Key) forwarding is not supported by mod loaders, and currently have no community implementations.  
-However, there is [**examples**](https://github.com/caunt/Void/blob/main/src/Servers/Bukkit/src/main/java/net/caunt/thevoid/EntryPoint.java) on how to enable it with **any** minecraft server, including modded.
+Online (Private Key) forwarding is not supported by mod loaders, and currently has no community implementations.  
+However, there are [**examples**](https://github.com/caunt/Void/blob/main/src/Servers/Bukkit/src/main/java/net/caunt/thevoid/EntryPoint.java) on how to enable it with **any** Minecraft server, including modded.
 :::
 
 :::caution[Limitations]
@@ -22,7 +22,7 @@ However, there is [**examples**](https://github.com/caunt/Void/blob/main/src/Ser
 :::
 
 ## Configuration
-Since currently it has no community implementation, you have to set up it manually by creating a Void plugin and Minecraft plugin, mod or Java agent. 
+Since currently it has no community implementation, you have to set it up manually by creating a Void plugin and Minecraft plugin, mod or Java agent. 
 
 First of all, you have to retrieve server's private key used to authenticate and encrypt network data.  
 

--- a/docs/astro/src/content/docs/watchdog.md
+++ b/docs/astro/src/content/docs/watchdog.md
@@ -3,14 +3,14 @@ title: Watchdog
 description: Learn how to enable and use the Watchdog feature in Void.
 ---
 
-The Watchdog feature in Void is designed to monitor the health of the Void Proxy and schedule restart if required. 
+The Watchdog feature in Void is designed to monitor the health of the Void Proxy and schedule a restart if required. 
 This is particularly useful for long-running processes or when running Void in a production environment.
 
 ## Enable Watchdog
 Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/configuration/in-file#watchdog) to `true`.
 
 ## Health Check
-`/health` endpoint is used to check the health of the Void Proxy.`
+`/health` endpoint is used to check the health of the Void Proxy.
 
 ```bash
 $ curl http://localhost:80/health
@@ -27,7 +27,7 @@ OK
 - STOPPING: The Void Proxy is shutting down.
 
 Status Code `200 OK` may be in any combination of above responses.   
-It is just meaning that the Void Proxy is still running and healthy.
+It just means that the Void Proxy is still running and healthy.
 
 ## Bound Check
 `/bound` endpoint is used to check if the Void Proxy is bound and accepting incoming connections.


### PR DESCRIPTION
## Summary
- fix spelling mistakes in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861de3263a0832b835f5580e7a1c4e6