### PR TITLE
perf(minecraft): ⚡ simplify command source comparison

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Context/CommandContext.cs
+++ b/src/Minecraft/Commands/Brigadier/Context/CommandContext.cs
@@ -23,7 +23,7 @@ public record CommandContext(
 
     public CommandContext CopyFor(ICommandSource source)
     {
-        if (Source?.Equals(source) ?? false)
+        if (Source.Equals(source))
             return this;
 
         return new CommandContext(source, Input, Arguments, Executor, RootNode, Nodes, Range, Child, RedirectModifier, Forks);


### PR DESCRIPTION
## Summary
- simplify command context's source equality check

## Testing
- `dotnet format Void.slnx --include src/Minecraft/Commands/Brigadier/Context/CommandContext.cs -v diag`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688eef637470832b9a72e1714a6dcc2c