### PR TITLE
refactor(benchmarks): ♻️ replace null-forgiving operators

### DIFF
--- a/src/Benchmarks/Streams/Compression.cs
+++ b/src/Benchmarks/Streams/Compression.cs
@@ -61,8 +61,8 @@ public class Compression
     [IterationSetup]
     public void IterationSetup()
     {
-        var sharpZipLibMemoryStream = (MinecraftMemoryStream)_sharpZipLibStream.BaseStream!;
-        var ionicZlibMemoryStream = (MinecraftMemoryStream)_ionicZlibStream.BaseStream!;
+        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
+        var ionicZlibMemoryStream = (MinecraftMemoryStream)(_ionicZlibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
 
         sharpZipLibMemoryStream.Reset(0);
         ionicZlibMemoryStream.Reset(0);
@@ -90,7 +90,7 @@ public class Compression
     [Benchmark]
     public async ValueTask SharpZipLib_Read()
     {
-        var sharpZipLibMemoryStream = (MinecraftMemoryStream)_sharpZipLibStream.BaseStream!;
+        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
         sharpZipLibMemoryStream.Reset();
 
         for (var i = 0; i < 1000; i++)
@@ -115,7 +115,7 @@ public class Compression
     [Benchmark]
     public async ValueTask IonicZlib_Read()
     {
-        var ionicZlibMemoryStream = (MinecraftMemoryStream)_ionicZlibStream.BaseStream!;
+        var ionicZlibMemoryStream = (MinecraftMemoryStream)(_ionicZlibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
         ionicZlibMemoryStream.Reset();
 
         for (var i = 0; i < 1000; i++)


### PR DESCRIPTION
## Summary
- remove `!` operators from benchmark compression test

## Testing
- `dotnet format src/Benchmarks/Void.Benchmarks.csproj` *(fails: Restore operation failed)*
- `dotnet build src/Benchmarks/Void.Benchmarks.csproj` *(fails: current .NET SDK does not support .NET 9.0)*
- `dotnet test src/Tests/Void.Tests.csproj` *(fails: current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b1607da1c832b85cb56060372dba2