### PR TITLE
docs(astro): 📝 normalize file path in LastUpdated component

### DIFF
--- a/docs/astro/src/components/LastUpdated.astro
+++ b/docs/astro/src/components/LastUpdated.astro
@@ -7,7 +7,10 @@ const { lang, entry } = Astro.locals.starlightRoute;
 let commit;
 if (entry?.filePath) {
     try {
-        const filePath = relative(process.cwd(), fileURLToPath(entry.filePath));
+        let path = entry.filePath;
+        if (path.startsWith('file:'))
+            path = fileURLToPath(path);
+        const filePath = relative(process.cwd(), path);
         const result = execSync(`git log -1 --format='%h|%H|%an|%cI' -- "${filePath}"`).toString().trim();
         const [shortHash, fullHash, author, isoDate] = result.split('|');
         commit = { shortHash, fullHash, author, date: new Date(isoDate), iso: isoDate };


### PR DESCRIPTION
## Summary
- resolve missing last updated date by normalizing file paths before calling git

## Testing
- `npm run build` *(fails: connect ENETUNREACH 140.82.114.6:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68991ad6aff8832ba69bc40b5f6a343e