### PR TITLE
style(platform): 🎨 remove duplicate word in serialization error

### DIFF
--- a/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
+++ b/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
@@ -438,7 +438,7 @@ public class ConfigurationTomlSerializer : IConfigurationSerializer
                 throw new InvalidOperationException($"Cannot serialize interface {type.Name}");
 
             if (type.IsAbstract)
-                throw new InvalidOperationException($"Cannot serialize serialize {type.Name}");
+                throw new InvalidOperationException($"Cannot serialize {type.Name}");
 
             // Assume the "primary" constructor is the one with the most parameters.
             // (Records typically have one primary constructor.)


### PR DESCRIPTION
## Summary
- clean up duplicate word in ConfigurationTomlSerializer error message

## Testing
- `dotnet format Void.slnx --include src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs --verify-no-changes` *(fails: Fix end of line marker)*
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`


------
https://chatgpt.com/codex/tasks/task_e_688eef97a43c832bbf820224ac12c6bf