### PR TITLE
fix(api): 🐛 remove redundant constructor constraint

### DIFF
--- a/src/Api/Network/Channels/INetworkChannel.cs
+++ b/src/Api/Network/Channels/INetworkChannel.cs
@@ -61,7 +61,7 @@ public interface INetworkChannel : IDisposable, IAsyncDisposable
     /// <summary>
     /// Removes a stream of type <typeparamref name="T"/> from the pipeline.
     /// </summary>
-    public void Remove<T>() where T : class, IMessageStream, new();
+    public void Remove<T>() where T : class, IMessageStream;
 
     /// <summary>
     /// Removes the specified <paramref name="stream"/> from the pipeline.

--- a/src/Plugins/Common/Network/Channels/SimpleMinecraftChannel.cs
+++ b/src/Plugins/Common/Network/Channels/SimpleMinecraftChannel.cs
@@ -52,7 +52,7 @@ public class SimpleMinecraftChannel(IMessageStreamBase head) : INetworkChannel
         before.BaseStream = stream;
     }
 
-    public void Remove<T>() where T : class, IMessageStream, new()
+    public void Remove<T>() where T : class, IMessageStream
     {
         Remove(Get<T>());
     }


### PR DESCRIPTION
## Summary
- remove redundant constructor constraint from INetworkChannel
- update SimpleMinecraftChannel to match interface

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689126a3ba8c832ba266e3f0b8c3bae1