### PR TITLE
style(platform): 💄 use nameof for start state validation

### DIFF
--- a/src/Platform/Links/Link.cs
+++ b/src/Platform/Links/Link.cs
@@ -67,7 +67,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
         cancellationToken.ThrowIfCancellationRequested();
 
         if (this is { _playerToServerTask: null } or { _serverToPlayerTask: null })
-            throw new InvalidOperationException("Link is not started");
+            throw new InvalidOperationException($"{nameof(Link)} is not started");
 
         await DisposeAsync();
     }


### PR DESCRIPTION
## Summary
- use `nameof` for link start validation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6892436a18b0832bb52cf2a86cb22101