### PR TITLE
refactor(tests): improve CollectingTextWriter thread safety ✨

### DIFF
--- a/src/Tests/Streams/CollectingTextWriter.cs
+++ b/src/Tests/Streams/CollectingTextWriter.cs
@@ -8,33 +8,52 @@ namespace Void.Tests.Streams;
 public class CollectingTextWriter : TextWriter
 {
     private readonly StringBuilder builder = new();
+    private readonly object _lock = new();
 
     public override Encoding Encoding { get; } = Encoding.UTF8;
 
-    public string Text => builder.ToString();
+    public string Text
+    {
+        get
+        {
+            lock (_lock)
+                return builder.ToString();
+        }
+    }
 
-    public IEnumerable<string> Lines => Text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+    public IEnumerable<string> Lines
+    {
+        get
+        {
+            var text = Text;
+            return text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
 
     public void Clear()
     {
-        builder.Clear();
+        lock (_lock)
+            builder.Clear();
     }
 
     public override void Write(char value)
     {
-        builder.Append(value);
+        lock (_lock)
+            builder.Append(value);
     }
 
     public override void Write(string? value)
     {
         if (value != null)
         {
-            builder.Append(value);
+            lock (_lock)
+                builder.Append(value);
         }
     }
 
     public override void Write(char[] buffer, int index, int count)
     {
-        builder.Append(buffer, index, count);
+        lock (_lock)
+            builder.Append(buffer, index, count);
     }
 }


### PR DESCRIPTION
## Summary
- make `CollectingTextWriter` thread-safe with a lock

## Testing
- `dotnet format --verbosity minimal`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Build failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688b15bbb1dc832bab9ed2e9c3183f9c