### PR TITLE
fix(benchmarks): 🐛 reference BaseStream via nameof

### DIFF
--- a/src/Benchmarks/Streams/Compression.cs
+++ b/src/Benchmarks/Streams/Compression.cs
@@ -62,7 +62,7 @@ public class Compression
     [IterationSetup]
     public void IterationSetup()
     {
-        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
+        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException($"{nameof(_sharpZipLibStream.BaseStream)} is null."));
         var ionicZlibMemoryStream = (MinecraftMemoryStream)(_ionicZlibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
 
         sharpZipLibMemoryStream.Reset(0);


### PR DESCRIPTION
## Summary
- use nameof for base stream null exception message in compression benchmark

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891269c0280832b8b48bfb4886a22de