### PR TITLE
Add comprehensive tests for BufferMemory and BufferSpan

### DIFF
--- a/tests/BufferTests/BufferMemoryTests.cs
+++ b/tests/BufferTests/BufferMemoryTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Buffers.Exceptions;
+using Xunit;
+
+namespace Void.Tests.BufferTests;
+
+public class BufferMemoryTests
+{
+    [Fact]
+    public void Slice_ReturnsExpectedMemory()
+    {
+        var memory = new BufferMemory(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        var slice = memory.Slice(2, 5);
+        Assert.Equal(new byte[] { 2, 3, 4, 5, 6 }, slice.Span.Access(0, 5).ToArray());
+    }
+
+    [Fact]
+    public void Slice_NegativePosition_Throws()
+    {
+        var memory = new BufferMemory(new byte[10]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => memory.Slice(-1, 1));
+    }
+
+    [Fact]
+    public void Slice_NegativeLength_Throws()
+    {
+        var memory = new BufferMemory(new byte[10]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => memory.Slice(0, -1));
+    }
+
+    [Fact]
+    public void Slice_PastEnd_Throws()
+    {
+        var memory = new BufferMemory(new byte[5]);
+        Assert.Throws<EndOfBufferException>(() => memory.Slice(3, 3));
+    }
+
+    [Fact]
+    public void Span_ReturnsBufferSpanWithSameLength()
+    {
+        var memory = new BufferMemory(new byte[7]);
+        Assert.Equal(7, memory.Span.Length);
+    }
+}

--- a/tests/BufferTests/BufferSpanTests.cs
+++ b/tests/BufferTests/BufferSpanTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Buffers.Exceptions;
+using Xunit;
+
+namespace Void.Tests.BufferTests;
+
+public class BufferSpanTests
+{
+    [Fact]
+    public void Position_SetValid_Succeeds()
+    {
+        var span = new BufferSpan(stackalloc byte[10]);
+        span.Position = 5;
+        Assert.Equal(5, span.Position);
+    }
+
+    [Fact]
+    public void Position_SetNegative_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[10]);
+            span.Position = -1;
+        });
+    }
+
+    [Fact]
+    public void Position_SetPastEnd_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[10]);
+            span.Position = 11;
+        });
+    }
+
+    [Fact]
+    public void Slice_ReturnsExpectedSpan()
+    {
+        Span<byte> source = stackalloc byte[] { 0, 1, 2, 3, 4 };
+        var span = new BufferSpan(source);
+        var slice = span.Slice(1, 3);
+        Assert.Equal(new byte[] { 1, 2, 3 }, slice.Access(0, 3).ToArray());
+    }
+
+    [Fact]
+    public void Access_ByLength_UsesCurrentPosition()
+    {
+        Span<byte> source = stackalloc byte[] { 0, 1, 2, 3, 4 };
+        var span = new BufferSpan(source);
+        span.Position = 2;
+        Assert.Equal(new byte[] { 2, 3 }, span.Access(2).ToArray());
+    }
+
+    [Fact]
+    public void Access_OutOfRange_Throws()
+    {
+        Assert.Throws<EndOfBufferException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[5]);
+            span.Access(3, 3);
+        });
+    }
+
+    [Fact]
+    public void Access_NegativePosition_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[5]);
+            span.Access(-1, 1);
+        });
+    }
+
+    [Fact]
+    public void Access_NegativeLength_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[5]);
+            span.Access(0, -1);
+        });
+    }
+
+    [Fact]
+    public void Access_LengthTooLong_Throws()
+    {
+        Assert.Throws<EndOfBufferException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[5]);
+            span.Access(4, 2);
+        });
+    }
+
+    [Fact]
+    public void Seek_Begin_UpdatesPosition()
+    {
+        var span = new BufferSpan(stackalloc byte[10]);
+        span.Seek(3, SeekOrigin.Begin);
+        Assert.Equal(3, span.Position);
+    }
+
+    [Fact]
+    public void Seek_Current_UpdatesPosition()
+    {
+        var span = new BufferSpan(stackalloc byte[10]);
+        span.Position = 2;
+        span.Seek(3, SeekOrigin.Current);
+        Assert.Equal(5, span.Position);
+    }
+
+    [Fact]
+    public void Seek_End_UpdatesPosition()
+    {
+        var span = new BufferSpan(stackalloc byte[10]);
+        span.Seek(-2, SeekOrigin.End);
+        Assert.Equal(8, span.Position);
+    }
+
+    [Fact]
+    public void Seek_Negative_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[10]);
+            span.Seek(-1, SeekOrigin.Begin);
+        });
+    }
+
+    [Fact]
+    public void Seek_PastEnd_Throws()
+    {
+        Assert.Throws<EndOfBufferException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[10]);
+            span.Seek(1, SeekOrigin.End);
+        });
+    }
+
+    [Fact]
+    public void Seek_InvalidOrigin_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var span = new BufferSpan(stackalloc byte[10]);
+            span.Seek(0, (SeekOrigin)42);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add BufferMemory unit tests covering slicing and Span
- add extensive BufferSpan tests for position, access, slicing and seeking

## Testing
- `dotnet format tests/Void.Tests.csproj`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68738e536fa8832b9902e894b47e9c7e