### PR TITLE
docs(exampleplugin): 📝 fix typo in chat command message

### DIFF
--- a/src/Plugins/ExamplePlugin/Services/ChatService.cs
+++ b/src/Plugins/ExamplePlugin/Services/ChatService.cs
@@ -82,7 +82,7 @@ public class ChatService(ILogger<ChatService> logger, IConfigurationService conf
             // Commands might be triggered by console, plugins, players, or anything
             if (context.Source is not IPlayer player)
             {
-                logger.LogInformation("This command can be executed only by player");
+                logger.LogInformation("This command can be executed only by a player");
                 return 1;
             }
 


### PR DESCRIPTION
## Summary
- correct grammar in ChatService log message

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689aaca81f3c832b868835ae947996fb