### PR TITLE
refactor(commands): ♻️ use interpolated string for error message

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
+++ b/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
@@ -3,7 +3,7 @@
 public class BuiltInExceptions : IBuiltInExceptionProvider
 {
     public Dynamic2CommandExceptionType DoubleTooSmall { get; } = new((found, min) => new LiteralMessage($"Double must not be less than {min}, found {found}"));
-    public Dynamic2CommandExceptionType DoubleTooBig { get; } = new((found, max) => new LiteralMessage("Double must not be more than " + max + ", found " + found));
+    public Dynamic2CommandExceptionType DoubleTooBig { get; } = new((found, max) => new LiteralMessage($"Double must not be more than {max}, found {found}"));
     public Dynamic2CommandExceptionType FloatTooSmall { get; } = new((found, min) => new LiteralMessage("Float must not be less than " + min + ", found " + found));
     public Dynamic2CommandExceptionType FloatTooBig { get; } = new((found, max) => new LiteralMessage("Float must not be more than " + max + ", found " + found));
     public Dynamic2CommandExceptionType IntegerTooSmall { get; } = new((found, min) => new LiteralMessage("Integer must not be less than " + min + ", found " + found));


### PR DESCRIPTION
## Summary
- replace string concatenation with interpolated string in built-in exception provider

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68922e41e77c832ba1fc37217d83af16