### PR TITLE
build(docs): 🛠️ fix last-updated path resolution

### DIFF
--- a/docs/astro/last-updated.js
+++ b/docs/astro/last-updated.js
@@ -1,11 +1,9 @@
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '..', '..');
-const contentRoot = path.join(__dirname, 'src', 'content');
+const repoRoot = path.resolve(process.cwd(), '..', '..');
+const contentRoot = path.resolve(process.cwd(), 'src', 'content');
 export const routeLastmod = new Map();
 
 function collect(dir, route = '') {


### PR DESCRIPTION
## Summary
- fix last-updated script to resolve paths from working directory

## Testing
- `npm run build` *(fails: connect ENETUNREACH 140.82.113.6:443)*
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899ec87bfd4832b84cb06c0148c7596