### PR TITLE
docs(nbt): 📝 clarify empty tag comment

### DIFF
--- a/src/Minecraft/Nbt/NbtReader.cs
+++ b/src/Minecraft/Nbt/NbtReader.cs
@@ -22,8 +22,8 @@ public class NbtReader(Stream stream, FormatOptions options, bool leaveOpen = fa
 
             var tag = ReadTag(tagType, named: true);
 
-            // 1.21.4 send empty string tag name with empty value for achievements
-            // 1.21.5 send new line characters in chat with empty tag name
+            // 1.21.4 sends empty string tag name with empty value for achievements
+            // 1.21.5 sends new line characters in chat with empty tag name
             if (string.IsNullOrWhiteSpace(tag.Name))
                 _tagNameField?.SetValue(tag, "text");
 


### PR DESCRIPTION
## Summary
- fix grammar in NBT reader comment about empty tag names

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689243811ec0832b917c641096e7871e