### PR TITLE
style(brigadier): 💄 remove redundant parentheses from ReaderExpectedLong

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
+++ b/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
@@ -18,7 +18,7 @@ public class BuiltInExceptions : IBuiltInExceptionProvider
     public DynamicCommandExceptionType ReaderInvalidInt { get; } = new(value => new LiteralMessage("Invalid integer '" + value + "'"));
     public SimpleCommandExceptionType ReaderExpectedInt { get; } = new(new LiteralMessage("Expected integer"));
     public DynamicCommandExceptionType ReaderInvalidLong { get; } = new(value => new LiteralMessage("Invalid long '" + value + "'"));
-    public SimpleCommandExceptionType ReaderExpectedLong { get; } = new((new LiteralMessage("Expected long")));
+    public SimpleCommandExceptionType ReaderExpectedLong { get; } = new(new LiteralMessage("Expected long"));
     public DynamicCommandExceptionType ReaderInvalidDouble { get; } = new(value => new LiteralMessage("Invalid double '" + value + "'"));
     public SimpleCommandExceptionType ReaderExpectedDouble { get; } = new(new LiteralMessage("Expected double"));
     public DynamicCommandExceptionType ReaderInvalidFloat { get; } = new(value => new LiteralMessage("Invalid float '" + value + "'"));


### PR DESCRIPTION
## Summary
- remove redundant parentheses in ReaderExpectedLong and normalize line endings

## Testing
- `dotnet format` *(failed: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test` *(terminated after a long wait without completing)*

------
https://chatgpt.com/codex/tasks/task_e_688dfb851d30832bbd424221770f926c