### PR TITLE
style(minecraft): 💄 use interpolation for DoubleTooSmall message

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
+++ b/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
@@ -2,7 +2,7 @@
 
 public class BuiltInExceptions : IBuiltInExceptionProvider
 {
-    public Dynamic2CommandExceptionType DoubleTooSmall { get; } = new((found, min) => new LiteralMessage("Double must not be less than " + min + ", found " + found));
+    public Dynamic2CommandExceptionType DoubleTooSmall { get; } = new((found, min) => new LiteralMessage($"Double must not be less than {min}, found {found}"));
     public Dynamic2CommandExceptionType DoubleTooBig { get; } = new((found, max) => new LiteralMessage("Double must not be more than " + max + ", found " + found));
     public Dynamic2CommandExceptionType FloatTooSmall { get; } = new((found, min) => new LiteralMessage("Float must not be less than " + min + ", found " + found));
     public Dynamic2CommandExceptionType FloatTooBig { get; } = new((found, max) => new LiteralMessage("Float must not be more than " + max + ", found " + found));


### PR DESCRIPTION
## Summary
- collapse string concatenation in built-in DoubleTooSmall exception

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891267dce28832ba524d953e722f4fb