### PR TITLE
perf(minecraft): ⚡ avoid array copy when creating BinaryProperty from stream

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/BinaryProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/BinaryProperty.cs
@@ -10,6 +10,9 @@ public record BinaryProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<Binar
 
     public static BinaryProperty FromStream(MemoryStream value)
     {
+        if (value.TryGetBuffer(out var segment))
+            return new BinaryProperty(segment.AsMemory());
+
         return new BinaryProperty(value.ToArray());
     }
 


### PR DESCRIPTION
## Summary
- avoid array copy when creating BinaryProperty from stream

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a8839dfe0832b876c11e64619101f