### PR TITLE
refactor(commands): ♻️ use nameof for parsed argument result

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Context/ParsedArgument.cs
+++ b/src/Minecraft/Commands/Brigadier/Context/ParsedArgument.cs
@@ -10,5 +10,5 @@ public interface IParsedArgument
 public record ParsedArgument<TType>(int Start, int End, TType Result) : IParsedArgument
 {
     public StringRange Range { get; } = new(Start, End);
-    public object GenericResult => Result ?? throw new InvalidOperationException("Result is null");
+    public object GenericResult => Result ?? throw new InvalidOperationException($"{nameof(Result)} is null");
 }


### PR DESCRIPTION
## Summary
- replace hard-coded Result text with nameof in parsed argument exception

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689126754e24832b9a0bc735adcf8099