### PR TITLE
docs(configuration): ✏️ fix grammar in plugin configuration docs

### DIFF
--- a/docs/astro/src/content/docs/developing-plugins/configuration.md
+++ b/docs/astro/src/content/docs/developing-plugins/configuration.md
@@ -69,7 +69,7 @@ public class MySettings
 }
 ```
 
-Also you can set custom name for the configuration file with `RootConfiguration` attribute.
+You can also set a custom name for the configuration file with the `RootConfiguration` attribute.
 ```csharp
 [RootConfiguration("settings")]
 public class MySettings


### PR DESCRIPTION
## Summary
- fix grammar in plugin configuration docs

## Testing
- `dotnet restore`
- `dotnet test --no-build --verbosity minimal` *(fails: The argument /workspace/Void/src/Tests/bin/Debug/net10.0/Void.Tests.dll is invalid)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688955c3749c832b91bf5abe381e879e