### PR TITLE
refactor(benchmarks): ♻️ use nameof in null check

### DIFF
--- a/src/Benchmarks/Streams/Compression.cs
+++ b/src/Benchmarks/Streams/Compression.cs
@@ -63,7 +63,7 @@ public class Compression
     public void IterationSetup()
     {
         var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException($"{nameof(_sharpZipLibStream.BaseStream)} is null."));
-        var ionicZlibMemoryStream = (MinecraftMemoryStream)(_ionicZlibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
+        var ionicZlibMemoryStream = (MinecraftMemoryStream)(_ionicZlibStream.BaseStream ?? throw new InvalidOperationException($"{nameof(_ionicZlibStream.BaseStream)} is null."));
 
         sharpZipLibMemoryStream.Reset(0);
         ionicZlibMemoryStream.Reset(0);


### PR DESCRIPTION
## Summary
- use nameof in null check

## Testing
- `dotnet build`
- `dotnet test` *(fails: no output, hung)*

------
https://chatgpt.com/codex/tasks/task_e_689238bbc150832bb2a6ef5e9e57fd6a