### PR TITLE
fix(api): 🐛 correct log argument for canceled task

### DIFF
--- a/src/Api/Extensions/TaskExtensions.cs
+++ b/src/Api/Extensions/TaskExtensions.cs
@@ -21,7 +21,7 @@ public static class TaskExtensions
                 }
                 catch (TaskCanceledException exception)
                 {
-                    logger.LogError("{Message} (Canceled)\n{Exception}\n{StackTrace}", message, exception.StackTrace, stackTrace);
+                    logger.LogError("{Message} (Canceled)\n{Exception}\n{StackTrace}", message, exception, stackTrace);
                 }
             }
 


### PR DESCRIPTION
## Summary
- correct log argument for canceled task

## Testing
- `dotnet format Void.slnx --include src/Api/Extensions/TaskExtensions.cs` *(failed: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test` *(incomplete: terminated after lengthy run)*

------
https://chatgpt.com/codex/tasks/task_e_6890fd541320832b94fdda56ca914337