### PR TITLE
docs(protocolsupport): 📝 clarify login disconnect comment

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Authentication/AuthenticationService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Authentication/AuthenticationService.cs
@@ -112,7 +112,7 @@ public class AuthenticationService(ILogger<AuthenticationService> logger, IEvent
             case LoginDisconnectPacket loginDisconnectPacket:
                 logger.LogInformation("Player {Player} cannot authenticate on {Server}: {Reason}", link.Player, link.Server, loginDisconnectPacket.Reason.SerializeLegacy());
 
-                // since IPlayer client is already completed login state, it cannot be kicked with login disconnect packet
+                // Since the player has already completed the login state, it cannot be kicked with a login disconnect packet
                 await link.Player.KickAsync(loginDisconnectPacket.Reason, cancellationToken);
                 return AuthenticationResult.NotAuthenticatedServer;
             case LoginSuccessPacket:


### PR DESCRIPTION
## Summary
- clarify wording about login disconnect handling

## Testing
- `dotnet format --folder . --include src/Plugins/ProtocolSupport/Java/v1_7_2_to_1_12_2/Authentication/AuthenticationService.cs`
- `dotnet build`
- `dotnet test` *(fails: terminated due to time)*

------
https://chatgpt.com/codex/tasks/task_e_6890fd3f2130832ba6022662343eb9a7