### PR TITLE
fix(plugins): 🩹 remove null-forgiving operator usage

### DIFF
--- a/src/Platform/Plugins/PluginService.cs
+++ b/src/Platform/Plugins/PluginService.cs
@@ -25,7 +25,9 @@ public class PluginService(ILogger<PluginService> logger, IEventService events, 
 
     public IEnumerable<IPlugin> All => _containers.SelectMany(container => container.Plugins);
 
-    public IEnumerable<string> Containers => _containers.Select(container => container.Context.Name!);
+    public IEnumerable<string> Containers => _containers
+        .Select(container => container.Context.Name)
+        .WhereNotNull();
 
     public static void RegisterOptions(Command command)
     {
@@ -238,7 +240,11 @@ public class PluginService(ILogger<PluginService> logger, IEventService events, 
     public async ValueTask UnloadContainersAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Unloading all plugins");
-        await _containers.Select(async reference => await UnloadContainerAsync(reference.Context.Name!, cancellationToken)).WhenAll();
+        await _containers
+            .Select(reference => reference.Context.Name)
+            .WhereNotNull()
+            .Select(name => UnloadContainerAsync(name, cancellationToken))
+            .WhenAll();
     }
 
     public async ValueTask UnloadContainerAsync(string name, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- clean up null-forgiving operators in `PluginService`

## Testing
- `dotnet format src/Platform/Void.Proxy.csproj --no-restore` *(fails: Required references did not load)*
- `dotnet build src/Platform/Void.Proxy.csproj` *(fails: .NET SDK does not support targeting .NET 9.0)*
- `dotnet test src/Tests/Void.Tests.csproj` *(fails: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b160a0ec0832b8d606fbe86c563ad