### PR TITLE
docs(configuration): 📝 fix article in server argument description

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -54,7 +54,7 @@ Options:
 
 ## Servers
 - `--server`  
-  Registers an server in format `<host>:<port>` where port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
+  Registers a server in format `<host>:<port>` where the port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
 - `--ignore-file-servers`  
   Ignore servers specified in configuration files.
 


### PR DESCRIPTION
## Summary
- fix typo in server registration description

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a90691ba0832b9f5882c2b36714f2