### PR TITLE
docs(articles): 📝 lower search priority for article pages

### DIFF
--- a/docs/astro/src/pages/articles/[slug].astro
+++ b/docs/astro/src/pages/articles/[slug].astro
@@ -14,6 +14,6 @@ const { article } = Astro.props;
 const { Content, headings } = await article.render();
 ---
 
-<StarlightPage frontmatter={{ ...article.data, template: 'splash', pagefind: { weight: 0.5 } }} headings={headings}>
+<StarlightPage frontmatter={{ ...article.data, template: 'splash' }} pagefind={{ weight: 0.2 }} headings={headings}>
   <Content />
 </StarlightPage>


### PR DESCRIPTION
## Summary
- limit article search weighting to reduce priority

## Testing
- `dotnet build`
- `dotnet test`
- `npm run build` *(fails: connect ENETUNREACH 140.82.113.5:443)*

------
https://chatgpt.com/codex/tasks/task_e_6898fb4ac008832ba111ef81dc1dd572