### PR TITLE
perf(binary-property): 🚀 avoid unnecessary MemoryStream

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/BinaryProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/BinaryProperty.cs
@@ -15,7 +15,7 @@ public record BinaryProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<Binar
 
     public static BinaryProperty Read(ref MinecraftBuffer buffer)
     {
-        return FromStream(new MemoryStream(buffer.ReadToEnd().ToArray()));
+        return new BinaryProperty(buffer.ReadToEnd().ToArray());
     }
 
     public void Write(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- streamline `BinaryProperty.Read` to skip an extra `MemoryStream` allocation

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore` *(fails: Assert.Contains failure)*

------
https://chatgpt.com/codex/tasks/task_e_688d2849a3b4832bb95ad96f44e5e126