### PR TITLE
docs(agents): 📝 enforce allowed commit types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,19 @@ Follow the existing C# style rules:
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.
 - Conventional Commits are required for commit messages.
+- Use only the following Conventional Commit types:
+  - `feat` — Features
+  - `fix` — Bug Fixes
+  - `perf` — Performance Improvements
+  - `deps` — Dependencies
+  - `revert` — Reverts
+  - `docs` — Documentation
+  - `style` — Styles
+  - `chore` — Miscellaneous Chores
+  - `refactor` — Code Refactoring
+  - `test` — Tests
+  - `build` — Build System
+  - `ci` — Continuous Integration
 - Include in the commit description a brief note about any observable behavior change.
 - Use the `fix` or `feat` type only when your changes modify the proxy code in `./src`. For documentation, CI, or other unrelated updates, choose a more appropriate type such as `docs` or `chore`.
 - Append a [gitmoji](https://gitmoji.dev/specification) after the commit scope, e.g., `feat(api): ✨ add new endpoint`.


### PR DESCRIPTION
## Summary
- clarify the allowed Conventional Commit types in AGENTS.md

## Testing
- `dotnet format --include AGENTS.md --no-restore --verbosity minimal`
- `dotnet test src/Tests/Void.Tests.csproj --no-build --no-restore` *(fails: Assert.Contains() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_688d23e86528832baecfd6148d64f4cc