### PR TITLE
fix(api): 📝 correct malformed param documentation

### DIFF
--- a/src/Api/IProxy.cs
+++ b/src/Api/IProxy.cs
@@ -26,7 +26,6 @@ public interface IProxy
     /// <remarks>If <paramref name="waitOnlinePlayers"/> is set to <see langword="true"/>, the proxy will
     /// wait until all players have disconnected. Use this option to ensure a graceful shutdown when active player
     /// sessions are present.</remarks>
-    /// <param name="waitOnlinePlayers">A value indicating whether to wait for all online players to disconnect before stopping the server.  <see
-    /// langword="true"/> to wait for players to disconnect; otherwise, <see langword="false"/>.</param>
+    /// <param name="waitOnlinePlayers">A value indicating whether to wait for all online players to disconnect before stopping the server. <see langword="true"/> to wait for players to disconnect; otherwise, <see langword="false"/>.</param>
     public void Stop(bool waitOnlinePlayers = false);
 }


### PR DESCRIPTION
## Summary
- fix malformed XML doc comment for `Stop` method's parameter in `IProxy`

## Testing
- `dotnet format --include src/Api/IProxy.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688ef639ee48832b8a5ad47c7cdd3e25