### PR TITLE
docs(containers): 📝 document pull policy in Kubernetes guide

### DIFF
--- a/docs/astro/src/content/docs/containers.md
+++ b/docs/astro/src/content/docs/containers.md
@@ -52,6 +52,7 @@ spec:
       containers:
       - name: void
         image: caunt/void:latest
+        imagePullPolicy: Always
         ports:
         - name: watchdog
           containerPort: 80
@@ -65,6 +66,8 @@ spec:
         - name: VOID_OFFLINE
           value: "true"
 ```
+
+The `imagePullPolicy: Always` line ensures Kubernetes pulls the container image if a newer version is available.
 
 ## Configuring Void in Containers
 Use [**environment variables**](/configuration/environment-variables/) or [**mount volumes**](/configuration/in-file/) to configure Void.


### PR DESCRIPTION
## Summary
- include `imagePullPolicy: Always` in Kubernetes deployment example
- explain why the pull policy ensures newer images are used

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891a05e79f8832b9b2be99b0ab0713a