### PR TITLE
test(guid-tests): 🧪 use stackalloc for variant bytes

### DIFF
--- a/src/Tests/GuidTests/UuidTests.cs
+++ b/src/Tests/GuidTests/UuidTests.cs
@@ -45,7 +45,7 @@ public class UuidTests
     [InlineData(0xF0, 3)]
     public void GetVariant_ReturnsExpected(byte variant, int expected)
     {
-        var bytes = new byte[16];
+        Span<byte> bytes = stackalloc byte[16];
         bytes[8] = variant;
         var uuid = new Uuid(new Guid(bytes));
         Assert.Equal(expected, uuid.GetVariant());


### PR DESCRIPTION
## Summary
- replace temporary byte array in `UuidTests` with stackalloc span

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688ef519c33c832b81ad220ce1bca544