### PR TITLE
fix(minecraft): 🐛 guard against negative list size

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/ListProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/ListProperty.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Void.Minecraft.Buffers;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
@@ -12,6 +13,9 @@ public record ListProperty<TPacketProperty>(List<TPacketProperty> Values) : IPac
 
     public static ListProperty<TPacketProperty> Read(ref MinecraftBuffer buffer, int size)
     {
+        if (size < 0)
+            throw new ArgumentOutOfRangeException(nameof(size));
+
         if (size == 0)
             return new([]);
 


### PR DESCRIPTION
## Summary
- guard against negative list property sizes in packet transformation

## Testing
- `dotnet format --include src/Minecraft/Network/Registries/Transformations/Properties/ListProperty.cs --no-restore -v minimal`
- `dotnet build --no-restore`
- `dotnet test --no-restore --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6890fd619820832ba0c910e5f531143f