### PR TITLE
docs(protocol-support): 📝 correct grammar in comment

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Channels/ChannelService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Channels/ChannelService.cs
@@ -55,7 +55,7 @@ public class ChannelService(IEventService events) : AbstractChannelService(event
         if (@event.Message is not EncryptionResponsePacket)
             return;
 
-        // if encryption forced channel to remove packet stream, resume reading with what has left
+        // if encryption forced channel to remove packet stream, resume reading with what is left
         if (!@event.Link.PlayerChannel.TryGet<MinecraftPacketMessageStream>(out _))
             @event.Link.PlayerChannel.Resume();
     }


### PR DESCRIPTION
## Summary
- correct grammar in ChannelService comment

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688eef8e3404832b98eb424d8b0123ce