### PR TITLE
perf(minecraft): ⚡ avoid array copy when serializing NBT property

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/NamedNbtProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/NamedNbtProperty.cs
@@ -17,7 +17,7 @@ public record NamedNbtProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<Nam
         var buffer = new MinecraftBuffer(stream);
         buffer.WriteTag(value);
 
-        return new NamedNbtProperty(stream.ToArray());
+        return new NamedNbtProperty(stream.GetBuffer().AsMemory(0, (int)stream.Length));
     }
 
     public static NamedNbtProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- avoid array copy when serializing NamedNbtProperty

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a884497a4832bb79363719dd5b21a