### PR TITLE
perf(encryption): ⚡ avoid heap allocation when verifying token

### DIFF
--- a/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
+++ b/src/Plugins/Common/Services/Encryption/AbstractEncryptionService.cs
@@ -107,7 +107,11 @@ public abstract class AbstractEncryptionService(IEventService events, ICryptoSer
             if (BitConverter.IsLittleEndian)
                 saltBytes.Reverse();
 
-            return identifiedKey.VerifyDataSignature(encrypted, [.. original, .. saltBytes]);
+            Span<byte> combined = stackalloc byte[original.Length + saltBytes.Length];
+            original.CopyTo(combined);
+            saltBytes.CopyTo(combined[original.Length..]);
+
+            return identifiedKey.VerifyDataSignature(encrypted, combined);
         }
 
         Span<byte> decrypted = stackalloc byte[encrypted.Length];


### PR DESCRIPTION
## Summary
- streamline token verification by hashing into a stack-allocated buffer

## Testing
- `dotnet format --verify-no-changes` *(fails: ENDOFLINE: Fix end of line marker...)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fe80cf93c832ba192a3956094ecd2