### PR TITLE
fix(minecraft): 🐛 correct default count for ShowItem hover action

### DIFF
--- a/src/Minecraft/Components/Text/Events/Actions/Hover/ShowItem.cs
+++ b/src/Minecraft/Components/Text/Events/Actions/Hover/ShowItem.cs
@@ -2,7 +2,7 @@
 
 namespace Void.Minecraft.Components.Text.Events.Actions.Hover;
 
-public record ShowItem(string Id, int? Count = 0, NbtCompound? ItemComponents = null) : IHoverEventAction
+public record ShowItem(string Id, int? Count = null, NbtCompound? ItemComponents = null) : IHoverEventAction
 {
     public string ActionName => "show_item";
 }


### PR DESCRIPTION
## Summary
- default count is null in ShowItem hover action

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922d50a48c832b8941108558afe621