### PR TITLE
docs(agents): 📝 add pull request formatting template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,33 @@ Follow the existing C# style rules:
 - Use the `fix` or `feat` type only when your changes modify the proxy code in `./src`. For documentation, CI, or other unrelated updates, choose a more appropriate type such as `docs` or `chore`.
 - Append a [gitmoji](https://gitmoji.dev/specification) after the commit scope, e.g., `feat(api): ✨ add new endpoint`.
 - Pull request titles should follow the same Conventional Commits format.
+- Pull request descriptions must use the following template:
+
+  ```
+  ## Summary
+  One-sentence problem and outcome.
+
+  ## Rationale
+  Why this is needed; alternatives considered briefly.
+
+  ## Changes
+  Concise, high-signal description of what changed.
+
+  ## Verification
+  How it was tested; include commands or steps.
+
+  ## Performance
+  Before/after numbers if relevant; memory/alloc notes.
+
+  ## Risks & Rollback
+  Known risks, how to revert safely.
+
+  ## Breaking/Migration
+  Required actions for users, if any.
+
+  ## Links
+  Issues, discussions, specs.
+  ```
 - Never modify `CHANGELOG.md`; it is generated automatically by `release-please` from commit history.
 
 ## Protocol guidance


### PR DESCRIPTION
## Summary
Add standardized pull request description template to AGENTS.md.

## Rationale
Ensures contributors document pull requests consistently; freeform descriptions hindered review.

## Changes
- Document required pull request template in AGENTS.md.

## Verification
- `dotnet test`
- `dotnet build`

## Performance
No impact; documentation only.

## Risks & Rollback
Low risk; revert commit if guidance is not desired.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bb0296fcc832b949937ba70f659be