### PR TITLE
perf(protocolsupport): ⚡️ avoid heap allocation when decoding acknowledgments

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Serverbound/SignedChatCommandPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Serverbound/SignedChatCommandPacket.cs
@@ -87,7 +87,14 @@ public class SignedChatCommandPacket : IMinecraftServerboundPacket<SignedChatCom
 
         static BitArray DecodeAcknowledged(ref MinecraftBuffer buffer)
         {
-            return new BitArray(buffer.Read(DivFloor).ToArray());
+            Span<byte> data = stackalloc byte[DivFloor];
+            buffer.Read(DivFloor).CopyTo(data);
+            var result = new BitArray(WindowSize);
+
+            for (var i = 0; i < WindowSize; i++)
+                result[i] = (data[i / 8] & (1 << (i % 8))) != 0;
+
+            return result;
         }
     }
 


### PR DESCRIPTION
## Summary
- use stackalloc instead of allocating a byte array for SignedChatCommandPacket acknowledgments

## Testing
- `dotnet format` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fe81462f8832b801a727fae11fcaa