### PR TITLE
docs(astro): 📝 hide article sidebar with splash template

### DIFF
--- a/docs/astro/src/pages/articles/[slug].astro
+++ b/docs/astro/src/pages/articles/[slug].astro
@@ -14,6 +14,6 @@ const { article } = Astro.props;
 const { Content, headings } = await article.render();
 ---
 
-<StarlightPage frontmatter={{ ...article.data, sidebar: false }} headings={headings}>
+<StarlightPage frontmatter={{ ...article.data, template: 'splash' }} headings={headings}>
   <Content />
 </StarlightPage>


### PR DESCRIPTION
## Summary
- render article pages with `splash` template to avoid sidebar

## Testing
- `dotnet build`
- `dotnet test`
- `npm run build` *(fails: connect ENETUNREACH 140.82.114.6:443)*

------
https://chatgpt.com/codex/tasks/task_e_6898eaa99f08832b988f6e68351a3b59