### PR TITLE
refactor(common): ♻️ use nameof in channel removal

### DIFF
--- a/src/Plugins/Common/Network/Channels/SimpleMinecraftChannel.cs
+++ b/src/Plugins/Common/Network/Channels/SimpleMinecraftChannel.cs
@@ -82,7 +82,7 @@ public class SimpleMinecraftChannel(IMessageStreamBase head) : INetworkChannel
         }
         else
         {
-            throw new InvalidOperationException($"Cannot remove {value} stream with unset BaseStream");
+            throw new InvalidOperationException($"Cannot remove {value} stream with unset {nameof(value.BaseStream)}");
         }
     }
 


### PR DESCRIPTION
## Summary
- use `nameof` to reference BaseStream in SimpleMinecraftChannel removal error

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68905a77e9b8832bad76162b48d02e64