### PR TITLE
Improve docs SEO metadata

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -77,6 +77,52 @@ export default defineConfig({
                 }
             },
             {
+                tag: 'meta',
+                attrs: {
+                    name: 'description',
+                    content: 'Void is a cross-platform Minecraft proxy supporting all versions and mods.'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    property: 'og:title',
+                    content: 'Void Proxy'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    property: 'og:description',
+                    content: 'Void is a cross-platform Minecraft proxy supporting all versions and mods.'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    name: 'twitter:card',
+                    content: 'summary_large_image'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    name: 'twitter:title',
+                    content: 'Void Proxy'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    name: 'twitter:description',
+                    content: 'Void is a cross-platform Minecraft proxy supporting all versions and mods.'
+                }
+            },
+            {
+                tag: 'link',
+                attrs: { rel: 'canonical', href: 'https://void.caunt.world' }
+            },
+            {
                 tag: 'link',
                 attrs: {
                     rel: 'apple-touch-icon',


### PR DESCRIPTION
## Summary
- add meta tags for description, OG and Twitter card
- include canonical link for docs site

## Testing
- `dotnet format` *(fails: Could not load Microsoft.VisualStudio.SolutionPersistence)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686c698e7db4832bb19ba10467bdcf1c