### PR TITLE
fix(benchmarks): 🐛 remove null-forgiving operator

### DIFF
--- a/src/Benchmarks/Streams/MinecraftMemoryStream.cs
+++ b/src/Benchmarks/Streams/MinecraftMemoryStream.cs
@@ -6,7 +6,7 @@ namespace Void.Benchmarks.Streams;
 internal class MinecraftMemoryStream : INetworkStream
 {
     private readonly MemoryStream _memoryStream = new();
-    public NetworkStream BaseStream => null!;
+    public NetworkStream BaseStream => throw new NotSupportedException();
     public bool CanRead => true;
     public bool CanWrite => true;
     public bool IsAlive => true;


### PR DESCRIPTION
## Summary
- remove null-forgiving operator in `MinecraftMemoryStream`

## Testing
- `dotnet format --no-restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b160126f8832b89c205ad083aa032