### PR TITLE
perf(profiles): ⚡ replace byte array allocation with stackalloc

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -89,8 +89,12 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
 
     public static Uuid FromLongs(long mostSig, long leastSig)
     {
-        var mostSigBytes = BitConverter.GetBytes(mostSig);
-        var leastSigBytes = BitConverter.GetBytes(leastSig);
+        Span<byte> bytes = stackalloc byte[16];
+        var mostSigBytes = bytes[..8];
+        var leastSigBytes = bytes[8..];
+
+        BinaryPrimitives.WriteInt64LittleEndian(mostSigBytes, mostSig);
+        BinaryPrimitives.WriteInt64LittleEndian(leastSigBytes, leastSig);
 
         return new Uuid(new Guid([
             mostSigBytes[4],


### PR DESCRIPTION
## Summary
- avoid heap allocation when building UUID from longs by using a stack-allocated buffer

## Testing
- `dotnet format src/Minecraft/Profiles/Uuid.cs` *(fails: The file 'Uuid.cs' does not appear to be a valid project or solution file)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f83256538832b93256df2ae5587cd