### PR TITLE
fix(example-plugin): 📝 correct plugin load comment typos

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
@@ -31,7 +31,7 @@ public class MyPlugin(IConfigurationService configs) : IPlugin
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except ours
+        // Skip all other plugin load events except ours
         if (@event.Plugin != this)
             return;
         

--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -28,7 +28,7 @@ public class MyPlugin(IDependencyService dependencies) : IPlugin
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except ours
+        // Skip all other plugin load events except ours
         if (@event.Plugin != this)
             return;
 

--- a/docs/astro/src/content/docs/docs/developing-plugins/services/singleton.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/singleton.md
@@ -26,7 +26,7 @@ public class MyPlugin(IDependencyService dependencies) : IPlugin
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except ours
+        // Skip all other plugin load events except ours
         if (@event.Plugin != this)
             return;
 

--- a/docs/astro/src/content/docs/docs/developing-plugins/services/transient.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/transient.md
@@ -26,7 +26,7 @@ public class MyPlugin(IDependencyService dependencies) : IPlugin
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except ours
+        // Skip all other plugin load events except ours
         if (@event.Plugin != this)
             return;
 

--- a/src/Plugins/ExamplePlugin/ExamplePlugin.cs
+++ b/src/Plugins/ExamplePlugin/ExamplePlugin.cs
@@ -21,7 +21,7 @@ public class ExamplePlugin(ILogger logger, IDependencyService dependencies) : IP
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except our plugin
+        // Skip all other plugin load events except our plugin
         if (@event.Plugin != this)
             return;
 

--- a/src/Plugins/ExamplePlugin/Services/ChatService.cs
+++ b/src/Plugins/ExamplePlugin/Services/ChatService.cs
@@ -64,7 +64,7 @@ public class ChatService(ILogger<ChatService> logger, IConfigurationService conf
     {
         // This event is fired when any plugin is being loaded
 
-        // Skip all other plugins load events except our plugin
+        // Skip all other plugin load events except our plugin
         if (@event.Plugin != this)
             return;
 


### PR DESCRIPTION
## Summary
- correct "plugins load events" phrasing in example plugin code
- update documentation snippets to use correct wording

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689aacabffd4832b8f0f2eaa60763ba2