### PR TITLE
perf(network): ♻️ avoid extra allocation in StringProperty

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/StringProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/StringProperty.cs
@@ -14,7 +14,7 @@ public record StringProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<Strin
         var buffer = new MinecraftBuffer(stream);
         buffer.WriteString(value);
 
-        return new StringProperty(stream.ToArray());
+        return new StringProperty(stream.GetBuffer().AsMemory(0, (int)stream.Length));
     }
 
     public static StringProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
- avoid extra array copy when building `StringProperty`

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a88359268832b89b9ecd2be2768fb