### PR TITLE
fix(auth): 🐛 correct typo in server authentication comment

### DIFF
--- a/src/Plugins/Common/Services/Authentication/AbstractAuthenticationService.cs
+++ b/src/Plugins/Common/Services/Authentication/AbstractAuthenticationService.cs
@@ -116,7 +116,7 @@ public abstract class AbstractAuthenticationService(IEventService events, IPlaye
         if (!link.Player.IsMinecraft)
             return AuthenticationResult.Authenticated;
 
-        // Server channel might be closed very early, skip authentication, ILink should stop itself as soon as its executes
+        // Server channel might be closed very early, skip authentication, ILink should stop itself as soon as it executes
         if (!link.ServerChannel.IsAlive)
             return AuthenticationResult.Authenticated;
 


### PR DESCRIPTION
## Summary
- fix typo in server authentication comment

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689aacb0ca9c832b883c53d0976b1b47