### PR TITLE
style(platform): 💄 collapse string concatenation in startup log

### DIFF
--- a/src/Platform/Platform.cs
+++ b/src/Platform/Platform.cs
@@ -125,7 +125,7 @@ public class Platform(
         if (context.ParseResult.HasOption(_loggingOption))
             LoggingLevelSwitch.MinimumLevel = (LogEventLevel)context.ParseResult.GetValueForOption(_loggingOption);
 
-        logger.LogInformation("Starting {Name} {Version} proxy", nameof(Void), "v" + GetType().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+        logger.LogInformation("Starting {Name} {Version} proxy", nameof(Void), $"v{GetType().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion}");
         var startTime = Stopwatch.GetTimestamp();
 
         logger.LogTrace("Working directory is {Path}", Directory.GetCurrentDirectory());


### PR DESCRIPTION
## Summary
- replace concatenated version string with an interpolated string for startup log

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922d632384832b9ce2c0415fd4dd45