### PR TITLE
perf(buffers): ♻️ remove UUID int array allocation

### DIFF
--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -418,7 +418,8 @@ internal ref struct MinecraftBackingBuffer
 
     public void WriteUuidAsIntArray(Uuid value)
     {
-        var span = value.AsGuid.ToByteArray(true).AsSpan();
+        Span<byte> span = stackalloc byte[16];
+        _ = value.AsGuid.TryWriteBytes(span, bigEndian: true, out _);
 
         WriteInt(BinaryPrimitives.ReadInt32BigEndian(span[..4]));
         WriteInt(BinaryPrimitives.ReadInt32BigEndian(span[4..8]));


### PR DESCRIPTION
## Summary
- avoid heap allocation when writing UUID as int array

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689572b7f394832b995e44a4662d424d