### PR TITLE
test(servers): ✨ add plugin flags to PaperServer

### DIFF
--- a/src/Tests/Integration/Sides/Servers/PaperPlugins.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperPlugins.cs
@@ -1,0 +1,12 @@
+namespace Void.Tests.Integration.Sides.Servers;
+
+using System;
+
+[Flags]
+public enum PaperPlugins
+{
+    None = 0,
+    ViaVersion = 1,
+    ViaBackwards = 2,
+    All = ViaVersion | ViaBackwards
+}

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 using Void.Tests.Exceptions;
 using Void.Tests.Extensions;
 
-public class PaperServer(string expectedText) : IntegrationSideBase, IIntegrationServer
+public class PaperServer(string expectedText, PaperPlugins plugins = PaperPlugins.All) : IntegrationSideBase, IIntegrationServer
 {
     private const string ViaVersionRepositoryOwnerName = "ViaVersion";
     private const string ViaVersionRepositoryName = "ViaVersion";
@@ -80,11 +80,17 @@ public class PaperServer(string expectedText) : IntegrationSideBase, IIntegratio
             if (!Directory.Exists(pluginsDirectory))
                 Directory.CreateDirectory(pluginsDirectory);
 
-            var viaVersion = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaVersionRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
-            await client.DownloadFileAsync(viaVersion, Path.Combine(pluginsDirectory, "ViaVersion.jar"), cancellationToken);
+            if (plugins.HasFlag(PaperPlugins.ViaVersion))
+            {
+                var viaVersion = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaVersionRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
+                await client.DownloadFileAsync(viaVersion, Path.Combine(pluginsDirectory, "ViaVersion.jar"), cancellationToken);
+            }
 
-            var viaBackwards = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaBackwardsRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
-            await client.DownloadFileAsync(viaBackwards, Path.Combine(pluginsDirectory, "ViaBackwards.jar"), cancellationToken);
+            if (plugins.HasFlag(PaperPlugins.ViaBackwards))
+            {
+                var viaBackwards = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaBackwardsRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
+                await client.DownloadFileAsync(viaBackwards, Path.Combine(pluginsDirectory, "ViaBackwards.jar"), cancellationToken);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow selecting Paper plugins via flags
- default to enabling all plugins

## Testing
- `dotnet format --no-restore --include src/Tests/Integration/Sides/Servers/PaperServer.cs src/Tests/Integration/Sides/Servers/PaperPlugins.cs`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Build failed with warning MSB5021)*

------
https://chatgpt.com/codex/tasks/task_e_68805c8525a0832bbe43626318cdad52