### PR TITLE
perf(buffers): ⚡ replace byte array allocation with stackalloc

### DIFF
--- a/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
+++ b/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
@@ -293,11 +293,12 @@ public static class WriteMinecraftBufferExtensions
 
     private static void WriteStringCore<TBuffer>(ref TBuffer buffer, string value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct
     {
-        var bytes = Encoding.UTF8.GetBytes(value);
-        var length = bytes.Length;
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        Span<byte> bytes = byteCount <= 1024 ? stackalloc byte[byteCount] : new byte[byteCount];
+        Encoding.UTF8.GetBytes(value, bytes);
 
-        buffer.WriteVarInt(length);
-        bytes.CopyTo(buffer.AccessWrite(length));
+        buffer.WriteVarInt(byteCount);
+        bytes.CopyTo(buffer.AccessWrite(byteCount));
     }
 
     private static void WritePropertyCore<TBuffer>(ref TBuffer buffer, Property value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct


### PR DESCRIPTION
## Summary
- use stackalloc for UTF-8 encoding in WriteStringCore to reduce heap allocations

## Testing
- `dotnet format --include src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs --verify-no-changes` (fails: Fix end of line marker)
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f7fb7edac832ba1de07732658a26e