### PR TITLE
fix(docs): 🔒 authenticate release fetch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install, build, and upload documentation site
         uses: withastro/action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: docs/astro
 #       - name: Validate links

--- a/docs/astro/src/content.config.ts
+++ b/docs/astro/src/content.config.ts
@@ -9,10 +9,23 @@ export const collections = {
     }),
     releases: defineCollection({
         loader: async () => {
-            const response = await fetch("https://api.github.com/repos/caunt/Void/releases");
+            const headers: Record<string, string> = {};
+            const token = process.env.GITHUB_TOKEN;
+            if (token) {
+                headers["Authorization"] = `Bearer ${token}`;
+            }
+
+            const response = await fetch(
+                "https://api.github.com/repos/caunt/Void/releases",
+                { headers }
+            );
             const data = await response.json();
 
-            data.forEach((item : any) => {
+            if (!Array.isArray(data)) {
+                throw new Error("Unexpected response from GitHub Releases API");
+            }
+
+            data.forEach((item: any) => {
                 item.id = item.id.toString();
             });
 


### PR DESCRIPTION
## Summary
- use the workflow token when building documentation
- authenticate `fetch` for release data in Astro

## Testing
- `dotnet format --no-restore --verbosity minimal`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687885b749a0832b95967076adee7cb2