### PR TITLE
docs: 📝 forbid null-forgiving operator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Follow the existing C# style rules:
 - Async methods carry an `Async` suffix.
 - Pattern matching is preferred over explicit casts.
 - `nameof` is used for parameter checks, logging, and exceptions.
+- Never use the null-forgiving `!` operator to silence possible null reference warnings.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- clarify coding standards to avoid the null-forgiving operator

## Testing
- `dotnet format Void.slnx` *(fails: The file 'Void.slnx' does not appear to be a valid project or solution file.)*
- `dotnet test --no-build` *(fails: Starting test execution, please wait...)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6882e1000088832bb997bb0a512b7899