### PR TITLE
perf(protocol-support): ⚡️ stackalloc acknowledged bytes

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Serverbound/SignedChatCommandPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Serverbound/SignedChatCommandPacket.cs
@@ -33,9 +33,15 @@ public class SignedChatCommandPacket : IMinecraftServerboundPacket<SignedChatCom
 
         buffer.WriteVarInt(MessageCount);
 
-        var array = new byte[DivFloor];
-        Acknowledged.CopyTo(array, 0);
-        buffer.Write(array);
+        Span<byte> acknowledgedBytes = stackalloc byte[DivFloor];
+
+        for (var i = 0; i < WindowSize; i++)
+        {
+            if (Acknowledged.Get(i))
+                acknowledgedBytes[i / 8] |= (byte)(1 << (i % 8));
+        }
+
+        buffer.Write(acknowledgedBytes);
 
         if (protocolVersion >= ProtocolVersion.MINECRAFT_1_21_5)
             buffer.WriteUnsignedByte(0); // always 0, no Checksum


### PR DESCRIPTION
## Summary
- optimize SignedChatCommandPacket by using stackalloc for acknowledged bytes

## Testing
- `dotnet format` *(fails: Could not find a MSBuild project file or solution file)*
- `dotnet build` *(fails: The element <Solution> is unrecognized)*
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688f01ada89c832ba18d517432f65049