### PR TITLE
docs(guidelines): 📝 highlight user-facing behavior in commit descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Follow the existing C# style rules:
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.
 - Conventional Commits are required for commit messages.
+- Include in the commit description a brief note about any observable behavior change.
 - Use the `fix` or `feat` type only when your changes modify the proxy code in `./src`. For documentation, CI, or other unrelated updates, choose a more appropriate type such as `docs` or `chore`.
 - Append a [gitmoji](https://gitmoji.dev/specification) after the commit scope, e.g., `feat(api): ✨ add new endpoint`.
 - Pull request titles should follow the same Conventional Commits format.


### PR DESCRIPTION
## Summary
- clarify that commit descriptions should mention observable behavior changes

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_688744174f78832b8b3c77d99951f619