### PR TITLE
docs(links): 🔗 prefix internal docs links with root path

### DIFF
--- a/docs/astro/src/content/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/configuration/in-file.md
@@ -40,7 +40,7 @@ Servers = [
 ```
 
 ## Watchdog
-[**Watchdog**](/watchdog) is a built-in HTTP server that allows you to check status or control the proxy.
+[**Watchdog**](/docs/watchdog) is a built-in HTTP server that allows you to check status or control the proxy.
 
 ```toml
 // configs/Watchdog/Settings.toml
@@ -58,7 +58,7 @@ Port = 80
 Forwarding helps to forward player data (IP, UUID, Skin, etc.) to the backend server.
 
 ### Modern (Velocity)
-Read more in [**Modern (Velocity)**](/forwardings/modern) forwarding.
+Read more in [**Modern (Velocity)**](/docs/forwardings/modern) forwarding.
 
 ```toml
 // configs/Velocity/Settings.toml
@@ -72,11 +72,11 @@ Secret = "YourSecretKeyHere"
 ## Plugins Installation
 
 Plugins are compiled with the *.dll extension in any .NET compatible language.
-See the [**Plugin Development Kit**](/developing-plugins/development-kit) section for more details.
+See the [**Plugin Development Kit**](/docs/developing-plugins/development-kit) section for more details.
 
 - Directory `plugins` is the default location for plugins.
-- [**Environment variable**](/configuration/environment-variables) `VOID_PLUGINS` might be used to include URLs or Local Paths to plugins, separated by comma or semicolon.
-- [**Program argument**](/configuration/program-arguments) `--plugin` (short `-p`) might be used to include URL or Local Path to plugin.
+- [**Environment variable**](/docs/configuration/environment-variables) `VOID_PLUGINS` might be used to include URLs or Local Paths to plugins, separated by comma or semicolon.
+- [**Program argument**](/docs/configuration/program-arguments) `--plugin` (short `-p`) might be used to include URL or Local Path to plugin.
 
 Examples:
 ```bash

--- a/docs/astro/src/content/docs/containers.md
+++ b/docs/astro/src/content/docs/containers.md
@@ -8,7 +8,7 @@ sidebar:
 Void provides docker images for running in a container.
 See the [Void Docker Hub](https://hub.docker.com/r/caunt/void/tags) for all available images.
 
-For running Void directly on your host, refer to the [Running](/getting-started/running/) guide.
+For running Void directly on your host, refer to the [Running](/docs/getting-started/running/) guide.
 
 ## Running Void in a Docker
 To run Void in a Docker container, use following example command:
@@ -16,7 +16,7 @@ To run Void in a Docker container, use following example command:
 docker run --name void --network host --pull=always --rm caunt/void:dev
 ```
 
-You can pass additional [program arguments](/configuration/program-arguments/) to customize servers and network settings:
+You can pass additional [program arguments](/docs/configuration/program-arguments/) to customize servers and network settings:
 
 ```bash
 docker run --name void --network host --pull=always --rm caunt/void:dev \
@@ -68,7 +68,7 @@ spec:
 ```
 
 ## Configuring Void in Containers
-Use [**environment variables**](/configuration/environment-variables/) or [**mount volumes**](/configuration/in-file/) to configure Void.
+Use [**environment variables**](/docs/configuration/environment-variables/) or [**mount volumes**](/docs/configuration/in-file/) to configure Void.
 
 
 ## Image Tags

--- a/docs/astro/src/content/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/links.md
@@ -36,5 +36,5 @@ public void OnCreateLink(CreateLinkEvent @event)
 }
 ```
 
-The job of an [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) implementation is to forward [**packets (messages)**](/developing-plugins/network/packets) from the player channel to the server channel and vice versa.
+The job of an [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) implementation is to forward [**packets (messages)**](/docs/developing-plugins/network/packets) from the player channel to the server channel and vice versa.
 If you want to replace the default implementation, follow [**this example**](https://github.com/caunt/Void/blob/main/src/Platform/Links/Link.cs).

--- a/docs/astro/src/content/docs/developing-plugins/network/modifying-data.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/modifying-data.md
@@ -5,18 +5,18 @@ sidebar:
   order: 2
 ---
 
-After you have [**defined your packets**](/developing-plugins/network/packets), you can modify, cancel or build and send them manually.
+After you have [**defined your packets**](/docs/developing-plugins/network/packets), you can modify, cancel or build and send them manually.
 
 :::note
-Void allows modifying packets in-place only for [**ILink**](/developing-plugins/network/links) implementer.
+Void allows modifying packets in-place only for [**ILink**](/docs/developing-plugins/network/links) implementer.
 
-However, you can still manipulate [**packets**](/developing-plugins/network/packets) by canceling them and sending a modified copy manually.
+However, you can still manipulate [**packets**](/docs/developing-plugins/network/packets) by canceling them and sending a modified copy manually.
 In this page, we will proceed with this approach.
 :::
 
 ## Modifying Packets
 You can modify packets by canceling them and sending a modified copy manually.
-We will use previously defined [**Set Held Item (clientbound)**](/developing-plugins/network/packets#defining-packets) packet as an example.
+We will use previously defined [**Set Held Item (clientbound)**](/docs/developing-plugins/network/packets#defining-packets) packet as an example.
 ```csharp
 [Subscribe]
 public async ValueTask OnMessageReceived(MessageReceivedEvent @event, CancellationToken cancellationToken)
@@ -36,5 +36,5 @@ public async ValueTask OnMessageReceived(MessageReceivedEvent @event, Cancellati
 ```
 
 :::caution
-Changes to the packet properties are ignored by internal [**ILink**](/developing-plugins/network/links) implementation, always ensure to call `Cancel()` and `SendPacketAsync()` to apply your changes.
+Changes to the packet properties are ignored by internal [**ILink**](/docs/developing-plugins/network/links) implementation, always ensure to call `Cancel()` and `SendPacketAsync()` to apply your changes.
 :::

--- a/docs/astro/src/content/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/packets.md
@@ -73,7 +73,7 @@ So the 0x4F packet id for `ProtocolVersion.MINECRAFT_1_20_2` means that this pac
 :::
 
 ## Receiving Packets
-Now that we have defined our packet, we can receive it with `MessageReceivedEvent` [**event**](/developing-plugins/events/listening-to-events/).
+Now that we have defined our packet, we can receive it with `MessageReceivedEvent` [**event**](/docs/developing-plugins/events/listening-to-events/).
 ```csharp
 [Subscribe]
 public void OnMessageReceived(MessageReceivedEvent @event)
@@ -105,7 +105,7 @@ public void OnMessageSent(MessageSentEvent @event)
 There are 3 ways to send packets in Void:
 - Directly to the `IPlayer` instance
 - To the `INetworkChannel` of server or player 
-- To the [**`ILink`**](/developing-plugins/network/links) connection between the server and player
+- To the [**`ILink`**](/docs/developing-plugins/network/links) connection between the server and player
 
 ### Sending Packets to the Player
 You can send packets to the player with `SendPacketAsync` method on `IPlayer` instance.
@@ -119,9 +119,9 @@ You can send packets to the server with `ILink.ServerChannel` instance.
 await player.GetLink().ServerChannel.SendPacketAsync(new SetHeldItemClientboundPacket { Slot = slot }, cancellationToken);
 ```
 
-### Sending Packets to the [**`ILink`**](/developing-plugins/network/links)
+### Sending Packets to the [**`ILink`**](/docs/developing-plugins/network/links)
 You can send packets to the link with `ILink.SendPacketAsync` method.
-[**`ILink`**](/developing-plugins/network/links) will automatically determine the destination of the packet based on the packet interface.  
+[**`ILink`**](/docs/developing-plugins/network/links) will automatically determine the destination of the packet based on the packet interface.  
 - If the packet has `IMinecraftClientboundPacket<TPacket>` interface, it will be sent to the client.
 - If the packet has `IMinecraftServerboundPacket<TPacket>` interface, it will be sent to the server.
 - If the packet has both interfaces, it will be sent only to the client.

--- a/docs/astro/src/content/docs/developing-plugins/network/transformations.md
+++ b/docs/astro/src/content/docs/developing-plugins/network/transformations.md
@@ -20,7 +20,7 @@ Instead, use transformations explained below.
 ## Conditional packet transformations
 Conditional packet transformations are the simplest way to handle changes, but they can become messy if the packet changes frequently.
 
-We will use previously defined [**Set Held Item (clientbound)**](/developing-plugins/network/packets#defining-packets) packet as an example.
+We will use previously defined [**Set Held Item (clientbound)**](/docs/developing-plugins/network/packets#defining-packets) packet as an example.
 In this packet, changes were made from Minecraft version **1.21** to **1.21.2**.
 In version **1.21**, the slot was defined as `byte`, but in version **1.21.2** it was changed to `varint`.
 ```csharp
@@ -95,7 +95,7 @@ public class SetHeldItemClientboundPacket : IMinecraftClientboundPacket<SetHeldI
 
 Now when we have latest implementation, we have to define changes that were made throughout the versions.
 
-In case of [**Set Held Item (clientbound)**](/developing-plugins/network/packets#defining-packets) packet, just one change was made - `slot` property type changed from `byte` to `varint`.
+In case of [**Set Held Item (clientbound)**](/docs/developing-plugins/network/packets#defining-packets) packet, just one change was made - `slot` property type changed from `byte` to `varint`.
 ```csharp
 MinecraftPacketTransformationMapping[] Transformations { get; } = [
     new(ProtocolVersion.MINECRAFT_1_21, ProtocolVersion.MINECRAFT_1_21_2, wrapper =>
@@ -140,7 +140,7 @@ public void OnPhaseChanged(PhaseChangedEvent @event)
 }
 ```
 
-Now the Void proxy can use your defined transformations to transform packets to version that is used by the player. If player is playing on version **1.21**, proxy will upgrade packet to your latest (**1.21.2**) version and pass it to the [**Events System**](/developing-plugins/events/listening-to-events/). When plugin is sending packet to the player playing old version, proxy will downgrade packet to **1.21** and send it to the player.
+Now the Void proxy can use your defined transformations to transform packets to version that is used by the player. If player is playing on version **1.21**, proxy will upgrade packet to your latest (**1.21.2**) version and pass it to the [**Events System**](/docs/developing-plugins/events/listening-to-events/). When plugin is sending packet to the player playing old version, proxy will downgrade packet to **1.21** and send it to the player.
 
 :::tip
 Keep defining flat transformations from one version to another when packet is changing. You have to **define only changed versions** and **skip versions without changes**. When `slot` property will be changed by Mojang to `long` type, define another two transformations - **upgrading** and **downgrading**. Reading `varint` / writing `long` for upgrade, and reading `long` / writing `varint` for downgrade.

--- a/docs/astro/src/content/docs/developing-plugins/serializers.md
+++ b/docs/astro/src/content/docs/developing-plugins/serializers.md
@@ -6,20 +6,20 @@ description: Learn about serializers in Void.
 Serializers are used to convert structured data between different formats. 
 
 ## Text Components
-Prefer using [**`Serialize` methods**](/developing-plugins/text-formatting/#converting-components) on `Component` for serialization.
+Prefer using [**`Serialize` methods**](/docs/developing-plugins/text-formatting/#converting-components) on `Component` for serialization.
 - `ComponentJsonSerializer` 
-  - Converts **[Text Component](/developing-plugins/text-formatting) to Json** or **Json to [Text Component](/developing-plugins/text-formatting)**.
+  - Converts **[Text Component](/docs/developing-plugins/text-formatting) to Json** or **Json to [Text Component](/docs/developing-plugins/text-formatting)**.
 - `ComponentLegacySerializer` 
-  - Converts **[Text Component](/developing-plugins/text-formatting) to [Legacy string](/developing-plugins/text-formatting#formatting-codes)** or **[Legacy string](/developing-plugins/text-formatting#formatting-codes) to [Text Component](/developing-plugins/text-formatting)**.
+  - Converts **[Text Component](/docs/developing-plugins/text-formatting) to [Legacy string](/docs/developing-plugins/text-formatting#formatting-codes)** or **[Legacy string](/docs/developing-plugins/text-formatting#formatting-codes) to [Text Component](/docs/developing-plugins/text-formatting)**.
 - `ComponentNbtSerializer` 
-  - Converts **[Text Component](/developing-plugins/text-formatting) to [Nbt](/developing-plugins/nbt)** or **[Nbt](/developing-plugins/nbt) to [Text Component](/developing-plugins/text-formatting)**.
+  - Converts **[Text Component](/docs/developing-plugins/text-formatting) to [Nbt](/docs/developing-plugins/nbt)** or **[Nbt](/docs/developing-plugins/nbt) to [Text Component](/docs/developing-plugins/text-formatting)**.
 
 ## NBT
 Helpful to convert Json or Snbt to Nbt and vice versa.  
 - `NbtJsonSerializer` 
-  - Converts **[Nbt](/developing-plugins/nbt) to Json** or **Json to [Nbt](/developing-plugins/nbt)**.
+  - Converts **[Nbt](/docs/developing-plugins/nbt) to Json** or **Json to [Nbt](/docs/developing-plugins/nbt)**.
 - `NbtStringSerializer` - 
-  - Converts **[Nbt](/developing-plugins/nbt) to [Snbt](/developing-plugins/nbt/#snbt)** or **[Snbt](/developing-plugins/nbt/#snbt) to [Nbt](/developing-plugins/nbt)**.
+  - Converts **[Nbt](/docs/developing-plugins/nbt) to [Snbt](/docs/developing-plugins/nbt/#snbt)** or **[Snbt](/docs/developing-plugins/nbt/#snbt) to [Nbt](/docs/developing-plugins/nbt)**.
 
 :::caution[Prefer deserializing from Snbt]
 Json is not recommended because its properties' type conversion is guessed by bounds of the value.  

--- a/docs/astro/src/content/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/developing-plugins/services/creating-a-service.md
@@ -71,9 +71,9 @@ public class ExampleScopedService(
 ## Lifetimes
 Services in the DI container can have different lifetimes, which determine how long they persist and how often they are created. These lifetimes are:
 
-1. [**Singleton**](/developing-plugins/services/singleton): A single instance is created and shared throughout the application.
-2. [**Scoped**](/developing-plugins/services/scoped): An instance is created once per player.
-3. [**Transient**](/developing-plugins/services/transient): A new instance is provided every time it is requested.
+1. [**Singleton**](/docs/developing-plugins/services/singleton): A single instance is created and shared throughout the application.
+2. [**Scoped**](/docs/developing-plugins/services/scoped): An instance is created once per player.
+3. [**Transient**](/docs/developing-plugins/services/transient): A new instance is provided every time it is requested.
 
 See the detailed description of each lifetime in the [**Microsoft Documentation**](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#service-lifetimes).
 

--- a/docs/astro/src/content/docs/forwardings/forwarding-overview.md
+++ b/docs/astro/src/content/docs/forwardings/forwarding-overview.md
@@ -12,12 +12,12 @@ Without any forwarding enabled, the server will use player's offline UUID, name 
 
 ## Legacy (BungeeCord)
 One of the oldest forwarding modes, developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).  
-Learn how to configure it in the [**Legacy forwarding**](/forwardings/legacy) page.
+Learn how to configure it in the [**Legacy forwarding**](/docs/forwardings/legacy) page.
 
 ## Modern (Velocity)
 Next generation of forwarding, developed by [PaperMC](https://docs.papermc.io/velocity/player-information-forwarding/).  
-Learn how to configure it in the [**Modern forwarding**](/forwardings/modern) page.
+Learn how to configure it in the [**Modern forwarding**](/docs/forwardings/modern) page.
 
 ## Online (Private Key)
 The newest forwarding mode, being developed by [Void](https://github.com/caunt/Void).  
-Learn how to configure it in the [**Online forwarding**](/forwardings/online) page.
+Learn how to configure it in the [**Online forwarding**](/docs/forwardings/online) page.

--- a/docs/astro/src/content/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/forwardings/modern.md
@@ -24,4 +24,4 @@ Velocity forwarding is not supported by mod loaders, however community has creat
 
 ## Configuration
 To configure the Velocity forwarding, you need to set up 'Secret' key on both proxy and servers sides.
-Check the [**In-file configuration**](/configuration/in-file/#modern-velocity) for more details.
+Check the [**In-file configuration**](/docs/configuration/in-file/#modern-velocity) for more details.

--- a/docs/astro/src/content/docs/getting-started/features.md
+++ b/docs/astro/src/content/docs/getting-started/features.md
@@ -31,13 +31,13 @@ Here's a quick look at what the Void proxy already supports and what's planned f
 ### Forwardings
 | Forwarding                                                  | Supported | WIP      |
 | :---------------------------------------------------------- | :------:  | :------: |
-| [**None (Offline)**](/forwardings/forwarding-overview)      | &#x2705;  | &#x2705; |
-| [**Legacy (Bungee)**](/forwardings/legacy)                  | &#x274C;  | &#x2705; |
-| [**Modern (Velocity)**](/forwardings/modern)                | &#x2705;  | &#x2705; |
-| [**Online (PK)**](/forwardings/online)                      | &#x2705;  | &#x2705; |
+| [**None (Offline)**](/docs/forwardings/forwarding-overview)      | &#x2705;  | &#x2705; |
+| [**Legacy (Bungee)**](/docs/forwardings/legacy)                  | &#x274C;  | &#x2705; |
+| [**Modern (Velocity)**](/docs/forwardings/modern)                | &#x2705;  | &#x2705; |
+| [**Online (PK)**](/docs/forwardings/online)                      | &#x2705;  | &#x2705; |
 
 :::tip[Online (Private Key)]
-Online (Private Key) is a new [**forwarding**](/forwardings/online) method.
+Online (Private Key) is a new [**forwarding**](/docs/forwardings/online) method.
 It lets you connect to servers using online mode.
 The server securely shares its private key so the proxy can expose an API to plugins.
 Without the key you can still play, but plugin features are limited.

--- a/docs/astro/src/content/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/getting-started/running.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 ## Download
-Download [**latest version here**](/download).
+Download [**latest version here**](/docs/download).
 
 ## Linux
 
@@ -22,7 +22,7 @@ Run the executable
 
 ## Docker
 
-Prefer containers? See the [Containers](/containers/) guide for Docker and Kubernetes deployments.
+Prefer containers? See the [Containers](/docs/containers/) guide for Docker and Kubernetes deployments.
 
 ## Android
 

--- a/docs/astro/src/content/docs/index.mdx
+++ b/docs/astro/src/content/docs/index.mdx
@@ -12,10 +12,10 @@ hero:
     alt: Void logo
   actions:
     - text: Run the Void
-      link: /getting-started/running
+      link: /docs/getting-started/running
       icon: right-arrow
     - text: Develop Plugins
-      link: /developing-plugins/development-kit
+      link: /docs/developing-plugins/development-kit
       icon: document
       variant: minimal
 ---
@@ -24,7 +24,7 @@ import { Card, LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Download" icon="cloud-download">
-                [**Download Void**](/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, macOS and more.
+                [**Download Void**](/docs/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, macOS and more.
 	</Card>
 	<Card title="Build Plugins" icon="pencil">
 		Void provides a powerful plugin API that allows you to create plugins on the raw network level.
@@ -33,6 +33,6 @@ import { Card, LinkCard, CardGrid } from '@astrojs/starlight/components';
 		Designed to support any Minecraft platforms, including Bedrock, Java, Pocket Edition and more.
 	</Card>
 	<Card title="Containers" icon="seti:docker">
-		Built with [Containers in mind](/containers), easy to deploy to Docker or Kubernetes cluster.
+		Built with [Containers in mind](/docs/containers), easy to deploy to Docker or Kubernetes cluster.
 	</Card>
 </CardGrid>

--- a/docs/astro/src/content/docs/watchdog.md
+++ b/docs/astro/src/content/docs/watchdog.md
@@ -7,7 +7,7 @@ The Watchdog feature in Void is designed to monitor the health of the Void Proxy
 This is particularly useful for long-running processes or when running Void in a production environment.
 
 ## Enable Watchdog
-Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/configuration/in-file#watchdog) to `true`.
+Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`.
 
 ## Health Check
 `/health` endpoint is used to check the health of the Void Proxy.


### PR DESCRIPTION
## Summary
- fix internal doc links to reference `/docs/` root paths

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a624925b0832b9cc9dbd90b089358