### PR TITLE
docs(astro): 📝 fix content path resolution

### DIFF
--- a/docs/astro/last-updated.js
+++ b/docs/astro/last-updated.js
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-const contentRoot = fileURLToPath(new URL('./src/content', import.meta.url));
+const contentRoot = path.join(process.cwd(), 'src', 'content');
 export const routeLastmod = new Map();
 
 function collect(dir, route = '') {


### PR DESCRIPTION
## Summary
- resolve docs content path from working directory to prevent missing folder errors

## Testing
- `npm --prefix docs/astro run build` *(fails: connect ENETUNREACH 140.82.113.5:443 - Local (0.0.0.0:0))*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689935ed42d4832bb737612b9766d415