### PR TITLE
Fix minor doc typo

### DIFF
--- a/docs/astro/src/content/docs/developing-plugins/network/transformations.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/transformations.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-When you have defined packet, it might be changed in future versions of Minecraft. There is two ways to handle this:
+When you have defined packet, it might be changed in future versions of Minecraft. There are two ways to handle this:
 - Define conditional packet transformation
 - Define flat packet transformation
 


### PR DESCRIPTION
## Summary
- fix a grammar typo in the network transformations guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686875de20b4832ba65fb1ace1954acd