### PR TITLE
ci(workflows): 🔧 enable single-file compression

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,6 +55,7 @@ jobs:
             /p:ContainerRuntimeIdentifiers='"${{ matrix.container_runtime_identifiers }}"' \
             /p:ContainerImageTags='"${{ matrix.container_image_tags }}"' \
             /p:ContainerBaseImage='"${{ matrix.container_base_image }}"' \
+            /p:EnableCompressionInSingleFile=true \
             /p:Version=${{ inputs.void-version }}
 
   push:
@@ -101,4 +102,5 @@ jobs:
             /p:ContainerRuntimeIdentifiers='"${{ matrix.container_runtime_identifiers }}"' \
             /p:ContainerImageTags='"${{ matrix.container_image_tags }}"' \
             /p:ContainerBaseImage='"${{ matrix.container_base_image }}"' \
+            /p:EnableCompressionInSingleFile=true \
             /p:Version=${{ inputs.void-version }}

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Build Platform
         run: dotnet build src/Platform --runtime ${{ matrix.runtime }} --self-contained --configuration Release /p:DebugType=embedded /p:PublishSingleFile=true /p:GenerateRuntimeConfigurationFiles=false /p:Version=${{ inputs.void-version }} ${{ matrix.parameters }} 
       - name: Publish
-        run: dotnet publish --runtime ${{ matrix.runtime }} --self-contained src/Platform --output artifacts --configuration Release --no-build /p:DebugType=embedded /p:PublishSingleFile=true /p:GenerateRuntimeConfigurationFiles=false /p:Version=${{ inputs.void-version }} ${{ matrix.parameters }}
+        run: dotnet publish --runtime ${{ matrix.runtime }} --self-contained src/Platform --output artifacts --configuration Release --no-build /p:DebugType=embedded /p:PublishSingleFile=true /p:EnableCompressionInSingleFile=true /p:GenerateRuntimeConfigurationFiles=false /p:Version=${{ inputs.void-version }} ${{ matrix.parameters }}
       - name: Save Artifact Suffix
         id: get_suffix
         shell: bash


### PR DESCRIPTION
## Summary
- enable compression when publishing single-file artifacts

## Testing
- `dotnet format`
- `dotnet build`
- `dotnet test --no-build` *(terminated: MSB5021 warning)*

------
https://chatgpt.com/codex/tasks/task_e_688d93fced10832baa1448a96a9c7e97