### PR TITLE
refactor(plugins): ♻️ use nameof in packet registry errors

### DIFF
--- a/src/Plugins/Common/Network/Registries/PacketId/MinecraftPacketIdSystemRegistry.cs
+++ b/src/Plugins/Common/Network/Registries/PacketId/MinecraftPacketIdSystemRegistry.cs
@@ -33,7 +33,7 @@ public class MinecraftPacketIdSystemRegistry : IMinecraftPacketIdSystemRegistry
     public void ReplacePackets(Operation operation, IReadOnlyDictionary<MinecraftPacketIdMapping[], Type> mappings)
     {
         if (ProtocolVersion is null)
-            throw new InvalidOperationException("Protocol version is not set yet");
+            throw new InvalidOperationException($"{nameof(ProtocolVersion)} is not set yet");
 
         switch (operation)
         {
@@ -55,7 +55,7 @@ public class MinecraftPacketIdSystemRegistry : IMinecraftPacketIdSystemRegistry
     public void AddPackets(Operation operation, IReadOnlyDictionary<MinecraftPacketIdMapping[], Type> mappings)
     {
         if (ProtocolVersion is null)
-            throw new InvalidOperationException("Protocol version is not set yet");
+            throw new InvalidOperationException($"{nameof(ProtocolVersion)} is not set yet");
 
         switch (operation)
         {


### PR DESCRIPTION
## Summary
- replace hard-coded protocol version error messages with `nameof`

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922d6d167c832b82d1103696ca8cba