### PR TITLE
test(platform): 🧪 fix typo in test name

### DIFF
--- a/tests/Integration/PlatformTests.cs
+++ b/tests/Integration/PlatformTests.cs
@@ -10,7 +10,7 @@ namespace Void.Tests.Integration;
 public class PlatformTests
 {
     [Fact]
-    public async Task EntryPoint_RunsStopsSuccessfuly()
+    public async Task EntryPoint_RunsStopsSuccessfully()
     {
         var logs = new CollectingTextWriter();
 


### PR DESCRIPTION
## Summary
- fix typo in PlatformTests so test name reads `EntryPoint_RunsStopsSuccessfully`

## Testing
- `dotnet build`
- `dotnet test` *(fails: ConnectionTestBase.GetGitHubRepositoryLatestReleaseAssetAsync)*

------
https://chatgpt.com/codex/tasks/task_e_6878f397cef0832b9e1902cfe55d15a6