### PR TITLE
perf(minecraft): ♻️ avoid substring allocation in literal command node

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Tree/Nodes/LiteralCommandNode.cs
+++ b/src/Minecraft/Commands/Brigadier/Tree/Nodes/LiteralCommandNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Void.Minecraft.Commands.Brigadier.Builder;
@@ -61,7 +62,7 @@ public class LiteralCommandNode(string literal, CommandExecutor? executor, Comma
         {
             var end = start + Literal.Length;
 
-            if (reader.Source[start..end] == Literal)
+            if (reader.Source.AsSpan(start, Literal.Length).Equals(Literal, StringComparison.Ordinal))
             {
                 reader.Cursor = end;
 


### PR DESCRIPTION
## Summary
- use span-based comparison in LiteralCommandNode to avoid substring allocation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689bac258a90832ba44c640aab555962