### PR TITLE
fix(platform): ♻️ reinitialize logger for each run

### DIFF
--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -42,10 +42,16 @@ public static class EntryPoint
     {
         System.Console.Title = nameof(Void);
         Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+    }
 
+    private static void ConfigureLogging()
+    {
         var configuration = new LoggerConfiguration();
+
         configuration.Enrich.FromLogContext();
+
         configuration.MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch);
+
         configuration.WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
 
         Log.Logger = configuration.CreateLogger();
@@ -53,6 +59,7 @@ public static class EntryPoint
 
     public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, params string[] args)
     {
+        ConfigureLogging();
         try
         {
             return await BuildCommandLine(logWriter, cancellationToken)


### PR DESCRIPTION
## Summary
- reset Serilog logger each time `EntryPoint.RunAsync` runs to avoid failures when tests invoke it multiple times

## Testing
- `dotnet build --no-restore`
- `dotnet test src/Tests/Void.Tests.csproj --no-build --filter FullyQualifiedName~Void.Tests.Integration.PlatformTests -v normal`


------
https://chatgpt.com/codex/tasks/task_e_687dd53281a0832b8c456149fd7feb38