### PR TITLE
docs(repo): 📝 require CRLF line endings for code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Follow the existing C# style rules:
 
 ## Development
 
-- Commit only hunks with actual code changes. Preserve each file's existing line endings and whitespace; never reformat untouched lines.
+- Commit only hunks with actual code changes. All code should use CRLF line endings and existing whitespace should be preserved; never reformat untouched lines.
 - Run `dotnet test` to ensure all tests pass.
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.


### PR DESCRIPTION
## Summary
- document that all code should use CRLF line endings

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6891206f9af8832bb67deb75bafa9b79