### PR TITLE
fix(plugins): 🐛 ensure transformation mappings sort equality

### DIFF
--- a/src/Plugins/Common/Network/Registries/Transformations/MinecraftPacketTransformationsRegistry.cs
+++ b/src/Plugins/Common/Network/Registries/Transformations/MinecraftPacketTransformationsRegistry.cs
@@ -61,8 +61,8 @@ public class MinecraftPacketTransformationsRegistry : IMinecraftPacketTransforma
                     mappingsToUpgrade.Add(mapping);
             }
 
-            mappingsToUpgrade.Sort((a, b) => a.From > b.From ? 1 : -1);
-            mappingsToDowngrade.Sort((a, b) => a.From > b.From ? -1 : 1);
+            mappingsToUpgrade.Sort((a, b) => a.From.CompareTo(b.From));
+            mappingsToDowngrade.Sort((a, b) => b.From.CompareTo(a.From));
 
             var upgradeTransformers = mappingsToUpgrade.Select(i => i.Transformation);
             var downgradeTransformers = mappingsToDowngrade.Select(i => i.Transformation);


### PR DESCRIPTION
## Summary
- keep upgrade/downgrade mapping sorts stable by comparing mapping versions directly

## Testing
- `dotnet format --include src/Plugins/Common/Network/Registries/Transformations/MinecraftPacketTransformationsRegistry.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68908f5978ec832bb06322e879dcd92f