### PR TITLE
perf(plugins): ⚡ reduce varint read allocation

### DIFF
--- a/src/Plugins/Common/Network/Streams/Extensions/ManualStreamExtensions.cs
+++ b/src/Plugins/Common/Network/Streams/Extensions/ManualStreamExtensions.cs
@@ -10,7 +10,7 @@ public static class ManualStreamExtensions
         var numRead = 0;
         var result = 0;
         byte read;
-        byte[] buffer = [0];
+        Span<byte> buffer = stackalloc byte[1];
 
         do
         {


### PR DESCRIPTION
## Summary
- use stackalloc for reading varints

## Testing
- `dotnet format --no-restore src/Platform/Void.Proxy.csproj` *(fails: The server disconnected unexpectedly)*
- `dotnet build src/Platform/Void.Proxy.csproj` *(fails: PlayerExtensions.cs compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d285ca1a8832b8c124168c0e41e1a