### PR TITLE
feat(platform): ✨ add offline mode

### DIFF
--- a/docs/astro/src/content/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/configuration/environment-variables.md
@@ -28,6 +28,10 @@ However, they might be used from the terminal directly as well.
   Defines the Mojang session server to use.  
   Example: `https://sessionserver.mojang.com/session/minecraft/hasJoined`
 
-- `VOID_MOJANG_PREVENT_PROXY_CONNECTIONS`  
-  Tells Mojang to disallow player proxy connections.  
+- `VOID_MOJANG_PREVENT_PROXY_CONNECTIONS`
+  Tells Mojang to disallow player proxy connections.
+  Example: `true`
+
+- `VOID_OFFLINE`
+  Disables Mojang authentication.
   Example: `true`

--- a/docs/astro/src/content/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/configuration/in-file.md
@@ -27,6 +27,9 @@ KickTimeout = 10000
 # Logging level (valid values are Trace, Debug, Information, Warning, Error, Critical)
 LogLevel = "Information"
 
+# When true, players are not authenticated with Mojang
+Offline = false
+
 # Predefined list of servers. 
 # Players will be connected to the first one, if not specified otherwise from plugins.
 Servers = [

--- a/docs/astro/src/content/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/configuration/program-arguments.md
@@ -25,6 +25,7 @@ Options:
   --server <server>              Registers an additional server in format <host>:<port>
   --interface <address>          Overrides the listening network interface
   --port <port>                  Overrides the listening port
+  --offline                      Disables Mojang authentication
   --ignore-file-servers          Ignore servers specified in configuration files
   --version                      Show version information
   -?, -h, --help                 Show help and usage information
@@ -54,6 +55,9 @@ Options:
 - `--port`
   Overrides the listening port for the proxy.
   Example: `./void-linux-x64 --port 25570`
+- `--offline`
+  Disables Mojang authentication.
+  Example: `./void-linux-x64 --offline`
 
 ## Version
 - `--version`

--- a/src/Api/Settings/ISettings.cs
+++ b/src/Api/Settings/ISettings.cs
@@ -11,5 +11,6 @@ public interface ISettings
     public int CompressionThreshold { get; }
     public int KickTimeout { get; }
     public LogLevel LogLevel { get; }
+    public bool Offline { get; }
     public IEnumerable<IServer> Servers { get; }
 }

--- a/src/Platform/Configurations/Settings.cs
+++ b/src/Platform/Configurations/Settings.cs
@@ -14,6 +14,7 @@ public record Settings : ISettings
     public int CompressionThreshold { get; init; } = 256;
     public int KickTimeout { get; init; } = 10_000;
     public LogLevel LogLevel { get; init; } = LogLevel.Information;
+    public bool Offline { get; init; } = false;
     public List<Server> Servers { get; init; } =
     [
         new("lobby", "127.0.0.1", 25566),
@@ -23,4 +24,5 @@ public record Settings : ISettings
 
     IPAddress ISettings.Address => IPAddress.Parse(Address);
     IEnumerable<IServer> ISettings.Servers => Servers;
+    bool ISettings.Offline => Offline;
 }

--- a/src/Platform/Platform.cs
+++ b/src/Platform/Platform.cs
@@ -31,9 +31,11 @@ public class Platform(
     public static readonly LoggingLevelSwitch LoggingLevelSwitch = new();
     private static readonly Option<int> _portOption = new("--port", description: "Sets the listening port");
     private static readonly Option<string> _interfaceOption = new("--interface", description: "Sets the listening network interface");
+    private static readonly Option<bool> _offlineOption = new("--offline", description: "Disables Mojang authentication");
 
     private readonly IPAddress _interface = context.ParseResult.GetValueForOption(_interfaceOption) is { } value ? IPAddress.Parse(value) : settings.Address;
     private readonly int _port = context.ParseResult.HasOption(_portOption) ? context.ParseResult.GetValueForOption(_portOption) : settings.Port;
+    private readonly bool _offline = context.ParseResult.HasOption(_offlineOption) ? context.ParseResult.GetValueForOption(_offlineOption) : settings.Offline;
 
     private Task? _backgroundTask;
     private TcpListener? _listener;
@@ -47,6 +49,8 @@ public class Platform(
             field = value;
         }
     }
+
+    public bool Offline => _offline;
 
     public async ValueTask StartAcceptingConnectionsAsync(CancellationToken cancellationToken)
     {
@@ -179,6 +183,7 @@ public class Platform(
     {
         command.AddOption(_interfaceOption);
         command.AddOption(_portOption);
+        command.AddOption(_offlineOption);
     }
 
     private async Task ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Plugins/Common/Mojang/MojangService.cs
+++ b/src/Plugins/Common/Mojang/MojangService.cs
@@ -7,11 +7,12 @@ using Void.Minecraft.Players.Extensions;
 using Void.Minecraft.Profiles;
 using Void.Proxy.Api.Crypto;
 using Void.Proxy.Api.Players;
+using Void.Proxy.Api.Settings;
 using Void.Proxy.Plugins.Common.Crypto;
 
 namespace Void.Proxy.Plugins.Common.Mojang;
 
-public class MojangService(ICryptoService crypto) : IMojangService
+public class MojangService(ICryptoService crypto, ISettings settings) : IMojangService
 {
     private static readonly HttpClient Client = new();
     private static readonly string SessionServer = Environment.GetEnvironmentVariable("VOID_MOJANG_SESSIONSERVER") ?? "https://sessionserver.mojang.com/session/minecraft/hasJoined";
@@ -19,6 +20,9 @@ public class MojangService(ICryptoService crypto) : IMojangService
 
     public async ValueTask<GameProfile?> VerifyAsync(IPlayer player, CancellationToken cancellationToken = default)
     {
+        if (settings.Offline)
+            return player.Profile is { } offlineProfile ? offlineProfile : null;
+
         if (player.Profile is not { } profile)
             throw new ArgumentNullException(nameof(player), "Player profile should be set in order to verify his session");
 


### PR DESCRIPTION
## Summary
- add `Offline` setting to disable Mojang authentication
- support `--offline` command-line option
- bypass Mojang session verification when offline
- document the new configuration setting and environment variable

## Testing
- `dotnet format --no-restore --verbosity minimal`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: JRE is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f1acf87e8832bb0c4218958ce4a65