### PR TITLE
fix(registry): 🐛 correct varlong property encoding

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/VarLongProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/VarLongProperty.cs
@@ -1,21 +1,25 @@
 ﻿using System;
+using System.IO;
 using Void.Minecraft.Buffers;
-using Void.Minecraft.Buffers.Extensions;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
 
 public record VarLongProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<VarLongProperty>
 {
-    public long AsPrimitive => new MinecraftBuffer(Value.Span).ReadVarInt();
+    public long AsPrimitive => new MinecraftBuffer(Value.Span).ReadVarLong();
 
-    public static VarLongProperty FromPrimitive(int value)
+    public static VarLongProperty FromPrimitive(long value)
     {
-        return new VarLongProperty(value.AsVarInt());
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        buffer.WriteVarLong(value);
+
+        return new VarLongProperty(stream.ToArray());
     }
 
     public static VarLongProperty Read(ref MinecraftBuffer buffer)
     {
-        return FromPrimitive(buffer.ReadVarInt());
+        return FromPrimitive(buffer.ReadVarLong());
     }
 
     public void Write(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- fix `VarLongProperty` to use var-long encoding methods

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: ProxiedConnectionTests)*

------
https://chatgpt.com/codex/tasks/task_e_688a5b66a2b8832bb50aaf59f63061c5