### PR TITLE
test(buffer-tests): ♻️ replace array allocation with stackalloc

### DIFF
--- a/src/Tests/BufferTests/BufferSpanTests.cs
+++ b/src/Tests/BufferTests/BufferSpanTests.cs
@@ -62,7 +62,8 @@ public class BufferSpanTests
         Span<byte> source = stackalloc byte[] { 0, 1, 2, 3, 4 };
         var span = new BufferSpan(source);
         var slice = span.Slice(1, 3);
-        Assert.Equal(new byte[] { 1, 2, 3 }, slice.Access(0, 3).ToArray());
+        Span<byte> expected = stackalloc byte[] { 1, 2, 3 };
+        Assert.True(slice.Access(0, 3).SequenceEqual(expected));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- refactor buffer span test to use stackalloc instead of heap allocation

## Testing
- `dotnet format --include src/Tests/BufferTests/BufferSpanTests.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688efb434f74832ba91aee67353410ec