### PR TITLE
test(buffer): ✅ avoid heap allocation in slice test

### DIFF
--- a/src/Tests/BufferTests/BufferMemoryTests.cs
+++ b/src/Tests/BufferTests/BufferMemoryTests.cs
@@ -24,7 +24,9 @@ public class BufferMemoryTests
 
         var slice = memory.Slice(0, data.Length);
 
-        Assert.Equal(data, slice.Span.Access(0, data.Length).ToArray());
+        Span<byte> actual = stackalloc byte[data.Length];
+        slice.Span.Access(0, data.Length).CopyTo(actual);
+        Assert.True(actual.SequenceEqual(data));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- avoid `ToArray()` in buffer slice test with stackalloc

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fe83ab938832bb1b191c9e8245dbe