### PR TITLE
style(commands): 🎨 use nameof for root command node error

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Tree/Nodes/RootCommandNode.cs
+++ b/src/Minecraft/Commands/Brigadier/Tree/Nodes/RootCommandNode.cs
@@ -19,7 +19,7 @@ public class RootCommandNode() : CommandNode(requirement: EmptyRequirement, redi
 
     public override IArgumentBuilder<CommandNode> CreateBuilder()
     {
-        throw new InvalidOperationException("Cannot convert root into a builder");
+        throw new InvalidOperationException($"Cannot convert {nameof(RootCommandNode)} into a builder");
     }
 
     public override bool IsValidInput(string input)


### PR DESCRIPTION
## Summary
- replace hard-coded root class name with `nameof(RootCommandNode)` in exception message to keep message consistent if the type is renamed

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689126840930832ba4a7d48bd3adb59d