### PR TITLE
feat(tests): ♻️ reset integration logs before each run

### DIFF
--- a/src/Tests/Integration/Connections/ConnectionUnitBase.cs
+++ b/src/Tests/Integration/Connections/ConnectionUnitBase.cs
@@ -12,6 +12,9 @@ public class ConnectionUnitBase
 
     public static async Task LoggedExecutorAsync(Func<Task> function, params IIntegrationSide[] sides)
     {
+        foreach (var side in sides)
+            side.ClearLogs();
+
         try
         {
             await function();

--- a/src/Tests/Integration/Sides/IIntegrationSide.cs
+++ b/src/Tests/Integration/Sides/IIntegrationSide.cs
@@ -6,4 +6,6 @@ namespace Void.Tests.Integration.Sides;
 public interface IIntegrationSide : IAsyncDisposable
 {
     public IEnumerable<string> Logs { get; }
+
+    public void ClearLogs();
 }

--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -31,6 +31,11 @@ public abstract class IntegrationSideBase : IIntegrationSide
 
     public IEnumerable<string> Logs => [.. _logs];
 
+    public void ClearLogs()
+    {
+        _logs.Clear();
+    }
+
     static IntegrationSideBase()
     {
         if (Environment.GetEnvironmentVariable("GITHUB_TOKEN") is { } token)

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -16,6 +16,11 @@ public class VoidProxy : IIntegrationSide
 
     public IEnumerable<string> Logs => _logWriter.Lines;
 
+    public void ClearLogs()
+    {
+        _logWriter.Clear();
+    }
+
     private VoidProxy(CollectingTextWriter logWriter, Task task, CancellationTokenSource cancellationTokenSource)
     {
         _logWriter = logWriter;

--- a/src/Tests/Streams/CollectingTextWriter.cs
+++ b/src/Tests/Streams/CollectingTextWriter.cs
@@ -15,6 +15,11 @@ public class CollectingTextWriter : TextWriter
 
     public IEnumerable<string> Lines => Text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
+    public void Clear()
+    {
+        builder.Clear();
+    }
+
     public override void Write(char value)
     {
         builder.Append(value);


### PR DESCRIPTION
## Summary
- clear integration logs at the start of each test

## Testing
- `dotnet format --no-restore --include src/Tests/Integration/Connections/ConnectionUnitBase.cs src/Tests/Integration/Sides/IIntegrationSide.cs src/Tests/Integration/Sides/IntegrationSideBase.cs src/Tests/Integration/Sides/Proxies/VoidProxy.cs src/Tests/Streams/CollectingTextWriter.cs --verbosity diag`
- `dotnet test --no-build --verbosity minimal` *(fails: A total of 1 test files matched the specified pattern)*

------
https://chatgpt.com/codex/tasks/task_e_688a16cc991c832b85c40acec87c4ad4