### PR TITLE
style(buffers): 🎨 use nameof in property validation

### DIFF
--- a/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
+++ b/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
@@ -312,7 +312,7 @@ public static class WriteMinecraftBufferExtensions
             return;
 
         if (string.IsNullOrWhiteSpace(value.Signature))
-            throw new InvalidDataException("Signature is null or whitespace, but IsSigned set to true");
+            throw new InvalidDataException($"{nameof(value.Signature)} is null or whitespace, but {nameof(value.IsSigned)} set to true");
 
         buffer.WriteString(value.Signature);
     }


### PR DESCRIPTION
## Summary
- replace hard-coded property name with `nameof`

## Testing
- `dotnet format` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `/root/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890fd568984832b8d43a95ab0325ea5