### PR TITLE
feat(platform): ✨ add logging level option

### DIFF
--- a/docs/astro/src/content/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/configuration/program-arguments.md
@@ -27,6 +27,7 @@ Options:
   --port <port>                  Overrides the listening port
   --ignore-file-servers          Ignore servers specified in configuration files
   --offline                      Allows players to connect without Mojang authorization
+  --logging <level>              Sets the logging level
   --version                      Show version information
   -?, -h, --help                 Show help and usage information
 ```
@@ -60,6 +61,11 @@ Options:
 - `--offline`
   Allows players to connect without Mojang authorization.
   Example: `./void-linux-x64 --offline`
+
+## Logging
+- `--logging`
+  Sets the logging level. Valid values are Trace, Debug, Information, Warning, Error and Critical.
+  Example: `./void-linux-x64 --logging Debug`
 
 ## Version
 - `--version`

--- a/src/Platform/Platform.cs
+++ b/src/Platform/Platform.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using Serilog.Core;
 using Serilog.Events;
 using Void.Proxy.Api;
@@ -33,6 +34,7 @@ public class Platform(
     private static readonly Option<int> _portOption = new("--port", description: "Sets the listening port");
     private static readonly Option<string> _interfaceOption = new("--interface", description: "Sets the listening network interface");
     private static readonly Option<bool> _offlineOption = new("--offline", description: "Allows players to connect without Mojang authorization");
+    private static readonly Option<LogLevel> _loggingOption = new("--logging", description: "Sets the logging level");
 
     private readonly IPAddress _interface = context.ParseResult.GetValueForOption(_interfaceOption) is { } value ? IPAddress.Parse(value) : settings.Address;
     private readonly int _port = context.ParseResult.HasOption(_portOption) ? context.ParseResult.GetValueForOption(_portOption) : settings.Port;
@@ -121,6 +123,9 @@ public class Platform(
         LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
 #endif
 
+        if (context.ParseResult.GetValueForOption(_loggingOption) is { } level)
+            LoggingLevelSwitch.MinimumLevel = (LogEventLevel)level;
+
         logger.LogInformation("Starting {Name} {Version} proxy", nameof(Void), "v" + GetType().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
         var startTime = Stopwatch.GetTimestamp();
 
@@ -191,6 +196,7 @@ public class Platform(
         command.AddOption(_interfaceOption);
         command.AddOption(_portOption);
         command.AddOption(_offlineOption);
+        command.AddOption(_loggingOption);
     }
 
     private async Task ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -33,7 +33,8 @@ public class VoidProxy : IIntegrationSide
         var args = new List<string>
         {
             "--server", targetServer,
-            "--port", proxyPort.ToString()
+            "--port", proxyPort.ToString(),
+            "--logging", "Trace"
         };
 
         if (ignoreFileServers)


### PR DESCRIPTION
## Summary
- add `--logging` option to control proxy log level
- document the new CLI option

## Testing
- `dotnet format src/Platform/Void.Proxy.csproj --no-restore --verify-no-changes` *(fails: ENDOFLINE issues)*
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore --filter "FullyQualifiedName~NonExisting"`

------
https://chatgpt.com/codex/tasks/task_e_6885d22381d0832bb00ae8a2a17dbb64