### PR TITLE
refactor(protocolsupport): ♻️ extract UUID string length constant

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/LoginSuccessPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/LoginSuccessPacket.cs
@@ -7,6 +7,8 @@ namespace Void.Proxy.Plugins.ProtocolSupport.Java.v1_7_2_to_1_12_2.Packets.Clien
 
 public class LoginSuccessPacket : IMinecraftClientboundPacket<LoginSuccessPacket>
 {
+    private const int UuidStringLength = 36;
+
     public required GameProfile GameProfile { get; set; }
 
     public void Encode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
@@ -23,7 +25,7 @@ public class LoginSuccessPacket : IMinecraftClientboundPacket<LoginSuccessPacket
 
     public static LoginSuccessPacket Decode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
     {
-        var uuid = Uuid.Parse(buffer.ReadString(36));
+        var uuid = Uuid.Parse(buffer.ReadString(UuidStringLength));
         var name = buffer.ReadString();
 
         return new LoginSuccessPacket { GameProfile = new GameProfile(name, uuid) };


### PR DESCRIPTION
## Summary
- constantify UUID string length in login success packet

## Testing
- `dotnet format --verbosity diag --include src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Packets/Clientbound/LoginSuccessPacket.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68905a3a5940832bba128619cceeea07