### PR TITLE
perf(velocity): ⚡️ stackalloc secret bytes to avoid heap allocation

### DIFF
--- a/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
+++ b/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
@@ -90,7 +90,10 @@ public class ForwardingService(IPlayerContext context, ILogger logger, Settings 
         }
 
         var forwardingData = buffer.Access(0, buffer.Position);
-        var signature = HMACSHA256.HashData(Encoding.UTF8.GetBytes(settings.Secret), forwardingData);
+        var secretLength = Encoding.UTF8.GetByteCount(settings.Secret);
+        Span<byte> secretBytes = stackalloc byte[secretLength];
+        Encoding.UTF8.GetBytes(settings.Secret, secretBytes);
+        var signature = HMACSHA256.HashData(secretBytes, forwardingData);
 
         @event.Cancel();
         await @event.Link.SendPacketAsync(new LoginPluginResponsePacket { Data = [.. signature, .. forwardingData], MessageId = packet.MessageId, Successful = true }, cancellationToken);


### PR DESCRIPTION
## Summary
- use stackalloc for secret string encoding in Velocity forwarding to avoid heap allocation

## Testing
- `dotnet format` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fd8da24f0832b92e8aa14040569eb