### PR TITLE
Add NbtReader whitespace tag name test

### DIFF
--- a/tests/NbtTests/NbtReaderTests.cs
+++ b/tests/NbtTests/NbtReaderTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text;
+using Void.Minecraft.Nbt;
+using Void.Minecraft.Nbt.Tags;
+using Xunit;
+
+namespace Void.Tests.NbtTests;
+
+public class NbtReaderTests
+{
+    [Theory]
+    [InlineData(new byte[] { 0x0A, 0x00, 0x04, 0x72, 0x6F, 0x6F, 0x74, 0x08, 0x00, 0x00, 0x00, 0x05, 0x76, 0x61, 0x6C, 0x75, 0x65, 0x00 })]
+    [InlineData(new byte[] { 0x0A, 0x00, 0x04, 0x72, 0x6F, 0x6F, 0x74, 0x08, 0x00, 0x01, 0x0A, 0x00, 0x05, 0x76, 0x61, 0x6C, 0x75, 0x65, 0x00 })]
+    public void ReadCompound_ReplacesWhitespaceTagNameWithText(byte[] bytes)
+    {
+        NbtTag.Parse<NbtCompound>(bytes, out var result, readName: true);
+
+        Assert.Equal("root", result.Name);
+        Assert.True(result.ContainsKey("text"));
+        var textTag = Assert.IsType<NbtString>(result["text"]);
+        Assert.Equal("value", textTag.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering NbtReader handling of whitespace tag names

## Testing
- `dotnet build`
- `dotnet test tests/Void.Tests.csproj --no-build --filter 'FullyQualifiedName!~Integration'`

------
https://chatgpt.com/codex/tasks/task_e_68736712b0d4832b9cd07fea90a46150