### PR TITLE
test(buffer-tests): ✅ replace byte array with stackalloc

### DIFF
--- a/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
+++ b/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
@@ -205,7 +205,8 @@ public class ReadMinecraftBufferExtensionsTests
 
         var remaining = buffer.ReadToEnd();
 
-        Assert.Equal(new byte[] { 2, 3, 4, 5 }, remaining.ToArray());
+        Span<byte> expected = stackalloc byte[] { 2, 3, 4, 5 };
+        Assert.True(remaining.SequenceEqual(expected));
         Assert.Equal(5, buffer.Position);
     }
 


### PR DESCRIPTION
## Summary
- use stackalloc for expected data in ReadToEnd test to avoid heap allocation

## Testing
- `dotnet format --include src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f01abcb74832b9786780ff8144e86