### PR TITLE
docs: 📝 capitalize Docker in containers guide

### DIFF
--- a/docs/astro/src/content/docs/docs/containers.md
+++ b/docs/astro/src/content/docs/docs/containers.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Void provides docker images for running in a container.
+Void provides Docker images for running in a container.
 See the [Void Docker Hub](https://hub.docker.com/r/caunt/void/tags) for all available images.
 
 For running Void directly on your host, refer to the [Running](/docs/getting-started/running/) guide.


### PR DESCRIPTION
## Summary
- capitalize Docker brand name in container instructions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689baa802468832b91b537f985a3afdd