### PR TITLE
style(tests): ♻️ reorder using directives in PaperServer

### DIFF
--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -1,4 +1,3 @@
-namespace Void.Tests.Integration.Sides.Servers;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -7,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Void.Tests.Exceptions;
 using Void.Tests.Extensions;
+
+namespace Void.Tests.Integration.Sides.Servers;
 
 public class PaperServer : IntegrationSideBase
 {


### PR DESCRIPTION
## Summary
- reorder `using` directives ahead of the namespace declaration for `PaperServer`

## Testing
- `dotnet format --no-restore` *(fails: Could not find a MSBuild project or solution file)*
- `dotnet test` *(fails: MSB1003 - no project or solution file)*
- `dotnet build` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688a5b781450832ba5a5d355c6bb7521