### PR TITLE
docs(astro): 📝 restore sitemap lastmod entries

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -270,9 +270,14 @@ export default defineConfig({
         changefreq: 'daily',
         priority: 1,
         serialize(item) {
-            const lastmod = routeLastmod.get(new URL(item.url).pathname)
-            if (lastmod) item.lastmod = lastmod
-            return item
+            const pathname = new URL(item.url).pathname;
+            const lookup = pathname.endsWith('/') ? pathname : pathname + '/';
+            const lastmod = routeLastmod.get(lookup);
+
+            if (lastmod)
+                item.lastmod = lastmod.toISOString();
+
+            return item;
         }
     })]
 });


### PR DESCRIPTION
## Summary
- add trailing-slash lookup for git-based lastmod dates
- serialize lastmod values to ISO strings for sitemap

## Testing
- `dotnet build`
- `dotnet test`
- `npm run build` *(fails: connect ENETUNREACH 140.82.112.5:443)*

------
https://chatgpt.com/codex/tasks/task_e_68990e55d284832bac4702cab15d533f