### PR TITLE
docs(articles): 📝 hide sidebar on article pages and restore header

### DIFF
--- a/docs/astro/src/pages/articles/[slug].astro
+++ b/docs/astro/src/pages/articles/[slug].astro
@@ -14,9 +14,6 @@ const { article } = Astro.props;
 const { Content, headings } = await article.render();
 ---
 
-<StarlightPage frontmatter={article.data} headings={headings}>
-  <style is:global>
-    header { display: none; }
-  </style>
+<StarlightPage frontmatter={{ ...article.data, sidebar: false }} headings={headings}>
   <Content />
 </StarlightPage>


### PR DESCRIPTION
## Summary
- show site header on article pages
- hide sidebar on articles for wider reading view

## Testing
- `npm run build` *(fails: connect ENETUNREACH 140.82.114.5:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898e6284fa0832ba1acdbba846523ff