### PR TITLE
docs(astro): 📝 hide header on article pages

### DIFF
--- a/docs/astro/src/pages/articles/[slug].astro
+++ b/docs/astro/src/pages/articles/[slug].astro
@@ -15,5 +15,8 @@ const { Content, headings } = await article.render();
 ---
 
 <StarlightPage frontmatter={article.data} headings={headings}>
+  <style is:global>
+    header { display: none; }
+  </style>
   <Content />
 </StarlightPage>


### PR DESCRIPTION
## Summary
- hide header on articles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: connect ENETUNREACH 140.82.114.5:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898e0766f34832b98b5586319d18ec8