### PR TITLE
fix(protocolsupport): 🐛 use specific exception for missing level type

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/JoinGamePacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/JoinGamePacket.cs
@@ -232,8 +232,8 @@ public class JoinGamePacket : IMinecraftClientboundPacket<JoinGamePacket>
 
         buffer.WriteUnsignedByte((byte)MaxPlayers);
 
-        if (LevelType == null)
-            throw new Exception("No level type specified.");
+        if (LevelType is null)
+            throw new InvalidOperationException($"{nameof(LevelType)} was not set.");
 
         buffer.WriteString(LevelType);
 

--- a/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/JoinGamePacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/JoinGamePacket.cs
@@ -70,8 +70,8 @@ public class JoinGamePacket : IMinecraftClientboundPacket<JoinGamePacket>
         buffer.WriteUnsignedByte((byte)Difficulty);
         buffer.WriteUnsignedByte((byte)MaxPlayers);
 
-        if (LevelType == null)
-            throw new Exception("No level type specified.");
+        if (LevelType is null)
+            throw new InvalidOperationException($"{nameof(LevelType)} was not set.");
 
         buffer.WriteString(LevelType);
 


### PR DESCRIPTION
## Summary
- replace generic `Exception` with `InvalidOperationException` when `LevelType` is missing

## Testing
- `dotnet format Void.slnx --verify-no-changes --include src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/JoinGamePacket.cs src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Packets/Clientbound/JoinGamePacket.cs` *(fails: ENDOFLINE marker errors)*
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`


------
https://chatgpt.com/codex/tasks/task_e_688eef35a0b4832bb20687d5155ca785