### PR TITLE
fix(minecraft): 🐛 correct float array color precision

### DIFF
--- a/src/Minecraft/Components/Text/Colors/TextShadowColor.cs
+++ b/src/Minecraft/Components/Text/Colors/TextShadowColor.cs
@@ -15,7 +15,7 @@ public record TextShadowColor(byte Alpha, byte Red, byte Green, byte Blue)
     public static implicit operator string(TextShadowColor color) => color.Name;
     public static implicit operator int(TextShadowColor color) => (color.Alpha << 24) + (color.Red << 16) + (color.Green << 8) + color.Blue;
     public static implicit operator TextShadowColor(int value) => new((byte)(value >> 24), (byte)((value >> 16) & 0xFF), (byte)((value >> 8) & 0xFF), (byte)(value & 0xFF));
-    public static implicit operator float[](TextShadowColor color) => [(color.Alpha >> 24 & 0xFF) / 255f, (color.Red >> 16 & 0xFF) / 255f, (color.Green >> 8 & 0xFF) / 255f, (color.Blue & 0xFF) / 255];
+    public static implicit operator float[](TextShadowColor color) => [(color.Alpha >> 24 & 0xFF) / 255f, (color.Red >> 16 & 0xFF) / 255f, (color.Green >> 8 & 0xFF) / 255f, (color.Blue & 0xFF) / 255f];
     public static implicit operator TextShadowColor(float[] components) => new((byte)(components[0] * 255), (byte)(components[1] * 255), (byte)(components[2] * 255), (byte)(components[3] * 255));
 
     public static TextShadowColor FromString(string value)


### PR DESCRIPTION
## Summary
- fix float conversion to retain precision

## Testing
- `dotnet format src/Minecraft/Void.Minecraft.csproj --no-restore --include src/Minecraft/Components/Text/Colors/TextShadowColor.cs`
- `dotnet test --no-build --filter "TestCategory!=Integration"`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688955d38f64832b8a63d52d0cf2ea11