### PR TITLE
perf(platform): ⚡ replace byte array allocation with stackalloc

### DIFF
--- a/src/Platform/Utils/GuidHelper.cs
+++ b/src/Platform/Utils/GuidHelper.cs
@@ -15,7 +15,10 @@ public static class GuidHelper
         ArgumentNullException.ThrowIfNull(text);
 
         var i128 = new Int128();
-        MD5.HashData(Encoding.UTF8.GetBytes(text), i128.AsSpan());
+        var byteCount = Encoding.UTF8.GetByteCount(text);
+        Span<byte> utf8Bytes = stackalloc byte[byteCount];
+        Encoding.UTF8.GetBytes(text, utf8Bytes);
+        MD5.HashData(utf8Bytes, i128.AsSpan());
 
         i128.version = (byte)((i128.version & 0x0f) | 0x30);
         i128.variant = (byte)((i128.variant & 0x3f) | 0x80);


### PR DESCRIPTION
## Summary
- optimize GuidHelper hashing by using stackalloc for UTF-8 buffer

## Testing
- `dotnet format --include src/Platform/Utils/GuidHelper.cs -v diag --no-restore`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f65954810832b940858982b4486ff