### PR TITLE
docs(astro): ✏️ fix command suggestion typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/commands.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/commands.md
@@ -3,7 +3,7 @@ title: Commands
 description: Learn how to define and listen to commands.
 ---
 
-Commands help user or administrator to interact with the proxy and plugins. 
+Commands help users and administrators interact with the proxy and plugins.
 
 ## Defining a command
 Inject `ICommandService` service to begin working with commands.  
@@ -59,7 +59,7 @@ class MyService(ICommandService commands) : ICommandSource
     public async ValueTask SuggestCommandAsync(CancellationToken cancellationToken)
     {
         ICommandSource commandSource = this;
-        string command = "hel";
+        string command = "he";
         
         var variants = await commands.CompleteAsync(command, commandSource, cancellationToken);
         // variants value is string[] { "hello" }


### PR DESCRIPTION
## Summary
- clarify commands documentation wording
- correct command completion example

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a906632d4832b8035b5f0127d72b1