### PR TITLE
perf(buffers): ⚡️ avoid heap allocation in WriteVarInt

### DIFF
--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -232,7 +232,7 @@ internal ref struct MinecraftBackingBuffer
     {
         Span<byte> buffer = stackalloc byte[5];
         var length = value.AsVarInt(buffer);
-        Write(buffer[..length].ToArray());
+        Write(buffer[..length]);
     }
 
     public long ReadVarLong()


### PR DESCRIPTION
## Summary
- avoid heap allocation in MinecraftBackingBuffer.WriteVarInt by writing stack-allocated buffer directly

## Testing
- `dotnet format Void.slnx --include src/Minecraft/Buffers/MinecraftBackingBuffer.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fcefe5c98832bac73571f57282d5f