### PR TITLE
refactor(minecraft): ♻️ use nameof for token message

### DIFF
--- a/src/Minecraft/Nbt/Serializers/Json/Tags/NbtCompoundJsonConverter.cs
+++ b/src/Minecraft/Nbt/Serializers/Json/Tags/NbtCompoundJsonConverter.cs
@@ -17,7 +17,7 @@ public class NbtCompoundJsonConverter : JsonConverter<NbtCompound>
                 break;
 
             if (reader.TokenType is not JsonTokenType.PropertyName)
-                throw new JsonException("Expected property name token.");
+                throw new JsonException($"Expected {nameof(JsonTokenType.PropertyName)} token.");
 
             var propertyName = reader.GetString() ?? throw new JsonException("Expected property name, but got null.");
 


### PR DESCRIPTION
## Summary
- use nameof to reference expected PropertyName token in JSON compound converter

## Testing
- `dotnet format --include src/Minecraft/Nbt/Serializers/Json/Tags/NbtCompoundJsonConverter.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890fd4e15d4832b9b48844400a6c5dd