### PR TITLE
test(servers): 🐛 fix jre binary path parameter

### DIFF
--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -17,10 +17,10 @@ public class PaperServer : IntegrationSideBase
 
     private readonly string _binaryPath;
 
-    private PaperServer(string binaryPath, string jreBinaryBath)
+    private PaperServer(string binaryPath, string jreBinaryPath)
     {
         _binaryPath = binaryPath;
-        _jreBinaryPath = jreBinaryBath;
+        _jreBinaryPath = jreBinaryPath;
 
         StartApplication(_binaryPath, hasInput: false);
     }


### PR DESCRIPTION
## Summary
- fix typo in PaperServer constructor parameter name

## Testing
- `dotnet build --no-restore`
- `timeout 20s dotnet test --no-build --no-restore` *(fails: DirectConnectionTests.MineflayerConnectsToPaperServer_WithProtocolVersion(...))*

------
https://chatgpt.com/codex/tasks/task_e_688955cbc248832b810a50d3c3b31550