### PR TITLE
docs(protocol-support): 📝 correct channel comment typo

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Channels/ChannelService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Channels/ChannelService.cs
@@ -51,7 +51,7 @@ public class ChannelService(IEventService events) : AbstractChannelService(event
         if (@event.Message is not EncryptionResponsePacket)
             return;
 
-        // if encryption forced channel to remove packet stream, resume reading with what has left
+        // if encryption forced channel to remove packet stream, resume reading with what is left
         if (!@event.Link.PlayerChannel.TryGet<MinecraftPacketMessageStream>(out _))
             @event.Link.PlayerChannel.Resume();
     }


### PR DESCRIPTION
## Summary
- fix grammar in channel service comment

## Testing
- `dotnet format Void.slnx`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68905a6fbe84832b9f4330fd3782a779