### PR TITLE
Add TryParse to Uuid and tests

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -30,6 +30,18 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
         return new Uuid(Guid.Parse(text));
     }
 
+    public static bool TryParse(string? text, out Uuid uuid)
+    {
+        if (Guid.TryParse(text, out var guid))
+        {
+            uuid = new Uuid(guid);
+            return true;
+        }
+
+        uuid = default;
+        return false;
+    }
+
     public static Uuid Parse(params int[] parts)
     {
         if (parts.Length is not 4)

--- a/tests/GuidTests/UuidTests.cs
+++ b/tests/GuidTests/UuidTests.cs
@@ -106,4 +106,18 @@ public class UuidTests
         Assert.False(u1 != u2);
         Assert.Equal(0, u1.CompareTo(u2));
     }
+
+    [Theory]
+    [InlineData("11223344-5566-7788-99aa-bbccddeeff00", true)]
+    [InlineData("not-a-uuid", false)]
+    public void TryParse_ReturnsExpected(string text, bool expected)
+    {
+        var result = Uuid.TryParse(text, out var uuid);
+        Assert.Equal(expected, result);
+
+        if (expected)
+            Assert.Equal(Guid.Parse(text), uuid.AsGuid);
+        else
+            Assert.Equal(Uuid.Empty, uuid);
+    }
 }


### PR DESCRIPTION
## Summary
- add `TryParse` method to `Uuid`
- cover `TryParse` in `UuidTests`

## Testing
- `dotnet build`
- `dotnet test --no-build`
- `dotnet format` *(fails: Microsoft.VisualStudio.SolutionPersistence missing)*

------
https://chatgpt.com/codex/tasks/task_e_68745b5e6b5c832bb6a833c50c4d4be5