### PR TITLE
refactor(platform): ♻️ replace LINQ queries with loops

### DIFF
--- a/src/Platform/Commands/CommandService.cs
+++ b/src/Platform/Commands/CommandService.cs
@@ -66,7 +66,13 @@ public class CommandService(IEventService events) : ICommandService, IEventListe
     public async ValueTask<string[]> CompleteAsync(string input, ICommandSource source, CancellationToken cancellationToken = default)
     {
         var suggestions = await _dispatcher.SuggestAsync(input, source, cancellationToken);
-        return [.. suggestions.All.Select(suggestion => suggestion.Text)];
+
+        var result = new string[suggestions.All.Count];
+
+        for (var i = 0; i < suggestions.All.Count; i++)
+            result[i] = suggestions.All[i].Text;
+
+        return result;
     }
 
     private void ClearByAssembly(Assembly assembly)

--- a/src/Platform/Events/EventService.cs
+++ b/src/Platform/Events/EventService.cs
@@ -11,7 +11,18 @@ public class EventService(ILogger<EventService> logger, IContainer container) : 
 {
     private readonly List<Entry> _entries = [];
 
-    public IEnumerable<IEventListener> Listeners => [.. _entries.Select(entry => entry.Listener)];
+    public IEnumerable<IEventListener> Listeners
+    {
+        get
+        {
+            var listeners = new IEventListener[_entries.Count];
+
+            for (var i = 0; i < _entries.Count; i++)
+                listeners[i] = _entries[i].Listener;
+
+            return listeners;
+        }
+    }
 
     public async ValueTask ThrowAsync<T>(CancellationToken cancellationToken = default) where T : IEvent, new()
     {


### PR DESCRIPTION
## Summary
- replace simple LINQ projection in command completions with a loop
- avoid LINQ in event service listener enumeration

## Testing
- `dotnet format --include src/Platform/Commands/CommandService.cs src/Platform/Events/EventService.cs -v diag`
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`


------
https://chatgpt.com/codex/tasks/task_e_688f6e325dac832b8c9289fd4f3b649f