### PR TITLE
perf(minecraft): ⚡ avoid substring allocation in ReadInt

### DIFF
--- a/src/Minecraft/Commands/Brigadier/StringReader.cs
+++ b/src/Minecraft/Commands/Brigadier/StringReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Void.Minecraft.Commands.Brigadier.Exceptions;
 
 namespace Void.Minecraft.Commands.Brigadier;
@@ -71,12 +72,12 @@ public class StringReader(string source, int cursor = 0) : IImmutableStringReade
         while (CanRead && IsAllowedNumber(Peek))
             Skip();
 
-        var number = Source[start..Cursor];
+        var span = Source.AsSpan(start, Cursor - start);
 
-        if (number.Length is 0)
+        if (span.Length is 0)
             throw CommandSyntaxException.BuiltInExceptions.ReaderExpectedInt.CreateWithContext(this);
 
-        if (int.TryParse(number, out var result))
+        if (int.TryParse(span, out var result))
             return result;
 
         Cursor = start;


### PR DESCRIPTION
## Summary
- use span for integer parsing to avoid substring allocation in `StringReader`

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689261b2c13c832bbc3cce908e0eaaf8