### PR TITLE
style(brigadier): 💄 replace string concatenation with interpolation

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
+++ b/src/Minecraft/Commands/Brigadier/Exceptions/BuiltInExceptions.cs
@@ -4,7 +4,7 @@ public class BuiltInExceptions : IBuiltInExceptionProvider
 {
     public Dynamic2CommandExceptionType DoubleTooSmall { get; } = new((found, min) => new LiteralMessage($"Double must not be less than {min}, found {found}"));
     public Dynamic2CommandExceptionType DoubleTooBig { get; } = new((found, max) => new LiteralMessage($"Double must not be more than {max}, found {found}"));
-    public Dynamic2CommandExceptionType FloatTooSmall { get; } = new((found, min) => new LiteralMessage("Float must not be less than " + min + ", found " + found));
+    public Dynamic2CommandExceptionType FloatTooSmall { get; } = new((found, min) => new LiteralMessage($"Float must not be less than {min}, found {found}"));
     public Dynamic2CommandExceptionType FloatTooBig { get; } = new((found, max) => new LiteralMessage("Float must not be more than " + max + ", found " + found));
     public Dynamic2CommandExceptionType IntegerTooSmall { get; } = new((found, min) => new LiteralMessage("Integer must not be less than " + min + ", found " + found));
     public Dynamic2CommandExceptionType IntegerTooBig { get; } = new((found, max) => new LiteralMessage("Integer must not be more than " + max + ", found " + found));


### PR DESCRIPTION
## Summary
- improve readability of `FloatTooSmall` exception message by using string interpolation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689243681958832bbdbadfb7ffb6df1a