### PR TITLE
docs(astro): 📝 fix LastUpdated component to show commit info

### DIFF
--- a/docs/astro/src/components/LastUpdated.astro
+++ b/docs/astro/src/components/LastUpdated.astro
@@ -5,7 +5,7 @@ const { lang, entry } = Astro.locals.starlightRoute;
 let commit;
 if (entry?.filePath) {
     try {
-        const result = execSync(`git log -1 --format=%h|%H|%an|%cI ${entry.filePath}`).toString().trim();
+        const result = execSync(`git log -1 --format='%h|%H|%an|%cI' -- "${entry.filePath}"`).toString().trim();
         const [shortHash, fullHash, author, isoDate] = result.split('|');
         commit = { shortHash, fullHash, author, date: new Date(isoDate), iso: isoDate };
     } catch {}


### PR DESCRIPTION
## Summary
- escape pipe separators in LastUpdated component's git command so commit metadata displays

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68990f434924832b96cef84b3b3b5c2c