### PR TITLE
docs(astro): 📝 use custom LastUpdated component

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -253,6 +253,9 @@ export default defineConfig({
             baseUrl: 'https://github.com/caunt/void/edit/main/docs/astro'
         },
         lastUpdated: true,
+        components: {
+            LastUpdated: './src/components/LastUpdated.astro'
+        },
         expressiveCode: {
             themes: [ExpressiveCodeTheme.fromJSONString(fs.readFileSync(new URL(`./themes/visual-studio-2019-dark.jsonc`, import.meta.url), 'utf-8'))],
             tabWidth: 4


### PR DESCRIPTION
## Summary
- use custom LastUpdated component for docs

## Testing
- `npm -C docs/astro run build` *(fails: connect ENETUNREACH 140.82.113.6:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68990ab6f7c4832b9906b76b237caa27