### PR TITLE
style(platform): 💄 use nameof for started link exception

### DIFF
--- a/src/Platform/Links/Link.cs
+++ b/src/Platform/Links/Link.cs
@@ -49,7 +49,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
         cancellationToken.ThrowIfCancellationRequested();
 
         if (this is { _playerToServerTask: not null } or { _serverToPlayerTask: not null })
-            throw new InvalidOperationException("Link was already started");
+            throw new InvalidOperationException($"{nameof(Link)} was already started");
 
         await events.ThrowAsync(new LinkStartingEvent(this, Player), cancellationToken);
 


### PR DESCRIPTION
## Summary
- refactor start validation to use `nameof(Link)` in exception

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891269f4150832ba462834c08341e98