### PR TITLE
ci(docs): 🤖 restrict docs deployment to main branch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   push:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: void
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- avoid deploying docs from pull request runs

## Testing
- `dotnet format`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e465beee4832bafa5c69965ac5c97