### PR TITLE
docs(astro): 🐛 include lastmod for all sitemap entries

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -19,7 +19,11 @@ const routeLastmod = new Map()
 function collect(dir, route = '') {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.isDirectory()) {
-            collect(path.join(dir, entry.name), path.posix.join(route, entry.name))
+            const nextRoute = route === '' && entry.name === 'docs'
+                ? route
+                : path.posix.join(route, entry.name)
+
+            collect(path.join(dir, entry.name), nextRoute)
         } else if (entry.isFile() && /\.mdx?$/.test(entry.name)) {
             try {
                 const iso = execSync(`git log -1 --format=%cI "${path.join(dir, entry.name)}"`).toString().trim()


### PR DESCRIPTION
## Summary
- ensure sitemap generation records last modified dates for docs pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: connect ENETUNREACH 140.82.112.6:443)*

------
https://chatgpt.com/codex/tasks/task_e_68991715ad54832bb64772f5f67bbed0