### PR TITLE
chore(common): add trace logging for SetPhaseAsync

### DIFF
--- a/src/Plugins/Common/Extensions/PlayerExtensions.cs
+++ b/src/Plugins/Common/Extensions/PlayerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Void.Minecraft.Events;
 using Void.Minecraft.Links.Extensions;
 using Void.Minecraft.Network;
@@ -27,6 +28,9 @@ public static class PlayerExtensions
 
     public static async ValueTask SetPhaseAsync(this IPlayer player, Side side, Phase phase, INetworkChannel channel, CancellationToken cancellationToken)
     {
+        var logger = player.GetLogger();
+        logger.LogTrace("Setting {Side} phase to {Phase}", side, phase);
+
         if (side is Side.Client)
             player.Phase = phase;
 


### PR DESCRIPTION
## Summary
- log phase transitions in `SetPhaseAsync`

## Testing
- `dotnet format --include src/Plugins/Common/Extensions/PlayerExtensions.cs`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688a2bdad214832ba214be8f58f19b24