### PR TITLE
fix(text): 🐛 include parameter name in TextColor parsing errors

### DIFF
--- a/src/Minecraft/Components/Text/Colors/TextColor.cs
+++ b/src/Minecraft/Components/Text/Colors/TextColor.cs
@@ -70,7 +70,7 @@ public record TextColor(byte Red, byte Green, byte Blue)
             }
             else
             {
-                throw new ArgumentException($"Invalid hex color string: {span}");
+                throw new ArgumentException($"Invalid hex color string: {span}", nameof(value));
             }
         }
 
@@ -82,7 +82,7 @@ public record TextColor(byte Red, byte Green, byte Blue)
             }
         }
 
-        throw new ArgumentException($"Invalid color string: {span}");
+        throw new ArgumentException($"Invalid color string: {span}", nameof(value));
     }
 
     public override string ToString() => Name;


### PR DESCRIPTION
## Summary
- use `nameof` for invalid color exceptions

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689238af130c832bb995f99b09d82a50