### PR TITLE
perf(minecraft): ⚡️ use stackalloc for UUID part parsing

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -50,7 +50,8 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
 
         Span<byte> m0Bytes = stackalloc byte[4]; // m0: first 4 bytes (little-endian)
         BinaryPrimitives.WriteInt32LittleEndian(m0Bytes, parts[0]);
-        var m1Bytes = BitConverter.GetBytes(parts[1]); // m1: next 4 bytes
+        Span<byte> m1Bytes = stackalloc byte[4]; // m1: next 4 bytes
+        BinaryPrimitives.WriteInt32LittleEndian(m1Bytes, parts[1]);
         var l0Bytes = BitConverter.GetBytes(parts[2]); // l0: third int
         var l1Bytes = BitConverter.GetBytes(parts[3]); // l1: fourth int
 


### PR DESCRIPTION
## Summary
- stackalloc int part bytes to avoid heap allocation

## Testing
- `dotnet format Void.slnx --include src/Minecraft/Profiles/Uuid.cs` *(no output)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f7bbe281c832bb6223190aa786080