### PR TITLE
perf(registries): ⚡ use stackalloc for short property

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/ShortProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/ShortProperty.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Void.Minecraft.Buffers;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
@@ -10,11 +9,11 @@ public record ShortProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<ShortP
 
     public static ShortProperty FromPrimitive(short value)
     {
-        using var stream = new MemoryStream();
-        var buffer = new MinecraftBuffer(stream);
+        Span<byte> bytes = stackalloc byte[2];
+        var buffer = new MinecraftBuffer(bytes);
         buffer.WriteShort(value);
 
-        return new ShortProperty(stream.ToArray());
+        return new ShortProperty(bytes.ToArray());
     }
 
     public static ShortProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- refactor ShortProperty construction to use stackalloc buffer

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689572b53784832bb59dbcb685a1b957