### PR TITLE
docs(protocol-support): 📝 fix comment typo

### DIFF
--- a/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Channels/ChannelService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_13_to_1_20_1/Channels/ChannelService.cs
@@ -51,7 +51,7 @@ public class ChannelService(IEventService events) : AbstractChannelService(event
         if (@event.Message is not EncryptionResponsePacket)
             return;
 
-        // if encryption forced channel to remove packet stream, resume reading with what has left
+        // if encryption forced channel to remove packet stream, resume reading with what is left
         if (!@event.Link.PlayerChannel.TryGet<MinecraftPacketMessageStream>(out _))
             @event.Link.PlayerChannel.Resume();
     }


### PR DESCRIPTION
## Summary
- fix typo in protocol support channel comment

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922d60439c832ba58b4deff88a43e2