### PR TITLE
perf(tests): ⚡ use stackalloc for slice assertion

### DIFF
--- a/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
+++ b/src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs
@@ -253,7 +253,8 @@ public class ReadMinecraftBufferExtensionsTests
 
         var slice = buffer.Read(3);
 
-        Assert.Equal(new byte[] { 1, 2, 3 }, slice.ToArray());
+        Span<byte> expected = stackalloc byte[] { 1, 2, 3 };
+        Assert.True(slice.SequenceEqual(expected));
         Assert.Equal(3, buffer.Position);
     }
 }


### PR DESCRIPTION
## Summary
- use stackalloc for expected slice in ReadMinecraftBufferExtensionsTests

## Testing
- `dotnet format Void.slnx --include src/Tests/BufferTests/ReadMinecraftBufferExtensionsTests.cs --verbosity normal`
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`


------
https://chatgpt.com/codex/tasks/task_e_688f42e64010832ba7d0172cb14bee9b