### PR TITLE
test(mineflayer): ⬇️ set lower bound to 1.8

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -24,7 +24,7 @@ public class MineflayerClient : IntegrationSideBase
 
     public static TheoryData<ProtocolVersion> SupportedVersions { get; } = [
         .. ProtocolVersion
-            .Range(ProtocolVersion.MINECRAFT_1_21_4, ProtocolVersion.MINECRAFT_1_7_6)
+            .Range(ProtocolVersion.MINECRAFT_1_21_4, ProtocolVersion.MINECRAFT_1_8)
             .Except([ProtocolVersion.MINECRAFT_1_21_2])
     ];
 


### PR DESCRIPTION
## Summary
- align mineflayer integration test versions with 1.8 as the minimum supported version

## Testing
- `dotnet format --include src/Tests/Integration/Sides/Clients/MineflayerClient.cs --no-restore --verbosity diagnostic`
- `dotnet build -c Release`
- `dotnet test` *(failed: Build failed with 1 warning(s) in 157.6s)*

------
https://chatgpt.com/codex/tasks/task_e_688357005254832b9f9997b30856fa87