### PR TITLE
Fix GitHub rate limit by passing token

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   publish:
     environment: void
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   push:
     environment: void
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: ${{ fromJson(inputs.release) }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- provide the `GITHUB_TOKEN` to CI jobs running tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68730f96dd1c832ba80f1c6cc5c22729