### PR TITLE
test(integration): 🧪 use correct MCC filename on Windows

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MinecraftConsoleClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MinecraftConsoleClient.cs
@@ -37,7 +37,8 @@ public class MinecraftConsoleClient(string sendText, string address) : Integrati
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);
 
-        var path = Path.Combine(workingDirectory, "client");
+        var clientFileName = OperatingSystem.IsWindows() ? "client.exe" : "client";
+        var path = Path.Combine(workingDirectory, clientFileName);
         var url = await GetGitHubRepositoryLatestReleaseAssetAsync(RepositoryOwnerName, RepositoryName, name => name.EndsWith(GetMinecraftConsoleClientSuffix()), cancellationToken);
 
         await client.DownloadFileAsync(url, path, cancellationToken);


### PR DESCRIPTION
## Summary
- fix Minecraft Console Client setup to keep `.exe` extension on Windows

## Testing
- `dotnet format` *(fails: Could not find a MSBuild project file or solution file)*
- `dotnet build` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68804550f5f8832b97f46ed0c840cae2