### PR TITLE
style(protocolsupport): 🎨 use string interpolation for command prefix

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Commands/CommandService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Commands/CommandService.cs
@@ -27,7 +27,7 @@ public class CommandService(ILogger<CommandService> logger, IEventService events
             return false;
 
         if (!command.StartsWith('/'))
-            command = "/" + command;
+            command = $"/{command}";
 
         await player.GetLink().SendPacketAsync(new ChatMessagePacket { Text = command }, cancellationToken);
         return true;


### PR DESCRIPTION
## Summary
- replace string concatenation with string interpolation for commands without leading slash

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922d561798832bac3858ada3aa9a1c