### PR TITLE
fix(buffers): 🐛 correct memory stream length comparison

### DIFF
--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -51,7 +51,7 @@ internal ref struct MinecraftBackingBuffer
             BufferType.Span => _spanBackingBuffer.Position < _spanBackingBuffer.Length,
             BufferType.ReadOnlySpan => _readOnlySpanBackingBuffer.Position < _readOnlySpanBackingBuffer.Length,
             BufferType.ReadOnlySequence => _readOnlySequenceBackingBuffer.Position < _readOnlySequenceBackingBuffer.Length,
-            BufferType.MemoryStream => _memoryStreamBackingBuffer.Position < _readOnlySequenceBackingBuffer.Length,
+            BufferType.MemoryStream => _memoryStreamBackingBuffer.Position < _memoryStreamBackingBuffer.Length,
             _ => throw new NotSupportedException(_bufferType.ToString())
         };
     }


### PR DESCRIPTION
## Summary
- correct comparison of MemoryStream length in MinecraftBackingBuffer

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: KICK:[object Object])*

------
https://chatgpt.com/codex/tasks/task_e_688955c7c3a8832baafd6843a0c06377