### PR TITLE
chore(docs): 🧹 remove try-catch to surface last-updated errors

### DIFF
--- a/docs/astro/last-updated.js
+++ b/docs/astro/last-updated.js
@@ -22,14 +22,9 @@ function collect(dir, route = '') {
             const lookup = name === 'index' ? route : path.posix.join(route, name);
             const urlPath = lookup ? '/' + lookup + '/' : '/';
 
-            try {
-                const result = execSync(`git log -1 --format='%h|%H|%an|%cI' -- "${fullPath}"`, { cwd: repoRoot }).toString().trim();
-                const [shortHash, fullHash, author, isoDate] = result.split('|');
-                routeLastmod.set(urlPath, { shortHash, fullHash, author, date: new Date(isoDate), iso: isoDate });
-            } catch {
-                const { mtime } = fs.statSync(fullPath);
-                routeLastmod.set(urlPath, { shortHash: '', fullHash: '', author: '', date: mtime, iso: mtime.toISOString() });
-            }
+            const result = execSync(`git log -1 --format='%h|%H|%an|%cI' -- "${fullPath}"`, { cwd: repoRoot }).toString().trim();
+            const [shortHash, fullHash, author, isoDate] = result.split('|');
+            routeLastmod.set(urlPath, { shortHash, fullHash, author, date: new Date(isoDate), iso: isoDate });
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow `last-updated.js` to throw when git lookups fail instead of swallowing errors

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899ea5bc3bc832b84e531cc6e2a872a