### PR TITLE
Add --ignore-file-servers option

### DIFF
--- a/docs/astro/src/content/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/configuration/program-arguments.md
@@ -22,6 +22,7 @@ Options:
                                  https://nuget.example.com/v3/index.json or --repository
                                  https://username:password@nuget.example.com/v3/index.json].
   -p, --plugin <plugin>          Provides a path to the file, directory or url to load plugin.
+  --ignore-file-servers         Ignore servers specified in configuration files
   --version                      Show version information
   -?, -h, --help                 Show help and usage information
 ```
@@ -32,11 +33,15 @@ Options:
   Example: `./void-linux-x64 --plugin https://example.org/download/YourPlugin1.dll --plugin /home/YourPlugin2.dll`
 
 ## NuGet
-- `--repository`  
-  Allows you to specify additional NuGet repositories to use.  
+- `--repository`
+  Allows you to specify additional NuGet repositories to use.
   Example: `./void-linux-x64 --repository https://nuget.example.com/v3/index.json`
 
+## Servers
+- `--ignore-file-servers`
+  Ignore servers specified in configuration files.
+
 ## Version
-- `--version`  
-  Displays the current version of Void Proxy.  
+- `--version`
+  Displays the current version of Void Proxy.
   Example: `./void-linux-x64 --version`

--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -107,6 +107,7 @@ public static class EntryPoint
 
         NuGetDependencyResolver.RegisterOptions(root);
         PluginService.RegisterOptions(root);
+        ServerService.RegisterOptions(root);
 
         root.SetHandler(async context => await MainHandlerAsync(logWriter, context, cancellationToken));
 

--- a/src/Platform/Servers/ServerService.cs
+++ b/src/Platform/Servers/ServerService.cs
@@ -1,10 +1,21 @@
-﻿using Void.Proxy.Api.Links;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Void.Proxy.Api.Links;
 using Void.Proxy.Api.Servers;
 using Void.Proxy.Api.Settings;
 
 namespace Void.Proxy.Servers;
 
-public class ServerService(ISettings settings, ILinkService links) : IServerService
+public class ServerService(ISettings settings, ILinkService links, InvocationContext context) : IServerService
 {
-    public IEnumerable<IServer> All => settings.Servers.Concat(links.All.Select(link => link.Server));
+    private static readonly Option<bool> _ignoreFileServersOption = new("--ignore-file-servers", description: "Ignore servers specified in configuration files");
+
+    public static void RegisterOptions(Command command)
+    {
+        command.AddOption(_ignoreFileServersOption);
+    }
+
+    public IEnumerable<IServer> All
+        => (context.ParseResult.GetValueForOption(_ignoreFileServersOption) ? [] : settings.Servers)
+            .Concat(links.All.Select(link => link.Server));
 }


### PR DESCRIPTION
## Summary
- add `--ignore-file-servers` option to ServerService
- expose new option from EntryPoint

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68785ed62550832bbc0b03faba5971ed