### PR TITLE
style(platform): ✏️ capitalize TCP acronym in exception message

### DIFF
--- a/src/Platform/Players/PlayerProxy.cs
+++ b/src/Platform/Players/PlayerProxy.cs
@@ -19,7 +19,7 @@ public class PlayerProxy(IPlayer player) : IPlayer
     public void Replace(IPlayer player)
     {
         if (Client != player.Client)
-            throw new InvalidOperationException($"Player {Source} and {player} have different tcp clients");
+            throw new InvalidOperationException($"Player {Source} and {player} have different TCP clients");
 
         Source = player;
     }


### PR DESCRIPTION
## Summary
- correct TCP acronym capitalization in player replacement validation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68912691a2cc832b8ea8cb654fc89077