### PR TITLE
test(integration): 🧪 reference CreateAsync in error message

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MinecraftConsoleClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MinecraftConsoleClient.cs
@@ -57,7 +57,7 @@ public class MinecraftConsoleClient : IntegrationSideBase
         using var disposable = await _lock.LockAsync(cancellationToken);
 
         if (string.IsNullOrWhiteSpace(_binaryPath))
-            throw new InvalidOperationException("Binary path is not set. Call SetupAsync first.");
+            throw new InvalidOperationException($"Binary path is not set. Call {nameof(CreateAsync)} first.");
 
         var configurationPath = Path.Combine(_workingDirectory, "MinecraftClient.ini");
 


### PR DESCRIPTION
## Summary
- ensure InvalidOperationException points to `CreateAsync` via `nameof`

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68922d5a85b4832baed3b5df681bd678