### PR TITLE
fix(nbt): 🐛 handle invalid token in boolean adapter

### DIFF
--- a/src/Minecraft/Nbt/Serializers/Json/Adapter/NbtTagBooleanAdapter.cs
+++ b/src/Minecraft/Nbt/Serializers/Json/Adapter/NbtTagBooleanAdapter.cs
@@ -9,6 +9,6 @@ public class NbtTagBooleanAdapter
     {
         JsonTokenType.True => new NbtByte(1),
         JsonTokenType.False => new NbtByte(0),
-        _ => throw new JsonException($"\"{reader.GetString()}\" is not a boolean.")
+        _ => throw new JsonException($"{reader.TokenType} is not a boolean.")
     };
 }


### PR DESCRIPTION
## Summary
- avoid invalid Utf8JsonReader usage when reporting non-boolean tokens

## Testing
- `dotnet format`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689069549b80832b8af2c57b93562443