### PR TITLE
fix(protocolsupport): 🐛 clarify dimension info exception

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/RespawnPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/RespawnPacket.cs
@@ -44,7 +44,7 @@ public class RespawnPacket : IMinecraftClientboundPacket<RespawnPacket>
         if (protocolVersion >= ProtocolVersion.MINECRAFT_1_16)
         {
             if (DimensionInfo is null)
-                throw new Exception("DimensionInfo was not set");
+                throw new InvalidOperationException($"{nameof(DimensionInfo)} was not set.");
 
             if (protocolVersion >= ProtocolVersion.MINECRAFT_1_16_2 && protocolVersion < ProtocolVersion.MINECRAFT_1_19)
             {
@@ -75,7 +75,7 @@ public class RespawnPacket : IMinecraftClientboundPacket<RespawnPacket>
         if (protocolVersion >= ProtocolVersion.MINECRAFT_1_16)
         {
             if (DimensionInfo is null)
-                throw new Exception("DimensionInfo was not set");
+                throw new InvalidOperationException($"{nameof(DimensionInfo)} was not set.");
 
             buffer.WriteUnsignedByte((byte)PreviousGamemode);
             buffer.WriteBoolean(DimensionInfo.IsDebugType);


### PR DESCRIPTION
## Summary
- use InvalidOperationException for missing DimensionInfo in RespawnPacket

## Testing
- `dotnet format --include src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/RespawnPacket.cs`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688dfb78c39c832b8e5e222f1fe21009