### PR TITLE
perf(minecraft): ♻️ use stackalloc to avoid byte array allocation

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -79,7 +79,9 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
         ArgumentNullException.ThrowIfNull(text);
 
         var i128 = new Int128();
-        MD5.TryHashData(Encoding.UTF8.GetBytes(text), i128.AsSpan(), out _);
+        Span<byte> textBytes = stackalloc byte[Encoding.UTF8.GetByteCount(text)];
+        Encoding.UTF8.GetBytes(text, textBytes);
+        MD5.TryHashData(textBytes, i128.AsSpan(), out _);
 
         i128.version = (byte)(i128.version & 0x0f | 0x30);
         i128.variant = (byte)(i128.variant & 0x3f | 0x80);


### PR DESCRIPTION
## Summary
- use stackalloc for FromStringHash string encoding to avoid byte array allocation

## Testing
- `dotnet format src/Minecraft/Void.Minecraft.csproj --no-restore --verify-no-changes` *(fails: ENDOFLINE: Fix end of line marker)*
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688f7fc0c994832baabae8dd1f158d11