### PR TITLE
fix(minecraft): 🐛 correct grammar in slice exception message

### DIFF
--- a/src/Minecraft/Buffers/ReadOnly/ReadOnlySequenceBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadOnly/ReadOnlySequenceBackingBuffer.cs
@@ -103,7 +103,7 @@ internal ref struct ReadOnlySequenceBackingBuffer
     public ReadOnlySpan<byte> Slice(long length)
     {
         if (_sequence.Length < Position + length)
-            throw new IndexOutOfRangeException($"Cannot slice {length} bytes from sequence with length {_sequence.Length}, and current position {Position}. Only {_sequence.Length - Position} bytes is available to slice.");
+            throw new IndexOutOfRangeException($"Cannot slice {length} bytes from sequence with length {_sequence.Length}, and current position {Position}. Only {_sequence.Length - Position} bytes are available to slice.");
 
         if (_currentBlock.Length < _blockPosition + length)
         {


### PR DESCRIPTION
## Summary
- correct a grammar typo in the exception message within `ReadOnlySequenceBackingBuffer`

## Testing
- `dotnet format --no-restore --include src/Minecraft/Buffers/ReadOnly/ReadOnlySequenceBackingBuffer.cs`
- `dotnet test --no-restore --verbosity minimal` *(fails: Terminating the task executable "dotnet" and its child processes because the build was canceled)*
- `dotnet build --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_688955cdc1d0832b93169846ab0142b5