### PR TITLE
perf(encryption): ⚡ avoid allocating byte array in VerifyToken

### DIFF
--- a/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
+++ b/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
@@ -109,7 +109,7 @@ public abstract class AbstractEncryptionService(IEventService events, ICryptoSer
             return identifiedKey.VerifyDataSignature(encrypted, [.. original, .. saltBytes]);
         }
 
-        var decrypted = new byte[encrypted.Length];
+        Span<byte> decrypted = stackalloc byte[encrypted.Length];
 
         if (!crypto.Instance.TryDecrypt(encrypted, decrypted, RSAEncryptionPadding.Pkcs1, out var length))
             return false;
@@ -117,7 +117,7 @@ public abstract class AbstractEncryptionService(IEventService events, ICryptoSer
         if (original.Length != length)
             return false;
 
-        if (!original.SequenceEqual(decrypted.AsSpan(0, length)))
+        if (!original.SequenceEqual(decrypted[..length]))
             return false;
 
         return true;


### PR DESCRIPTION
## Summary
- avoid allocating temporary byte array when verifying tokens

## Testing
- `dotnet format --include src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs`
- `dotnet build`
- `dotnet test --no-build` *(fails: Assert.Contains() Failure in EntryPoint_RunsStopsSuccessfully)*

------
https://chatgpt.com/codex/tasks/task_e_688d8b213020832bb8d8cdd763542238