### PR TITLE
chore(astro): resolve content path in last-updated.js

### DIFF
--- a/docs/astro/last-updated.js
+++ b/docs/astro/last-updated.js
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const contentRoot = path.join(process.cwd(), 'src', 'content');
+const contentRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), 'src', 'content');
 export const routeLastmod = new Map();
 
 function collect(dir, route = '') {


### PR DESCRIPTION
## Summary
- resolve docs content path using `import.meta.url`
- normalize CRLF line endings in `last-updated.js`

## Testing
- `node -e "import('./docs/astro/last-updated.js').then(m=>console.log(Array.from(m.routeLastmod.entries()).slice(0,3)))"`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68995f736270832ba37dfbaaa26bd5aa