### PR TITLE
fix(plugins): 🐛 correct remote plugin log message

### DIFF
--- a/src/Platform/Plugins/PluginService.cs
+++ b/src/Platform/Plugins/PluginService.cs
@@ -65,7 +65,7 @@ public class PluginService(ILogger<PluginService> logger, IEventService events, 
             else if (Uri.TryCreate(variable, UriKind.Absolute, out var url))
             {
                 var name = url.LocalPath;
-                logger.LogTrace("Found {Name} local plugin", name);
+                logger.LogTrace("Found {Name} remote plugin", name);
 
                 using var response = await httpClient.GetAsync(url);
                 await using var stream = response.Content.ReadAsStream();


### PR DESCRIPTION
## Summary
- correct remote plugin log message in PluginService

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6892436b8d60832baf4a172dfe9fd2bc