### PR TITLE
perf(minecraft): ⚡️ avoid MemoryStream when serializing float

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/FloatProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/FloatProperty.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Void.Minecraft.Buffers;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
@@ -10,11 +9,11 @@ public record FloatProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<FloatP
 
     public static FloatProperty FromPrimitive(float value)
     {
-        using var stream = new MemoryStream();
-        var buffer = new MinecraftBuffer(stream);
+        var bytes = new byte[4];
+        var buffer = new MinecraftBuffer(bytes);
         buffer.WriteFloat(value);
 
-        return new FloatProperty(stream.ToArray());
+        return new FloatProperty(bytes);
     }
 
     public static FloatProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- reduce allocations in FloatProperty by writing directly to a byte array

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689261af89e4832bb8d69e055ff6bab9