### PR TITLE
perf(buffers): ⚡ use stackalloc for string encoding

### DIFF
--- a/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
+++ b/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
@@ -294,7 +294,7 @@ public static class WriteMinecraftBufferExtensions
     private static void WriteStringCore<TBuffer>(ref TBuffer buffer, string value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct
     {
         var byteCount = Encoding.UTF8.GetByteCount(value);
-        Span<byte> bytes = byteCount <= 1024 ? stackalloc byte[byteCount] : new byte[byteCount];
+        Span<byte> bytes = stackalloc byte[byteCount];
         Encoding.UTF8.GetBytes(value, bytes);
 
         buffer.WriteVarInt(byteCount);


### PR DESCRIPTION
## Summary
- replace heap byte buffer with stackalloc when writing strings

## Testing
- `dotnet format Void.slnx` *(fails: The server disconnected unexpectedly)*
- `dotnet build Void.slnx`
- `dotnet test Void.slnx` *(terminates before completion)*

------
https://chatgpt.com/codex/tasks/task_e_688fceead14c832b98c5e5c21acd183e