### PR TITLE
perf(platform): ⚡ adopt ZLinq enumerables

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -12,6 +12,7 @@ using Void.Proxy.Api.Players.Extensions;
 using Void.Proxy.Api.Plugins.Dependencies;
 using Void.Proxy.Api.Settings;
 using Void.Proxy.Players.Extensions;
+using ZLinq;
 
 namespace Void.Proxy.Players;
 
@@ -20,7 +21,7 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     private readonly AsyncLock _lock = new();
     private readonly List<PlayerProxy> _players = [];
 
-    public IEnumerable<IPlayer> All => _players.Select(proxy => proxy.Source);
+    public IEnumerable<IPlayer> All => _players.AsValueEnumerable().Select(proxy => proxy.Source).ToArray();
 
     public void ForEach(Action<IPlayer> action)
     {

--- a/src/Platform/Plugins/Containers/WeakPluginContainer.cs
+++ b/src/Platform/Plugins/Containers/WeakPluginContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Void.Proxy.Api.Plugins;
 using Void.Proxy.Plugins.Context;
+using ZLinq;
 
 namespace Void.Proxy.Plugins.Containers;
 
@@ -17,7 +18,7 @@ public class WeakPluginContainer
     public WeakPluginContainer(PluginAssemblyLoadContext context, params IPlugin[] plugins)
     {
         Context = context;
-        _references = [.. plugins.Select(plugin => new WeakReference<IPlugin>(plugin, true))];
+        _references = [.. plugins.AsValueEnumerable().Select(plugin => new WeakReference<IPlugin>(plugin, true))];
     }
 
     public void Add(IPlugin plugin)

--- a/src/Platform/Plugins/Dependencies/DependencyService.cs
+++ b/src/Platform/Plugins/Dependencies/DependencyService.cs
@@ -11,6 +11,7 @@ using Void.Proxy.Api.Plugins;
 using Void.Proxy.Api.Plugins.Dependencies;
 using Void.Proxy.Plugins.Dependencies.Extensions;
 using Void.Proxy.Utils;
+using ZLinq;
 
 namespace Void.Proxy.Plugins.Dependencies;
 
@@ -31,7 +32,10 @@ public class DependencyService(ILogger<DependencyService> logger, IContainer con
         var assembly = @event.Plugin.GetType().Assembly;
 
         var events = container.GetRequiredService<IEventService>();
-        events.UnregisterListeners(events.Listeners.Where(listener => listener.GetType().Assembly == assembly));
+        var listeners = events.Listeners.AsValueEnumerable()
+            .Where(listener => listener.GetType().Assembly == assembly)
+            .ToArray();
+        events.UnregisterListeners(listeners);
 
         if (_assemblyContainers.Remove(assembly, out var pluginContainer))
         {

--- a/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
+++ b/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
@@ -14,6 +14,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Void.Proxy.Api.Plugins.Dependencies;
+using ZLinq;
 
 namespace Void.Proxy.Plugins.Dependencies.Nuget;
 
@@ -104,7 +105,7 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
                 return null;
             }
 
-            var identities = availableVersions.Select(version => new PackageIdentity(assemblyName.Name, NuGetVersion.Parse(version)));
+            var identities = availableVersions.AsValueEnumerable().Select(version => new PackageIdentity(assemblyName.Name, NuGetVersion.Parse(version))).ToArray();
             var identity = SelectBestNuGetPackageVersion(identities, assemblyName.Version);
 
             if (identity == null)
@@ -143,7 +144,10 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
     {
         try
         {
-            var environmentVariableRepositories = UnescapedSemicolonRegex().Split(Environment.GetEnvironmentVariable("VOID_NUGET_REPOSITORIES") ?? "").Select(repo => repo.Replace(@"\;", ";"));
+            var environmentVariableRepositories = UnescapedSemicolonRegex().Split(Environment.GetEnvironmentVariable("VOID_NUGET_REPOSITORIES") ?? "")
+                .AsValueEnumerable()
+                .Select(repo => repo.Replace(@"\;", ";"))
+                .ToArray();
             var repositories = environmentVariableRepositories.Concat(_repositories.Concat(context.ParseResult.GetValueForOption(_repositoriesOption) ?? []))
                 .Select(source =>
                 {
@@ -261,7 +265,7 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
             return null;
 
         var packages = await GetNuGetPackageVersionAsync(repository, assemblyName.Name, cancellationToken);
-        var best = SelectBestNuGetPackageVersion(packages.Select(package => package.Identity), assemblyName.Version);
+        var best = SelectBestNuGetPackageVersion(packages.AsValueEnumerable().Select(package => package.Identity).ToArray(), assemblyName.Version);
 
         return best;
     }
@@ -275,7 +279,7 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
         foreach (var packageSearchResult in packageSearchResults)
         {
             var packages = await GetNuGetPackageVersionAsync(repository, packageSearchResult.Identity.Id, cancellationToken);
-            var best = SelectBestNuGetPackageVersion(packages.Select(package => package.Identity), assemblyName.Version);
+            var best = SelectBestNuGetPackageVersion(packages.AsValueEnumerable().Select(package => package.Identity).ToArray(), assemblyName.Version);
 
             return best;
         }


### PR DESCRIPTION
## Summary
- refactor plugin container and player service to enumerate with ZLinq
- use ZLinq in configuration and dependency resolution paths

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b9f9608e8832ba42889cb102e03ff