### PR TITLE
fix(terminal): 🩹 remove unsupported constructor

### DIFF
--- a/src/Terminal/PromptWriter.cs
+++ b/src/Terminal/PromptWriter.cs
@@ -12,11 +12,6 @@ public class PromptWriter(PromptReader reader, StreamWriter writer) : TextWriter
         throw new NotSupportedException("Virtual terminal processing is not supported.");
     }
 
-    private PromptWriter() : this(null!, null!)
-    {
-        throw new NotSupportedException("This constructor is not supported.");
-    }
-
     public override Encoding Encoding => writer.Encoding;
 
     public override void Write(string? value)


### PR DESCRIPTION
## Summary
- remove private constructor using null-forgiving operator from `PromptWriter`

## Testing
- `dotnet test src/Tests/Void.Tests.csproj --no-build --no-restore -c Debug --filter FullyQualifiedName~UtilsTests`


------
https://chatgpt.com/codex/tasks/task_e_688c78e7b6c4832bb4ad76d220650dba