### PR TITLE
style(commands): 🎨 use nameof for source in error

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Context/CommandContextBuilder.cs
+++ b/src/Minecraft/Commands/Brigadier/Context/CommandContextBuilder.cs
@@ -95,7 +95,7 @@ public class CommandContextBuilder
     public CommandContext Build(string input)
     {
         if (Source is null)
-            throw new InvalidOperationException("Can't build command context without source");
+            throw new InvalidOperationException($"Can't build command context without {nameof(Source)}");
 
         return new(Source, input, Arguments, Command, RootNode, Nodes, Range, Child?.Build(input), RedirectModifier, IsFork);
     }


### PR DESCRIPTION
## Summary
- use `nameof` for Source in `CommandContextBuilder` error message

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68924365ee94832b88017f118c37c2b1