### PR TITLE
ci(main): 🔒 inherit secrets for semver job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,7 @@ on:
 jobs:
   semver:
     uses: ./.github/workflows/version.yaml
+    secrets: inherit
     with:
       dotnet-version: ${{ github.event.inputs.dotnet-version }}
 


### PR DESCRIPTION
## Summary
- allow semver job to inherit secrets

## Testing
- `dotnet format` *(fails: Could not find a MSBuild project file)*
- `dotnet test` *(fails: current directory does not contain a project)*

------
https://chatgpt.com/codex/tasks/task_e_688303864e70832bbc89260327a6ed6c