### PR TITLE
fix(protocol-support): 🛠️ restore chat command handling for 1.21.6

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Registries/Registry.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Registries/Registry.cs
@@ -100,7 +100,8 @@ public static class Registry
         {
             [
                 new MinecraftPacketIdMapping(0x04, ProtocolVersion.MINECRAFT_1_20_5),
-                new MinecraftPacketIdMapping(0x05, ProtocolVersion.MINECRAFT_1_21_2)
+                new MinecraftPacketIdMapping(0x05, ProtocolVersion.MINECRAFT_1_21_2),
+                new MinecraftPacketIdMapping(0x06, ProtocolVersion.MINECRAFT_1_21_6)
             ], typeof(ChatCommandPacket)
         },
         {


### PR DESCRIPTION
## Summary
- add serverbound ChatCommand mapping for Minecraft 1.21.6

## Testing
- `dotnet format --include src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Registries/Registry.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890abb54968832b90114badafe752b3