### PR TITLE
perf(minecraft): ♻️ stack allocate verification buffer

### DIFF
--- a/src/Minecraft/Profiles/IdentifiedKey.cs
+++ b/src/Minecraft/Profiles/IdentifiedKey.cs
@@ -72,7 +72,7 @@ public record IdentifiedKey(IdentifiedKeyRevision Revision, long ExpiresAt, byte
             if (guid == default)
                 return false;
 
-            var verify = new byte[PublicKey.Length + 24].AsSpan();
+            Span<byte> verify = stackalloc byte[PublicKey.Length + 24];
             var buffer = new MinecraftBuffer(verify);
             buffer.WriteUuid(uuid);
             buffer.WriteLong(ExpiresAt);


### PR DESCRIPTION
## Summary
- reduce allocations when validating identified key signatures

## Testing
- `dotnet format --verify-no-changes` *(fails: ENDOFLINE errors for many files)*
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_RunsStopsSuccessfully assertion)*

------
https://chatgpt.com/codex/tasks/task_e_688d8b1c2514832ba816c47c63eabedf