### PR TITLE
fix(protocolsupport): remove null forgiving operator from login packet 📝

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Serverbound/LoginStartPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Serverbound/LoginStartPacket.cs
@@ -18,18 +18,18 @@ public class LoginStartPacket : IMinecraftServerboundPacket<LoginStartPacket>
         {
             if (protocolVersion < ProtocolVersion.MINECRAFT_1_19_3)
             {
-                var hasSignatureData = Key is not null;
+                var hasSignatureData = Key is IdentifiedKey key;
                 buffer.WriteBoolean(hasSignatureData);
 
                 if (hasSignatureData)
                 {
-                    buffer.WriteLong(Key!.ExpiresAt);
+                    buffer.WriteLong(key.ExpiresAt);
 
-                    buffer.WriteVarInt(Key.PublicKey.Length);
-                    buffer.Write(Key.PublicKey);
+                    buffer.WriteVarInt(key.PublicKey.Length);
+                    buffer.Write(key.PublicKey);
 
-                    buffer.WriteVarInt(Key.Signature.Length);
-                    buffer.Write(Key.Signature);
+                    buffer.WriteVarInt(key.Signature.Length);
+                    buffer.Write(key.Signature);
                 }
             }
 


### PR DESCRIPTION
## Summary
- avoid `!` null forgiveness in LoginStartPacket

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b160995cc832b99056164001c0c96