### PR TITLE
refactor(platform): ♻️ rename async callback

### DIFF
--- a/src/Platform/Links/Link.cs
+++ b/src/Platform/Links/Link.cs
@@ -56,7 +56,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
         _playerToServerTask = ExecuteAsync(PlayerChannel, ServerChannel, Direction.Serverbound, _ctsPlayerToServer.Token, _ctsPlayerToServerForce.Token);
         _serverToPlayerTask = ExecuteAsync(ServerChannel, PlayerChannel, Direction.Clientbound, _ctsServerToPlayer.Token, _ctsServerToPlayerForce.Token);
 
-        _onStoppingTask = Task.WhenAll(_playerToServerTask, _serverToPlayerTask).ContinueWith(task => OnStopped(task, cancellationToken).CatchExceptions(logger, $"{nameof(LinkStoppedEvent)} caused exception(s)"));
+        _onStoppingTask = Task.WhenAll(_playerToServerTask, _serverToPlayerTask).ContinueWith(task => OnStoppedAsync(task, cancellationToken).CatchExceptions(logger, $"{nameof(LinkStoppedEvent)} caused exception(s)"));
 
         logger.LogTrace("Started forwarding {Link} traffic", this);
         await events.ThrowAsync(new LinkStartedEvent(this, Player), cancellationToken);
@@ -252,7 +252,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
         return await Task.WhenAny(timeout, task) == timeout;
     }
 
-    private async Task OnStopped(Task task, CancellationToken cancellationToken)
+    private async Task OnStoppedAsync(Task task, CancellationToken cancellationToken)
     {
         await task;
 


### PR DESCRIPTION
## Summary
- rename async callback method OnStopped to OnStoppedAsync

## Testing
- `dotnet build Void.slnx --no-restore`
- `dotnet test --no-build --no-restore` *(failed: terminated)*
- `dotnet format --no-restore` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_688c7ead6d18832b88262d8ecfe42660