### PR TITLE
test(mineflayer): 🐛 fallback npm path

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -146,6 +146,8 @@ public class MineflayerClient : IntegrationSideBase
         var nodeRootDirectory = Directory.GetParent(nodeDirectoryName) ?? throw new IntegrationTestException("Failed to resolve Node root");
         var nodeRoot = nodeRootDirectory.FullName;
         var npmCli = Path.Combine(nodeRoot, "lib", "node_modules", "npm", "bin", "npm-cli.js");
+        if (!File.Exists(npmCli))
+            npmCli = Path.Combine(nodeRoot, "node_modules", "npm", "bin", "npm-cli.js");
 
         await RunProcessAsync(nodePath, [npmCli, "init", "-y"], workingDirectory, cancellationToken);
         await RunProcessAsync(nodePath, [npmCli, "install", "mineflayer"], workingDirectory, cancellationToken);


### PR DESCRIPTION
## Summary
- handle missing npm-cli.js in Mineflayer tests

## Testing
- `dotnet build`
- `dotnet test --no-build --filter FullyQualifiedName~Integration` *(fails: event not found)*

------
https://chatgpt.com/codex/tasks/task_e_688368de3f38832bb86bd223d3942126