### PR TITLE
Remove leftover debug code

### DIFF
--- a/src/Plugins/Common/Network/Streams/Packet/MinecraftPacketMessageStream.cs
+++ b/src/Plugins/Common/Network/Streams/Packet/MinecraftPacketMessageStream.cs
@@ -184,7 +184,6 @@ public class MinecraftPacketMessageStream : RecyclableStream, IMinecraftPacketMe
         if (Registries.PacketIdSystem?.Read is not { } registry || !registry.TryCreateDecoder(id, out var packetType, out var decoder))
             return new MinecraftBinaryPacket(id, stream);
 
-        // Console.WriteLine(stream.Position + " " + stream.Length + " " + Convert.ToHexString(buffer.Dump()));
         if (TryGetTransformations(packetType, TransformationType.Upgrade, out var transformations))
         {
             var position = stream.Position;


### PR DESCRIPTION
## Summary
- clean up `MinecraftPacketMessageStream` by removing commented `Console.WriteLine`

## Testing
- `dotnet format` *(fails: Could not load file or assembly 'Microsoft.VisualStudio.SolutionPersistence')*
- `dotnet build Void.slnx`

------
https://chatgpt.com/codex/tasks/task_e_68628625c15c832b9fa2142b04812b69