### PR TITLE
perf(buffers): ⚡️ use stackalloc for UUID serialization

### DIFF
--- a/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
+++ b/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
@@ -283,7 +283,8 @@ public static class WriteMinecraftBufferExtensions
 
     private static void WriteUuidAsIntArrayCore<TBuffer>(ref TBuffer buffer, Uuid value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct
     {
-        var span = value.AsGuid.ToByteArray(true).AsSpan();
+        Span<byte> span = stackalloc byte[16];
+        value.AsGuid.TryWriteBytes(span, true, out _);
 
         buffer.WriteInt(BinaryPrimitives.ReadInt32BigEndian(span[..4]));
         buffer.WriteInt(BinaryPrimitives.ReadInt32BigEndian(span[4..8]));


### PR DESCRIPTION
## Summary
- avoid heap allocation when writing UUIDs

## Testing
- `dotnet format --verify-no-changes` *(fails: ENDOFLINE Fix end of line marker)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688fcf038e20832b99c7415fa2dac929