### PR TITLE
perf(nbt): ⚡ reuse buffer when creating NBT property

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/NbtProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/NbtProperty.cs
@@ -15,7 +15,7 @@ public record NbtProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<NbtPrope
         var buffer = new MinecraftBuffer(stream);
         buffer.WriteTag(value);
 
-        return new NbtProperty(stream.ToArray());
+        return new NbtProperty(stream.GetBuffer().AsMemory(0, (int)stream.Length));
     }
 
     public static NbtProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- reuse MemoryStream buffer when converting NBT tags to reduce allocations

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68925a99e138832b85d6b2243ff6eeb5