### PR TITLE
docs(agents): 📝 remove dotnet format instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Follow the existing C# style rules:
 ## Development
 
 - Commit only hunks with actual code changes. Preserve each file's existing line endings and whitespace; never reformat untouched lines.
-- Run `dotnet format` before committing any code changes, then execute `dotnet test` to ensure all tests pass.
+- Run `dotnet test` to ensure all tests pass.
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.
 - Conventional Commits are required for commit messages.


### PR DESCRIPTION
## Summary
- remove dotnet format requirement from contributor guidelines

## Testing
- `dotnet test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_6890fd18ffb8832b823e64286c098ed0