### PR TITLE
style(console): 🎨 use nameof for service name

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -32,7 +32,7 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
         }
 
         if (_reader is null)
-            throw new InvalidOperationException($"ConsoleService is not set up. Call {nameof(Setup)}() before using this method.");
+            throw new InvalidOperationException($"{nameof(ConsoleService)} is not set up. Call {nameof(Setup)}() before using this method.");
 
         var command = await _reader.ReadLineAsync(SuggestAsync, cancellationToken);
         logger.LogInformation("Proxy issued command: {command}", command);


### PR DESCRIPTION
## Summary
- replace hard-coded service name string in console guard with `nameof`

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6892438ef540832b9acd0510754d0c20