### PR TITLE
style(nbt): 🎨 use nameof for data parameter

### DIFF
--- a/src/Minecraft/Nbt/NbtTag.cs
+++ b/src/Minecraft/Nbt/NbtTag.cs
@@ -104,7 +104,7 @@ public abstract record NbtTag
     public static long Parse<T>(ReadOnlyMemory<byte> data, out T result, bool readName = false, NbtFormatOptions formatOptions = NbtFormatOptions.Java) where T : NbtTag
     {
         if (!MemoryMarshal.TryGetArray(data, out var segment) || segment.Array is null)
-            throw new Exception("Cannot get array segment from memory");
+            throw new ArgumentException("Cannot get array segment from data", nameof(data));
 
         using var stream = new MemoryStream(segment.Array);
         var reader = new NbtReader(stream, (FormatOptions)formatOptions);


### PR DESCRIPTION
## Summary
- apply nameof to identify problematic `data` parameter when parsing NBT

## Testing
- `dotnet format --no-restore --verify-no-changes`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68905a6c6570832ba2688f30eb898713