### PR TITLE
docs(articles): 📝 render author and publication date

### DIFF
--- a/docs/astro/src/pages/articles/[slug].astro
+++ b/docs/astro/src/pages/articles/[slug].astro
@@ -12,8 +12,10 @@ export async function getStaticPaths() {
 
 const { article } = Astro.props;
 const { Content, headings } = await article.render();
+const formattedPubDate = article.data.pubDate.toLocaleDateString();
 ---
 
 <StarlightPage frontmatter={{ ...article.data, template: 'splash' }} pagefind={{ weight: 0.2 }} headings={headings}>
+  <p>{article.data.author} — <time datetime={article.data.pubDate.toISOString()}>{formattedPubDate}</time></p>
   <Content />
 </StarlightPage>


### PR DESCRIPTION
## Summary
- show author and publication date at the top of article pages

## Testing
- `dotnet build`
- `dotnet test`
- `npm --prefix docs/astro run build` *(fails: fetch failed, connect ENETUNREACH 140.82.113.5:443)*

------
https://chatgpt.com/codex/tasks/task_e_6898ffb37c04832b90d7bf768afb0136