### PR TITLE
fix(common): 🛠️ remove null-forgiving operator

### DIFF
--- a/src/Plugins/Common/Network/Bundles/BundleService.cs
+++ b/src/Plugins/Common/Network/Bundles/BundleService.cs
@@ -18,7 +18,7 @@ public class BundleService : IBundleService
     {
         if (IsActivated)
         {
-            _taskCompletionSource!.SetResult();
+            _taskCompletionSource?.SetResult();
         }
         else
         {


### PR DESCRIPTION
## Summary
- avoid using null-forgiving operator in `BundleService`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688a6a62d434832ba6d8bb274b0dc76c