### PR TITLE
perf(buffers): ⚡️ avoid heap allocation when encoding UTF-8 strings

### DIFF
--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -453,7 +453,9 @@ internal ref struct MinecraftBackingBuffer
             case BufferType.ReadOnlySpan or BufferType.ReadOnlySequence:
                 throw new ReadOnlyException();
             case BufferType.MemoryStream:
-                _memoryStreamBackingBuffer.Write(Encoding.UTF8.GetBytes(value));
+                Span<byte> utf8 = stackalloc byte[length];
+                Encoding.UTF8.GetBytes(value, utf8);
+                _memoryStreamBackingBuffer.Write(utf8);
                 break;
             default:
                 throw new NotSupportedException(_bufferType.ToString());


### PR DESCRIPTION
## Summary
- use stackalloc when writing UTF-8 strings to memory streams

## Testing
- `dotnet format --include src/Minecraft/Buffers/MinecraftBackingBuffer.cs -v diag`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fd9d80f9c832ba06350145d38ad8e