### PR TITLE
perf(encryption): ⚡ use stackalloc for salt bytes

### DIFF
--- a/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
+++ b/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
@@ -101,10 +101,11 @@ public abstract class AbstractEncryptionService(IEventService events, ICryptoSer
 
         if (player.IdentifiedKey is { } identifiedKey)
         {
-            var saltBytes = BitConverter.GetBytes(salt);
+            Span<byte> saltBytes = stackalloc byte[sizeof(long)];
+            BitConverter.TryWriteBytes(saltBytes, salt);
 
             if (BitConverter.IsLittleEndian)
-                Array.Reverse(saltBytes);
+                saltBytes.Reverse();
 
             return identifiedKey.VerifyDataSignature(encrypted, [.. original, .. saltBytes]);
         }


### PR DESCRIPTION
## Summary
- replace heap allocation with stackalloc for salt bytes in encryption service

## Testing
- `dotnet format --verify-no-changes --include src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f42ef5b34832b92e9c689a13ff056