### PR TITLE
test(integration): ✅ add proxied connection test

### DIFF
--- a/src/Tests/Integration/Connections/ConnectionTestBase.cs
+++ b/src/Tests/Integration/Connections/ConnectionTestBase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Void.Tests.Exceptions;
 using Void.Tests.Integration.Sides.Clients;
 using Void.Tests.Integration.Sides.Servers;
+using Void.Tests.Integration.Sides;
 
 public abstract class ConnectionTestBase : IDisposable
 {
@@ -51,6 +52,35 @@ public abstract class ConnectionTestBase : IDisposable
         catch (Exception exception)
         {
             throw new IntegrationTestException(exception.Message + $"\nServer logs:\n{string.Join("\n", server.Logs)}\n\n\nClient logs:\n{string.Join("\n", client.Logs)}", exception);
+        }
+    }
+
+    public async Task ExecuteAsync(IIntegrationServer server, IIntegrationSide proxy, IIntegrationClient client, CancellationToken cancellationToken = default)
+    {
+        await Task.WhenAll(
+            server.SetupAsync(WorkingDirectory, _httpClient, cancellationToken),
+            proxy.SetupAsync(WorkingDirectory, _httpClient, cancellationToken),
+            client.SetupAsync(WorkingDirectory, _httpClient, cancellationToken));
+
+        Task serverTask, proxyTask, clientTask;
+
+        try
+        {
+            serverTask = server.RunAsync(cancellationToken);
+            var completedServerTask = await Task.WhenAny(serverTask, server.ServerLoadingTask);
+
+            if (completedServerTask == serverTask)
+                await serverTask;
+
+            proxyTask = proxy.RunAsync(cancellationToken);
+
+            clientTask = client.RunAsync(cancellationToken);
+
+            await serverTask;
+        }
+        catch (Exception exception)
+        {
+            throw new IntegrationTestException(exception.Message + $"\nServer logs:\n{string.Join("\n", server.Logs)}\n\nProxy logs:\n{string.Join("\n", proxy.Logs)}\n\nClient logs:\n{string.Join("\n", client.Logs)}", exception);
         }
     }
 

--- a/src/Tests/Integration/Connections/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/ProxiedConnectionTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections;
+
+public class ProxiedConnectionTests : ConnectionTestBase
+{
+    private const string ExpectedText = "hello void!";
+
+    [Fact]
+    public async Task MccConnectsToPaperServerThroughProxy()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        await using var paper = new PaperServer(ExpectedText);
+        await using var proxy = new ProxyPlatform("localhost:25565", 25566, true);
+        await using var mcc = new MinecraftConsoleClient(ExpectedText, "localhost:25566");
+
+        await ExecuteAsync(paper, proxy, mcc, cancellationTokenSource.Token);
+
+        Assert.Contains(paper.Logs, line => line.Contains(ExpectedText));
+    }
+}

--- a/src/Tests/Integration/Sides/Proxies/ProxyPlatform.cs
+++ b/src/Tests/Integration/Sides/Proxies/ProxyPlatform.cs
@@ -1,0 +1,37 @@
+namespace Void.Tests.Integration.Sides.Proxies;
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Proxy;
+using Void.Tests.Integration.Sides;
+using Void.Tests.Streams;
+
+public class ProxyPlatform(string serverAddress, int port, bool ignoreFileServers) : IIntegrationSide
+{
+    private readonly CollectingTextWriter _logs = new();
+
+    public IEnumerable<string> Logs => _logs.Lines;
+
+    public Task SetupAsync(string workingDirectory, HttpClient client, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var args = new List<string>
+        {
+            "--server", serverAddress,
+            "--port", port.ToString()
+        };
+
+        if (ignoreFileServers)
+            args.Add("--ignore-file-servers");
+
+        await EntryPoint.RunAsync(logWriter: _logs, cancellationToken: cancellationToken, args: [.. args]);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- support running integration tests with a proxy between server and client
- set up `ProxyPlatform` integration side that launches `EntryPoint` with `--server`, `--port` and `--ignore-file-servers` options
- add new execution method that starts server, proxy, then client
- verify MCC can connect through the proxy

## Testing
- `dotnet format --no-restore --verbosity diag`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: A task was canceled)*

------
https://chatgpt.com/codex/tasks/task_e_687df2d99014832b9a84aeaed0be07d2