### PR TITLE
docs: 📝 fix download links

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/docs/getting-started/running.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 ## Download
-Download [**latest version here**](/docs/download).
+Download [**latest version here**](/download).
 
 ## Linux
 

--- a/docs/astro/src/content/docs/index.mdx
+++ b/docs/astro/src/content/docs/index.mdx
@@ -24,7 +24,7 @@ import { Card, LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Download" icon="cloud-download">
-                [**Download Void**](/docs/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, macOS and more.
+                [**Download Void**](/download). Available for many platforms, including Kubernetes, Docker, Windows, Linux, macOS and more.
 	</Card>
 	<Card title="Build Plugins" icon="pencil">
 		Void provides a powerful plugin API that allows you to create plugins on the raw network level.


### PR DESCRIPTION
## Summary
- remove `/docs` prefix from download links

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a85381870832bb8c16857adb73d8c