### PR TITLE
perf(minecraft): ⚡ avoid heap allocation in UUID parsing

### DIFF
--- a/src/Minecraft/Profiles/Uuid.cs
+++ b/src/Minecraft/Profiles/Uuid.cs
@@ -54,7 +54,8 @@ public struct Uuid(Guid guid) : IComparable<Uuid>, IEquatable<Uuid>
         BinaryPrimitives.WriteInt32LittleEndian(m1Bytes, parts[1]);
         Span<byte> l0Bytes = stackalloc byte[4]; // l0: third int
         BinaryPrimitives.WriteInt32LittleEndian(l0Bytes, parts[2]);
-        var l1Bytes = BitConverter.GetBytes(parts[3]); // l1: fourth int
+        Span<byte> l1Bytes = stackalloc byte[4]; // l1: fourth int
+        BinaryPrimitives.WriteInt32LittleEndian(l1Bytes, parts[3]);
 
         return new Uuid(new Guid([
             m0Bytes[0],


### PR DESCRIPTION
## Summary
- stackallocate UUID component to remove BitConverter array allocation

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet format --verify-no-changes` *(fails: ENDOFLINE errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8d698e8832b9c73b3e365d932c3