### PR TITLE
docs(api): add documentation for IServerService

### DIFF
--- a/src/Api/Servers/IServerService.cs
+++ b/src/Api/Servers/IServerService.cs
@@ -1,6 +1,12 @@
 ﻿namespace Void.Proxy.Api.Servers;
 
+/// <summary>
+/// Provides access to the collection of servers available to the proxy.
+/// </summary>
 public interface IServerService
 {
+    /// <summary>
+    /// Gets all configured servers.
+    /// </summary>
     public IEnumerable<IServer> All { get; }
 }


### PR DESCRIPTION
## Summary
- add XML documentation to `IServerService` in the API project

## Testing
- `dotnet format` *(fails: Could not load file or assembly 'Microsoft.VisualStudio.SolutionPersistence')*

------
https://chatgpt.com/codex/tasks/task_e_68628295df1c832b8a1d94570c23a1e7