### PR TITLE
Fix typos in code

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Context/CommandContext.cs
+++ b/src/Minecraft/Commands/Brigadier/Context/CommandContext.cs
@@ -55,7 +55,7 @@ public record CommandContext(
             return false;
 
         if (argument.GenericResult is not TType result)
-            throw new ArgumentException($"Argument {name}' is defined as {argument.GenericResult}, not {typeof(TType)}");
+            throw new ArgumentException($"Argument '{name}' is defined as {argument.GenericResult}, not {typeof(TType)}");
 
         type = result;
         return true;


### PR DESCRIPTION
## Summary
- fix error message formatting in CommandContext

## Testing
- `dotnet format` *(fails: Could not load file or assembly 'Microsoft.VisualStudio.SolutionPersistence')*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686284c26524832b814ee17c134ab48e