### PR TITLE
fix(common-network): 🐛 handle disposed stream

### DIFF
--- a/src/Plugins/Common/Network/Streams/Network/SimpleNetworkStream.cs
+++ b/src/Plugins/Common/Network/Streams/Network/SimpleNetworkStream.cs
@@ -64,7 +64,7 @@ public class SimpleNetworkStream(NetworkStream baseStream) : INetworkStream
                 _nextBuffer = Memory<byte>.Empty;
                 baseStream.ReadExactly(span[length..]);
             }
-            catch (Exception exception) when (exception is EndOfStreamException || exception is IOException { InnerException: SocketException })
+            catch (Exception exception) when (exception is EndOfStreamException or IOException { InnerException: SocketException } or ObjectDisposedException)
             {
                 throw new StreamClosedException();
             }
@@ -87,7 +87,7 @@ public class SimpleNetworkStream(NetworkStream baseStream) : INetworkStream
                 _nextBuffer = Memory<byte>.Empty;
                 await baseStream.ReadExactlyAsync(memory[length..], cancellationToken);
             }
-            catch (Exception exception) when (exception is EndOfStreamException || exception is IOException { InnerException: SocketException })
+            catch (Exception exception) when (exception is EndOfStreamException or IOException { InnerException: SocketException } or ObjectDisposedException)
             {
                 throw new StreamClosedException();
             }
@@ -100,7 +100,7 @@ public class SimpleNetworkStream(NetworkStream baseStream) : INetworkStream
         {
             baseStream.Write(span);
         }
-        catch (Exception exception) when (exception is EndOfStreamException || exception is IOException { InnerException: SocketException })
+        catch (Exception exception) when (exception is EndOfStreamException or IOException { InnerException: SocketException } or ObjectDisposedException)
         {
             throw new StreamClosedException();
         }
@@ -112,7 +112,7 @@ public class SimpleNetworkStream(NetworkStream baseStream) : INetworkStream
         {
             await baseStream.WriteAsync(memory, cancellationToken);
         }
-        catch (Exception exception) when (exception is EndOfStreamException || exception is IOException { InnerException: SocketException })
+        catch (Exception exception) when (exception is EndOfStreamException or IOException { InnerException: SocketException } or ObjectDisposedException)
         {
             throw new StreamClosedException();
         }


### PR DESCRIPTION
## Summary
- handle `ObjectDisposedException` in `SimpleNetworkStream`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_688c8b4a6664832bb64820e27dedb0a8