### PR TITLE
docs(running): 📝 add Docker section linking containers

### DIFF
--- a/docs/astro/src/content/docs/containers.md
+++ b/docs/astro/src/content/docs/containers.md
@@ -5,8 +5,10 @@ sidebar:
   order: 1
 ---
 
-Void provides docker images for running in a container.  
+Void provides docker images for running in a container.
 See the [Void Docker Hub](https://hub.docker.com/r/caunt/void/tags) for all available images.
+
+For running Void directly on your host, refer to the [Running](/getting-started/running/) guide.
 
 ## Running Void in a Docker
 To run Void in a Docker container, use following example command:

--- a/docs/astro/src/content/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/getting-started/running.md
@@ -20,6 +20,10 @@ Run the executable
 ./void-linux-x64 [optional arguments]
 ```
 
+## Docker
+
+Prefer containers? See the [Containers](/containers/) guide for Docker and Kubernetes deployments.
+
 ## Android
 
 Run the [**Termux**](https://play.google.com/store/apps/details?id=com.termux) or any other terminal emulator.


### PR DESCRIPTION
## Summary
- cross-link running guide with new Docker section
- reference running guide from containers page

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689117e3cba0832bb6aaa85caff00704