### PR TITLE
perf(nbt): ⚡ avoid TrimStart allocation

### DIFF
--- a/src/Minecraft/Nbt/NbtTag.cs
+++ b/src/Minecraft/Nbt/NbtTag.cs
@@ -86,11 +86,11 @@ public abstract record NbtTag
 
     public static NbtTag Parse(string data)
     {
-        var trimmed = data.TrimStart();
+        ReadOnlySpan<char> span = data.AsSpan().TrimStart();
 
-        if (trimmed.StartsWith('{'))
+        if (!span.IsEmpty && span[0] == '{')
             return StringNbt.Parse(data);
-        else if (trimmed.StartsWith('['))
+        else if (!span.IsEmpty && span[0] == '[')
             return StringNbt.ParseList(data);
         else
             throw new FormatException($"Only NbtCompound and NbtList can be parsed from Snbt. Provided value: {data}");


### PR DESCRIPTION
## Summary
- refactor NbtTag.Parse to use ReadOnlySpan<char> and avoid allocating a trimmed string

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689261bda8b4832bab0827df9353a6cb