### PR TITLE
fix(nuget): 🐛 select newer versions correctly

### DIFF
--- a/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
+++ b/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
@@ -298,7 +298,7 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
             if (!identity.HasVersion)
                 continue;
 
-            if (identity.Version.CompareTo(identity.Version) < 0)
+            if (identity.Version.CompareTo(result.Version) <= 0)
                 continue;
 
             if (assemblyVersion is null)


### PR DESCRIPTION
## Summary
- fix NuGet dependency resolver to compare against current best version

## Testing
- `dotnet build`
- `dotnet test --no-build -v minimal` *(fails: A task was canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688a5b811498832b8ae84ef62ee0a01b