### PR TITLE
perf(platform): ⚡ avoid array allocation in endpoint parser

### DIFF
--- a/src/Platform/Utils/JsonIPEndPointConverter.cs
+++ b/src/Platform/Utils/JsonIPEndPointConverter.cs
@@ -16,7 +16,18 @@ public class JsonIpEndPointConverter : JsonConverter<IPEndPoint>
             throw new InvalidDataException();
 
         Span<char> charData = stackalloc char[53];
-        var count = Encoding.UTF8.GetChars(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan, charData);
+        int count;
+
+        if (reader.HasValueSequence)
+        {
+            Span<byte> bytes = stackalloc byte[(int)reader.ValueSequence.Length];
+            reader.ValueSequence.CopyTo(bytes);
+            count = Encoding.UTF8.GetChars(bytes, charData);
+        }
+        else
+        {
+            count = Encoding.UTF8.GetChars(reader.ValueSpan, charData);
+        }
 
         var addressLength = count;
         var lastColonPos = charData.LastIndexOf(':');


### PR DESCRIPTION
## Summary
- use stackalloc to parse IP endpoints without allocating

## Testing
- `dotnet format Void.slnx --include src/Platform/Utils/JsonIPEndPointConverter.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f831c3890832b93d9b89e406f5e8d