### PR TITLE
fix(platform): 🔨 avoid null-forgiving operator

### DIFF
--- a/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
+++ b/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
@@ -398,7 +398,7 @@ public class ConfigurationTomlSerializer : IConfigurationSerializer
                 {
                     // Try using a parameterless constructor first
                     var ctor = type.GetConstructor(Type.EmptyTypes);
-                    collectionInstance = ctor is not null ? ctor.Invoke(null) : Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
+                    collectionInstance = ctor is not null ? ctor.Invoke(null) : Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType)) ?? throw new InvalidOperationException($"Unable to create instance of type {type.FullName}");
                 }
 
                 // Find an "Add" method on the concrete type.


### PR DESCRIPTION
## Summary
- remove a null forgiving operator usage

## Testing
- `dotnet build Void.slnx --no-restore`
- `dotnet test Void.slnx --no-build --verbosity quiet` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_688c78e21014832b94e41f9c72d8673e