### PR TITLE
perf(transformations): ♻️ avoid stream allocation in short property serialization

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/ShortProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/ShortProperty.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.Buffers.Binary;
 using Void.Minecraft.Buffers;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
@@ -10,11 +10,10 @@ public record ShortProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<ShortP
 
     public static ShortProperty FromPrimitive(short value)
     {
-        using var stream = new MemoryStream();
-        var buffer = new MinecraftBuffer(stream);
-        buffer.WriteShort(value);
+        Span<byte> bytes = stackalloc byte[sizeof(short)];
+        BinaryPrimitives.WriteInt16BigEndian(bytes, value);
 
-        return new ShortProperty(stream.ToArray());
+        return new ShortProperty(bytes.ToArray());
     }
 
     public static ShortProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- refactor ShortProperty primitive conversion to use stackalloc and BinaryPrimitives

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689572d2f28c832b84097ac05a0d3924