### PR TITLE
perf(forwarding-support): ♻️ avoid split allocation

### DIFF
--- a/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
+++ b/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
@@ -52,7 +52,11 @@ public class ForwardingService(IPlayerContext context, ILogger logger, Settings 
         var buffer = new BufferSpan(stackalloc byte[2048]);
 
         buffer.WriteVarInt((int)actualVersion);
-        buffer.WriteString(context.Player.RemoteEndPoint.Split(':')[0]);
+
+        var remoteEndPoint = context.Player.RemoteEndPoint.AsSpan();
+        var colonIndex = remoteEndPoint.IndexOf(':');
+
+        buffer.WriteString((colonIndex >= 0 ? remoteEndPoint[..colonIndex] : remoteEndPoint).ToString());
 
         if (context.Player.Profile is not { } profile)
         {


### PR DESCRIPTION
## Summary
- avoid array allocation when parsing remote endpoint in Velocity forwarding service

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689bac32c5ec832bb66c00d3ba6aca88