### PR TITLE
style(example-plugin): 🎨 remove redundant string interpolation

### DIFF
--- a/src/Plugins/ExamplePlugin/Services/ChatService.cs
+++ b/src/Plugins/ExamplePlugin/Services/ChatService.cs
@@ -20,7 +20,7 @@ namespace Void.Proxy.Plugins.ExamplePlugin.Services;
 // Example Chat configuration class.
 public class ChatSettings
 {
-    public string WelcomeMessage { get; set; } = $"Welcome to the %SERVER% server!";
+    public string WelcomeMessage { get; set; } = "Welcome to the %SERVER% server!";
 }
 
 // Here you can use DI to inject any service API you want to use.


### PR DESCRIPTION
## Summary
- avoid unnecessary string interpolation in ChatSettings

## Testing
- `dotnet format --verify-no-changes Void.slnx` *(fails: The server disconnected unexpectedly)*
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`

------
https://chatgpt.com/codex/tasks/task_e_688dfb8a1460832b998613684c243bad