### PR TITLE
perf(network): ⚡️ avoid extra copy in LongProperty.FromPrimitive

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/LongProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/LongProperty.cs
@@ -9,12 +9,10 @@ public record LongProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<LongPro
 
     public static LongProperty FromPrimitive(long value)
     {
-        Span<byte> span = stackalloc byte[8];
+        var array = GC.AllocateUninitializedArray<byte>(8);
+        var span = array.AsSpan();
         var buffer = new MinecraftBuffer(span);
         buffer.WriteLong(value);
-
-        var array = GC.AllocateUninitializedArray<byte>(8);
-        span.CopyTo(array);
 
         return new LongProperty(array);
     }


### PR DESCRIPTION
## Summary
- avoid redundant stack allocation in LongProperty.FromPrimitive

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689261b779a0832b89a650c31036550a