### PR TITLE
fix(links): 🐛 correct comment typo

### DIFF
--- a/src/Platform/Links/LinkService.cs
+++ b/src/Platform/Links/LinkService.cs
@@ -123,7 +123,7 @@ public class LinkService(ILogger<LinkService> logger, ISettings settings, IEvent
                 throw new InvalidOperationException($"Link {@event.Link} is not found");
         }
 
-        // IServer channel is no longed needed
+        // IServer channel is no longer needed
         @event.Link.ServerChannel.Close();
 
         if (!@event.Link.PlayerChannel.IsAlive)


### PR DESCRIPTION
## Summary
- fix a typo in LinkService comment

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68789dea627c832b89a2f82698df28b7