### PR TITLE
Update dotnet version in workflows

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -19,7 +19,7 @@ on:
         value: ${{ jobs.release-please.outputs.tag_name }}
 
 env:
-  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || '10.0.100-preview.4.25258.110' }}
+  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || '10.0.100-preview.6.25358.103' }}
 
 jobs:
   dev:


### PR DESCRIPTION
## Summary
- bump default .NET SDK version used in GitHub Actions

## Testing
- `dotnet format` *(fails: Restore operation failed)*
- `dotnet build --no-restore` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68771ef96aa4832b8a26cd60ead87aab