### PR TITLE
fix: correct variable name in integration test

### DIFF
--- a/tests/Integration/MinecraftTests.cs
+++ b/tests/Integration/MinecraftTests.cs
@@ -303,9 +303,9 @@ public class MinecraftTests : IDisposable
 
             var proxyCertificatePath = Environment.GetEnvironmentVariable("CODEX_PROXY_CERT");
 
-            if (!string.IsNullOrWhiteSpace(proxyCertificatePath) && File.Exists(proxyCertificatePath) && Path.GetDirectoryName(javaPath) is { } javaBiniariesPath && Directory.GetParent(javaBiniariesPath) is { } javaHomePath)
+            if (!string.IsNullOrWhiteSpace(proxyCertificatePath) && File.Exists(proxyCertificatePath) && Path.GetDirectoryName(javaPath) is { } javaBinariesPath && Directory.GetParent(javaBinariesPath) is { } javaHomePath)
             {
-                var keytool = Path.Combine(javaBiniariesPath, OperatingSystem.IsWindows() ? "keytool.exe" : "keytool");
+                var keytool = Path.Combine(javaBinariesPath, OperatingSystem.IsWindows() ? "keytool.exe" : "keytool");
 
                 if (File.Exists(keytool))
                 {


### PR DESCRIPTION
## Summary
- fix a typo in `MinecraftTests` variable name

## Testing
- `dotnet build -c Release`
- `dotnet test --no-build`
- `dotnet format` *(fails: Could not load file or assembly 'Microsoft.VisualStudio.SolutionPersistence')*

------
https://chatgpt.com/codex/tasks/task_e_6876c476458c832b91f1403d054c5230