### PR TITLE
fix(plugins): 🐛 use nameof for protocol version check

### DIFF
--- a/src/Plugins/Common/Network/Registries/PacketId/MinecraftPacketIdPluginsRegistry.cs
+++ b/src/Plugins/Common/Network/Registries/PacketId/MinecraftPacketIdPluginsRegistry.cs
@@ -19,7 +19,7 @@ public class MinecraftPacketIdPluginsRegistry : IMinecraftPacketIdPluginsRegistr
     public IMinecraftPacketIdRegistry Get(IPlugin plugin)
     {
         if (ProtocolVersion is null)
-            throw new InvalidOperationException("Protocol version is not set yet");
+            throw new InvalidOperationException($"{nameof(ProtocolVersion)} is not set yet");
 
         if (!_map.TryGetValue(plugin, out var registry))
         {


### PR DESCRIPTION
## Summary
- replace hard-coded string with `nameof(ProtocolVersion)`

## Testing
- `dotnet format --include src/Plugins/Common/Network/Registries/PacketId/MinecraftPacketIdPluginsRegistry.cs -v diag`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68906949513c832b9521d1e0ed330f03