### PR TITLE
perf(minecraft): ⚡️ stackalloc WriteUuid

### DIFF
--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -398,7 +398,10 @@ internal ref struct MinecraftBackingBuffer
 
     public void WriteUuid(Uuid value)
     {
-        Write(value.AsGuid == Guid.Empty ? new byte[16] : value.AsGuid.ToByteArray(true));
+        Span<byte> data = stackalloc byte[16];
+        _ = value.AsGuid.TryWriteBytes(data, bigEndian: true, out _);
+
+        Write(data);
     }
 
     public Uuid ReadUuidAsIntArray()
@@ -553,7 +556,7 @@ internal ref struct MinecraftBackingBuffer
         };
     }
 
-    public void Write(ReadOnlySpan<byte> data)
+    public void Write(scoped ReadOnlySpan<byte> data)
     {
         switch (_bufferType)
         {

--- a/src/Minecraft/Buffers/ReadWrite/SpanBackingBuffer.cs
+++ b/src/Minecraft/Buffers/ReadWrite/SpanBackingBuffer.cs
@@ -122,7 +122,7 @@ internal ref struct SpanBackingBuffer(Span<byte> span)
         return Slice(length);
     }
 
-    public void Write(ReadOnlySpan<byte> data)
+    public void Write(scoped ReadOnlySpan<byte> data)
     {
         if (_block.Length < Position + data.Length)
             throw new InternalBufferOverflowException($"Buffer length with max {_block.Length} at position {Position} attempted to write {data.Length} bytes");


### PR DESCRIPTION
## Summary
- stackalloc UUID bytes in `MinecraftBackingBuffer` to avoid heap allocation
- mark write helpers with `scoped ReadOnlySpan<byte>` to keep stack spans safe

## Testing
- `dotnet format --include src/Minecraft/Buffers/MinecraftBackingBuffer.cs --include src/Minecraft/Buffers/ReadWrite/SpanBackingBuffer.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f7404c800832b92fe7f862862d07d