### PR TITLE
Improve SEO meta tags

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -72,8 +72,22 @@ export default defineConfig({
             {
                 tag: 'meta',
                 attrs: {
+                    property: 'og:image:alt',
+                    content: 'Void Proxy logo'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
                     property: 'twitter:image',
                     content: '/logo-text-horizontal.1024x512.dark.png'
+                }
+            },
+            {
+                tag: 'meta',
+                attrs: {
+                    property: 'twitter:image:alt',
+                    content: 'Void Proxy logo'
                 }
             },
             {


### PR DESCRIPTION
## Summary
- add alt text to social media images in docs site for SEO

## Testing
- `dotnet format` *(fails: Could not load file or assembly)*
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686ef6dd3200832bae9fc28da16e825d