### PR TITLE
test(buffer): 🧪 use stackalloc in ReadToEnd test

### DIFF
--- a/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
+++ b/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
@@ -205,7 +205,8 @@ public class ReadMinecraftBufferExtensionsTests
 
         var remaining = buffer.ReadToEnd();
 
-        Assert.Equal(new byte[] { 2, 3, 4, 5 }, remaining.ToArray());
+        ReadOnlySpan<byte> expected = stackalloc byte[] { 2, 3, 4, 5 };
+        Assert.True(expected.SequenceEqual(remaining));
         Assert.Equal(5, buffer.Position);
     }
 


### PR DESCRIPTION
## Summary
- use stackalloc when comparing expected bytes in ReadToEnd test

## Testing
- `dotnet format --include src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f01bb3fec832baf15295fc7350bde