### PR TITLE
perf(minecraft): ♻️ use stackalloc for bool property serialization

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/BoolProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/BoolProperty.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Void.Minecraft.Buffers;
 
 namespace Void.Minecraft.Network.Registries.Transformations.Properties;
@@ -10,11 +9,11 @@ public record BoolProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<BoolPro
 
     public static BoolProperty FromPrimitive(bool value)
     {
-        using var stream = new MemoryStream();
-        var buffer = new MinecraftBuffer(stream);
+        Span<byte> data = stackalloc byte[1];
+        var buffer = new MinecraftBuffer(data);
         buffer.WriteBoolean(value);
 
-        return new BoolProperty(stream.ToArray());
+        return new BoolProperty(data.ToArray());
     }
 
     public static BoolProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- use stackalloc to serialize boolean packet property without intermediate stream

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689572d7c4a8832b86f84a5ed766d075