### PR TITLE
refactor(benchmarks): ♻️ use nameof for stream null check

### DIFF
--- a/src/Benchmarks/Streams/Compression.cs
+++ b/src/Benchmarks/Streams/Compression.cs
@@ -91,7 +91,7 @@ public class Compression
     [Benchmark]
     public async ValueTask SharpZipLib_Read()
     {
-        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException("Base stream is null."));
+        var sharpZipLibMemoryStream = (MinecraftMemoryStream)(_sharpZipLibStream.BaseStream ?? throw new InvalidOperationException($"{nameof(_sharpZipLibStream.BaseStream)} is null."));
         sharpZipLibMemoryStream.Reset();
 
         for (var i = 0; i < IterationCount; i++)


### PR DESCRIPTION
## Summary
- use `nameof` for sharpZipLib stream null check

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6892439920cc832b84f43821e0f8a289