### PR TITLE
test(integration): 🐛 avoid redundant token source

### DIFF
--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -32,8 +32,7 @@ public class VoidProxy : IIntegrationSide
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken).Token;
+        cancellationToken = cancellationTokenSource.Token;
 
         var args = new List<string>
         {


### PR DESCRIPTION
## Summary
- avoid creating an unnecessary linked cancellation token source

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689238ac7ac4832bb443919bf9660690