### PR TITLE
perf(profiles): ⚡ use stackalloc for key verification

### DIFF
--- a/src/Minecraft/Profiles/IdentifiedKey.cs
+++ b/src/Minecraft/Profiles/IdentifiedKey.cs
@@ -60,7 +60,9 @@ public record IdentifiedKey(IdentifiedKeyRevision Revision, long ExpiresAt, byte
         if (Revision == IdentifiedKeyRevision.GenericV1Revision)
         {
             var publicKeyText = $"-----BEGIN RSA PUBLIC KEY-----\n{Convert.ToBase64String(PublicKey, Base64FormattingOptions.InsertLineBreaks)}\n-----END RSA PUBLIC KEY-----\n";
-            var verify = Encoding.ASCII.GetBytes(ExpiresAt + publicKeyText.Replace("\r", string.Empty));
+            var verifyText = ExpiresAt + publicKeyText.Replace("\r", string.Empty);
+            Span<byte> verify = stackalloc byte[Encoding.ASCII.GetByteCount(verifyText)];
+            Encoding.ASCII.GetBytes(verifyText, verify);
 
             using var rsa = RSA.Create();
             rsa.ImportSubjectPublicKeyInfo(YggdrasilSessionPublicKey, out _);


### PR DESCRIPTION
## Summary
- avoid heap allocations when verifying profile key signatures

## Testing
- `dotnet-format src/Minecraft/Void.Minecraft.csproj --include src/Minecraft/Profiles/IdentifiedKey.cs`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688fd8cc0274832bb040000356990ce4