### PR TITLE
style(network): 🎨 correct cast exception message

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/IPacketProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/IPacketProperty.cs
@@ -10,7 +10,7 @@ public interface IPacketProperty
     public virtual TCastValue As<TCastValue>() where TCastValue : IPacketProperty
     {
         if (this is not TCastValue value)
-            throw new InvalidCastException($"Property value {this} cannot be casted to {typeof(TCastValue)}");
+            throw new InvalidCastException($"Property value {this} cannot be cast to {typeof(TCastValue)}");
 
         return value;
     }


### PR DESCRIPTION
## Summary
- fix typo in InvalidCastException message when casting packet property

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6892437e6c68832baa6da944e2feabef