### PR TITLE
docs(download): 📝 rename OSX references to macOS

### DIFF
--- a/docs/astro/src/content/docs/download.mdx
+++ b/docs/astro/src/content/docs/download.mdx
@@ -12,7 +12,7 @@ export const releases = await getCollection('releases');
 export const platforms = [
     { "id": "windows",      "title": "Windows",         "pattern": "-win-",          "icon": "seti:windows" },
     { "id": "linux",        "title": "Linux",           "pattern": "-linux-",        "icon": "linux"        },
-    { "id": "osx",          "title": "OSX",             "pattern": "-osx-",          "icon": "apple"        },
+    { "id": "osx",          "title": "macOS",           "pattern": "-osx-",          "icon": "apple"        },
     { "id": "pdk",          "title": "DevKit",          "pattern": "-devkit",        "icon": "vscode"       },
     // { "id": "linux-bionic", "title": "Linux (Android)", "pattern": "-linux-bionic-", "icon": "linux"        },
     // { "id": "linux-musl",   "title": "Linux (Alpine)",  "pattern": "-linux-musl-",   "icon": "linux"        }

--- a/docs/astro/src/content/docs/index.mdx
+++ b/docs/astro/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { Card, LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Download" icon="cloud-download">
-		[**Download Void**](/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, OSX and more.
+                [**Download Void**](/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, macOS and more.
 	</Card>
 	<Card title="Build Plugins" icon="pencil">
 		Void provides a powerful plugin API that allows you to create plugins on the raw network level.


### PR DESCRIPTION
## Summary
- rename OSX platform tab in downloads page to macOS
- update index page to mention macOS instead of OSX

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68788b4953ac832b8ad792f5f0f18822