### PR TITLE
Add JsonIpEndPointConverter tests

### DIFF
--- a/src/Platform/Utils/JsonIPEndPointConverter.cs
+++ b/src/Platform/Utils/JsonIPEndPointConverter.cs
@@ -41,7 +41,8 @@ public class JsonIpEndPointConverter : JsonConverter<IPEndPoint>
     public override void Write(Utf8JsonWriter writer, IPEndPoint value, JsonSerializerOptions options)
     {
         var isIpv6 = value.AddressFamily == AddressFamily.InterNetworkV6;
-        Span<char> data = stackalloc char[isIpv6 ? 21 : 53];
+        // IPv6 endpoints require a larger buffer than IPv4 endpoints
+        Span<char> data = stackalloc char[isIpv6 ? 53 : 21];
         var offset = 0;
 
         if (isIpv6)

--- a/tests/UtilsTests/JsonIpEndPointConverterTests.cs
+++ b/tests/UtilsTests/JsonIpEndPointConverterTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Text.Json;
+using Void.Proxy.Utils;
+using Xunit;
+
+namespace Void.Tests;
+
+public class JsonIpEndPointConverterTests
+{
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new JsonIpEndPointConverter());
+        return options;
+    }
+
+    [Fact]
+    public void SerializeDeserialize_Ipv4_RoundTrips()
+    {
+        var ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 25565);
+        var options = CreateOptions();
+        var json = JsonSerializer.Serialize(ep, options);
+        Assert.Equal("\"127.0.0.1:25565\"", json);
+        var deserialized = JsonSerializer.Deserialize<IPEndPoint>(json, options);
+        Assert.Equal(ep, deserialized);
+    }
+
+    [Fact]
+    public void SerializeDeserialize_Ipv6_RoundTrips()
+    {
+        var ep = new IPEndPoint(IPAddress.Parse("::1"), 443);
+        var options = CreateOptions();
+        var json = JsonSerializer.Serialize(ep, options);
+        Assert.Equal("\"[::1]:443\"", json);
+        var deserialized = JsonSerializer.Deserialize<IPEndPoint>(json, options);
+        Assert.Equal(ep, deserialized);
+    }
+
+    [Fact]
+    public void Serialize_LongIpv6_DoesNotTruncate()
+    {
+        var address = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+        var ep = new IPEndPoint(IPAddress.Parse(address), 65535);
+        var options = CreateOptions();
+        var json = JsonSerializer.Serialize(ep, options);
+        Assert.Equal($"\"[{address}]:65535\"", json);
+        var deserialized = JsonSerializer.Deserialize<IPEndPoint>(json, options);
+        Assert.Equal(ep, deserialized);
+    }
+}


### PR DESCRIPTION
## Summary
- cover JsonIpEndPointConverter serialization logic for IPv4 and IPv6
- ensure long IPv6 addresses serialize correctly

## Testing
- `dotnet build tests/Void.Tests.csproj -v minimal`
- `dotnet test tests/Void.Tests.csproj --no-build -v minimal`
- `dotnet format tests/Void.Tests.csproj --no-restore -v diag`

------
https://chatgpt.com/codex/tasks/task_e_6861e49f0178832bbdb24bf745b9e2dc