### PR TITLE
fix(events): 🐛 remove null forgiving operator

### DIFF
--- a/src/Platform/Events/EventService.cs
+++ b/src/Platform/Events/EventService.cs
@@ -156,7 +156,8 @@ public class EventService(ILogger<EventService> logger, IContainer container) : 
                         logger.LogTrace("Registering {Type} event listener method {Name}", listener, method.Name);
                         SubscribeAttribute.SanityChecks(method);
 
-                        var attribute = method.GetCustomAttribute<SubscribeAttribute>()!;
+                        var attribute = method.GetCustomAttribute<SubscribeAttribute>()
+                                         ?? throw new InvalidOperationException($"Method {method.Name} does not define {nameof(SubscribeAttribute)}.");
                         _entries.Add(new Entry(listener, method, attribute.Order, attribute.BypassScopedFilter, cancellationToken));
                     }
 


### PR DESCRIPTION
## Summary
- fix EventService to avoid using null-forgiving operator

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b1604dbe0832ba192ce98929e4865