### PR TITLE
test(buffer): 🧪 replace byte array allocation with stackalloc

### DIFF
--- a/src/Tests/BufferTests/BufferSpanTests.cs
+++ b/src/Tests/BufferTests/BufferSpanTests.cs
@@ -95,7 +95,8 @@ public class BufferSpanTests
         Span<byte> source = stackalloc byte[] { 0, 1, 2, 3, 4 };
         var span = new BufferSpan(source);
         span.Position = 2;
-        Assert.Equal(new byte[] { 2, 3 }, span.Access(2).ToArray());
+        Span<byte> expected = stackalloc byte[] { 2, 3 };
+        Assert.True(span.Access(2).SequenceEqual(expected));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace heap byte array with stackalloc span in BufferSpanTests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f42eb99e0832bbdb448c58f5b5d63