### PR TITLE
docs(astro): 📝 fix grammar in command example

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/commands.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/commands.md
@@ -120,7 +120,7 @@ class MyService(ICommandService commands)
     {
         if (context.Source is not IPlayer player)
         {
-            logger.LogInformation("This command can be executed only by player");
+            logger.LogInformation("This command can be executed only by a player");
             return 1;
         }
 


### PR DESCRIPTION
## Summary
- fix grammar in command example within Astro docs

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a905f4978832bad7fa994cec0a180