### PR TITLE
docs(articles): 📄 use splash template without pagefind for docker article

### DIFF
--- a/docs/astro/src/content/docs/articles/void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/void-minecraft-proxy-docker.md
@@ -3,6 +3,8 @@ title: How to Set Up Void Minecraft Proxy in Docker for Modded & Vanilla Servers
 description: Learn how to run the Void Minecraft Proxy in Docker with a clean, fast setup for both modded and vanilla servers, plus tips for plugins, forwarding, and smooth production use.
 author: Vitalii Kotenko
 pubDate: 2025-08-10
+template: splash
+pagefind: false
 ---
 
 # Setting up Minecraft Proxy — Void (In Docker)


### PR DESCRIPTION
## Summary
- use `splash` template for Docker setup article
- disable pagefind indexing for the article

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a7c48af50832bb344ad178f652ebb