### PR TITLE
test(integration): 🧪 add PaperServer keepalive parameter

### DIFF
--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -23,7 +23,7 @@ public class PaperServer : IntegrationSideBase
         _binaryPath = binaryPath;
         _jreBinaryPath = jreBinaryPath;
 
-        StartApplication(_binaryPath, hasInput: false);
+        StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=60");
     }
 
     public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- ensure PaperServer JVM is started with a 60s keepalive timeout
- allow IntegrationSideBase to separate JVM and jar arguments

## Testing
- `dotnet format --verify-no-changes --include src/Tests/Integration/Sides/IntegrationSideBase.cs src/Tests/Integration/Sides/Servers/PaperServer.cs` *(fails: Fix end of line marker. Replace 1 characters with '\r\n')*
- `dotnet build`
- `dotnet test` *(fails: process exited without running tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d831d90c0832ba4366400700f3f76