### PR TITLE
docs: 📝 clarify commit hunk policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Follow the existing C# style rules:
 
 ## Development
 
+- Commit only hunks with actual code changes. Preserve each file's existing line endings and whitespace; never reformat untouched lines.
 - Run `dotnet format` before committing any code changes, then execute `dotnet test` to ensure all tests pass.
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.


### PR DESCRIPTION
## Summary
- document committing only hunks with real code changes and preserving original line endings

## Testing
- `dotnet format Void.slnx --verify-no-changes --verbosity minimal` *(fails: Fix end of line marker)*
- `dotnet build Void.slnx`
- `dotnet test Void.slnx`


------
https://chatgpt.com/codex/tasks/task_e_688f84990f04832b819fd363e173c0a9