### PR TITLE
test(buffer): 🧪 use stackalloc in BufferMemoryTests

### DIFF
--- a/src/Tests/BufferTests/BufferMemoryTests.cs
+++ b/src/Tests/BufferTests/BufferMemoryTests.cs
@@ -10,7 +10,7 @@ public class BufferMemoryTests
     [Fact]
     public void Slice_ReturnsExpectedMemory()
     {
-        var memory = new BufferMemory(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        var memory = new BufferMemory(stackalloc byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }.ToArray());
         var slice = memory.Slice(2, 5);
         Assert.Equal(new byte[] { 2, 3, 4, 5, 6 }, slice.Span.Access(0, 5).ToArray());
     }


### PR DESCRIPTION
## Summary
- replace byte array allocation in BufferMemoryTests with stackalloc sample data

## Testing
- `dotnet format --include src/Tests/BufferTests/BufferMemoryTests.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f42f196ac832ba20ac8ede8f207e0