### PR TITLE
test(platform): ✅ add interface and port option tests

### DIFF
--- a/src/Void.Tests/Integration/PlatformTests.cs
+++ b/src/Void.Tests/Integration/PlatformTests.cs
@@ -22,4 +22,32 @@ public class PlatformTests
         Assert.Contains(logs.Lines, line => line.Contains("Hosting started"));
         Assert.Contains(logs.Lines, line => line.Contains("Hosting stopped"));
     }
+
+    [Fact]
+    public async Task EntryPoint_UsesPortOption()
+    {
+        var logs = new CollectingTextWriter();
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var exitCode = await EntryPoint.RunAsync(logWriter: logs, cancellationToken: cancellationTokenSource.Token, args: ["--port", "50000"]);
+
+        Assert.Equal(0, exitCode);
+
+        Assert.Contains(logs.Lines, line => line.Contains("Connection listener started"));
+        Assert.Contains(logs.Lines, line => line.Contains("50000"));
+    }
+
+    [Fact]
+    public async Task EntryPoint_UsesInterfaceOption()
+    {
+        var logs = new CollectingTextWriter();
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var exitCode = await EntryPoint.RunAsync(logWriter: logs, cancellationToken: cancellationTokenSource.Token, args: ["--interface", "127.0.0.1"]);
+
+        Assert.Equal(0, exitCode);
+
+        Assert.Contains(logs.Lines, line => line.Contains("Connection listener started"));
+        Assert.Contains(logs.Lines, line => line.Contains("127.0.0.1"));
+    }
 }


### PR DESCRIPTION
## Summary
- add integration tests checking `--port` and `--interface` CLI options

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter "FullyQualifiedName~PlatformTests.EntryPoint_UsesPortOption" -v minimal`
- `dotnet test --no-build --filter "FullyQualifiedName~PlatformTests.EntryPoint_UsesInterfaceOption" -v minimal`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687da8d00f88832b99feefa35b44634e