### PR TITLE
test(buffer): ✅ use stackalloc for expected span

### DIFF
--- a/src/Tests/BufferTests/BufferSpanTests.cs
+++ b/src/Tests/BufferTests/BufferSpanTests.cs
@@ -113,7 +113,8 @@ public class BufferSpanTests
         Span<byte> source = stackalloc byte[] { 1, 2, 3 };
         var span = new BufferSpan(source);
 
-        Assert.Equal(new byte[] { 1, 2, 3 }, span.Access(0, 3).ToArray());
+        Span<byte> expected = stackalloc byte[] { 1, 2, 3 };
+        Assert.True(expected.SequenceEqual(span.Access(0, 3)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace byte array in BufferSpan test with stack-allocated span

## Testing
- `dotnet build`
- `dotnet test` *(fails: build was canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688f658e1ae0832b9a06f8a1c5ea6132