### PR TITLE
style(brigadier): 🔤 correct constructor parameter casing

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Builder/LiteralArgumentBuilder.cs
+++ b/src/Minecraft/Commands/Brigadier/Builder/LiteralArgumentBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace Void.Minecraft.Commands.Brigadier.Builder;
 
-public class LiteralArgumentBuilder(string Literal) : ArgumentBuilder<LiteralArgumentBuilder, LiteralCommandNode>
+public class LiteralArgumentBuilder(string literal) : ArgumentBuilder<LiteralArgumentBuilder, LiteralCommandNode>
 {
     public static LiteralArgumentBuilder Create(string value)
     {
@@ -11,7 +11,7 @@ public class LiteralArgumentBuilder(string Literal) : ArgumentBuilder<LiteralArg
 
     public override LiteralCommandNode Build()
     {
-        var result = new LiteralCommandNode(Literal, Executor, Requirement, RedirectTarget, RedirectModifier, IsForks);
+        var result = new LiteralCommandNode(literal, Executor, Requirement, RedirectTarget, RedirectModifier, IsForks);
 
         foreach (var argument in Arguments)
             result.AddChild(argument);


### PR DESCRIPTION
## Summary
- fix parameter casing in `LiteralArgumentBuilder`

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689238a0d328832b98fe5731212ede6e