### PR TITLE
test(integration): ✅ add env vars to toggle direct and proxied tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/DirectConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/DirectConnectionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Void.Minecraft.Network;
+using Void.Tests.Integration;
 using Void.Tests.Integration.Sides.Clients;
 using Void.Tests.Integration.Sides.Servers;
 using Xunit;
@@ -13,7 +14,7 @@ public class DirectConnectionTests(DirectConnectionTests.PaperMccFixture fixture
     private const int ServerPort = 25000;
     private const string ExpectedText = "hello void!";
 
-    [Fact]
+    [DirectFact]
     public async Task MccConnectsToPaperServer()
     {
         var expectedText = $"{ExpectedText} test #{Random.Shared.Next()}";
@@ -28,7 +29,7 @@ public class DirectConnectionTests(DirectConnectionTests.PaperMccFixture fixture
         }, fixture.MinecraftConsoleClient, fixture.PaperServer);
     }
 
-    [Theory]
+    [DirectTheory]
     [MemberData(nameof(MinecraftConsoleClient.SupportedVersions), MemberType = typeof(MinecraftConsoleClient))]
     public async Task MccConnectsToPaperServer_WithProtocolVersion(ProtocolVersion protocolVersion)
     {
@@ -44,7 +45,7 @@ public class DirectConnectionTests(DirectConnectionTests.PaperMccFixture fixture
         }, fixture.MinecraftConsoleClient, fixture.PaperServer);
     }
 
-    [Fact]
+    [DirectFact]
     public async Task MineflayerConnectsToPaperServer()
     {
         var expectedText = $"{ExpectedText} test #{Random.Shared.Next()}";
@@ -59,7 +60,7 @@ public class DirectConnectionTests(DirectConnectionTests.PaperMccFixture fixture
         }, fixture.MineflayerClient, fixture.PaperServer);
     }
 
-    [Theory]
+    [DirectTheory]
     [MemberData(nameof(MineflayerClient.SupportedVersions), MemberType = typeof(MineflayerClient))]
     public async Task MineflayerConnectsToPaperServer_WithProtocolVersion(ProtocolVersion protocolVersion)
     {

--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Void.Minecraft.Network;
+using Void.Tests.Integration;
 using Void.Tests.Integration.Sides.Clients;
 using Void.Tests.Integration.Sides.Proxies;
 using Void.Tests.Integration.Sides.Servers;
@@ -15,7 +16,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.PaperVoidMccFixture f
     private const int ServerPort = 35001;
     private const string ExpectedText = "hello proxied void!";
 
-    [Fact]
+    [ProxiedFact]
     public async Task MccConnectsToPaperServerThroughProxy()
     {
         var expectedText = $"{ExpectedText} test #{Random.Shared.Next()}";
@@ -30,7 +31,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.PaperVoidMccFixture f
         }, fixture.MinecraftConsoleClient, fixture.VoidProxy, fixture.PaperServer);
     }
 
-    [Theory]
+    [ProxiedTheory]
     [MemberData(nameof(MinecraftConsoleClient.SupportedVersions), MemberType = typeof(MinecraftConsoleClient))]
     public async Task MccConnectsToPaperServerThroughProxy_WithProtocolVersion(ProtocolVersion protocolVersion)
     {
@@ -46,7 +47,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.PaperVoidMccFixture f
         }, fixture.MinecraftConsoleClient, fixture.VoidProxy, fixture.PaperServer);
     }
 
-    [Fact]
+    [ProxiedFact]
     public async Task MineflayerConnectsToPaperServerThroughProxy()
     {
         var expectedText = $"{ExpectedText} test #{Random.Shared.Next()}";
@@ -61,7 +62,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.PaperVoidMccFixture f
         }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer);
     }
 
-    [Theory]
+    [ProxiedTheory]
     [MemberData(nameof(MineflayerClient.SupportedVersions), MemberType = typeof(MineflayerClient))]
     public async Task MineflayerConnectsToPaperServerThroughProxy_WithProtocolVersion(ProtocolVersion protocolVersion)
     {

--- a/src/Tests/Integration/IntegrationTestAttributes.cs
+++ b/src/Tests/Integration/IntegrationTestAttributes.cs
@@ -1,0 +1,56 @@
+using System;
+using Xunit;
+
+namespace Void.Tests.Integration;
+
+internal static class IntegrationTestEnvironment
+{
+    public const string DirectTestsEnabledVariable = "VOID_INTEGRATION_DIRECT_TESTS_ENABLED";
+
+    public const string ProxiedTestsEnabledVariable = "VOID_INTEGRATION_PROXIED_TESTS_ENABLED";
+
+    public static bool DirectTestsEnabled => bool.TryParse(Environment.GetEnvironmentVariable(DirectTestsEnabledVariable), out var enabled) && enabled;
+
+    public static bool ProxiedTestsEnabled => !bool.TryParse(Environment.GetEnvironmentVariable(ProxiedTestsEnabledVariable), out var enabled) || enabled;
+}
+
+public sealed class DirectFactAttribute : FactAttribute
+{
+    public DirectFactAttribute()
+    {
+
+        if (!IntegrationTestEnvironment.DirectTestsEnabled)
+            Skip = $"Direct integration tests are disabled. Set {IntegrationTestEnvironment.DirectTestsEnabledVariable}=true to enable.";
+    }
+}
+
+public sealed class DirectTheoryAttribute : TheoryAttribute
+{
+    public DirectTheoryAttribute()
+    {
+
+        if (!IntegrationTestEnvironment.DirectTestsEnabled)
+            Skip = $"Direct integration tests are disabled. Set {IntegrationTestEnvironment.DirectTestsEnabledVariable}=true to enable.";
+    }
+}
+
+public sealed class ProxiedFactAttribute : FactAttribute
+{
+    public ProxiedFactAttribute()
+    {
+
+        if (!IntegrationTestEnvironment.ProxiedTestsEnabled)
+            Skip = $"Proxied integration tests are disabled. Set {IntegrationTestEnvironment.ProxiedTestsEnabledVariable}=true to enable.";
+    }
+}
+
+public sealed class ProxiedTheoryAttribute : TheoryAttribute
+{
+    public ProxiedTheoryAttribute()
+    {
+
+        if (!IntegrationTestEnvironment.ProxiedTestsEnabled)
+            Skip = $"Proxied integration tests are disabled. Set {IntegrationTestEnvironment.ProxiedTestsEnabledVariable}=true to enable.";
+    }
+}
+


### PR DESCRIPTION
## Summary
- add environment variables to toggle direct and proxied integration tests
- skip direct tests by default unless VOID_INTEGRATION_DIRECT_TESTS_ENABLED=true
- allow disabling proxied tests via VOID_INTEGRATION_PROXIED_TESTS_ENABLED

## Testing
- `dotnet format --include src/Tests/Integration/Connections/Units/DirectConnectionTests.cs src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs src/Tests/Integration/IntegrationTestAttributes.cs`
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=false dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688da04dda88832bbba31df3614d9ebd