### PR TITLE
build(docs): 🏗️ resolve content root for last updated script

### DIFF
--- a/docs/astro/last-updated.js
+++ b/docs/astro/last-updated.js
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const contentRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), 'src', 'content');
+const contentRoot = path.resolve(process.cwd(), 'src', 'content');
 export const routeLastmod = new Map();
 
 function collect(dir, route = '') {


### PR DESCRIPTION
## Summary
- resolve last updated content root using current working directory to avoid missing directory

## Testing
- `npm ci`
- `npm run build` *(fails: connect ENETUNREACH 140.82.113.5:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689967b197ec832ba12fd994179db821