### PR TITLE
ci(workflows): 🤖 restrict auto approvals to contributors

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -20,7 +20,7 @@ jobs:
   merge:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association) }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- limit auto-approval to PR authors recognized as repository contributors

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893e3bf380c832bbb5a15239adb2854