### PR TITLE
perf(buffers): ⚡ accept ReadOnlySpan<char> in WriteString

### DIFF
--- a/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
+++ b/src/Minecraft/Buffers/Extensions/WriteMinecraftBufferExtensions.cs
@@ -161,8 +161,8 @@ public static class WriteMinecraftBufferExtensions
     /// </summary>
     /// <typeparam name="TBuffer">This type parameter represents a structure that implements a specific buffer interface for Minecraft.</typeparam>
     /// <param name="buffer">This parameter is a reference to the buffer where the string will be written.</param>
-    /// <param name="value">This parameter is the string that will be written to the buffer.</param>
-    public static void WriteString<TBuffer>(ref this TBuffer buffer, string value)
+    /// <param name="value">The characters that will be written to the buffer.</param>
+    public static void WriteString<TBuffer>(ref this TBuffer buffer, ReadOnlySpan<char> value)
         where TBuffer : struct, IMinecraftBuffer<TBuffer>,
         allows ref struct =>
         WriteStringCore(ref buffer, value);
@@ -292,7 +292,7 @@ public static class WriteMinecraftBufferExtensions
         buffer.WriteInt(BinaryPrimitives.ReadInt32BigEndian(span[12..16]));
     }
 
-    private static void WriteStringCore<TBuffer>(ref TBuffer buffer, string value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct
+    private static void WriteStringCore<TBuffer>(ref TBuffer buffer, ReadOnlySpan<char> value) where TBuffer : struct, IMinecraftBuffer<TBuffer>, allows ref struct
     {
         var byteCount = Encoding.UTF8.GetByteCount(value);
         Span<byte> bytes = stackalloc byte[byteCount];

--- a/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBackingBuffer.cs
@@ -440,7 +440,7 @@ internal ref struct MinecraftBackingBuffer
         return value;
     }
 
-    public void WriteString(string value)
+    public void WriteString(ReadOnlySpan<char> value)
     {
         var length = Encoding.UTF8.GetByteCount(value);
         WriteVarInt(length);

--- a/src/Minecraft/Buffers/MinecraftBuffer.cs
+++ b/src/Minecraft/Buffers/MinecraftBuffer.cs
@@ -179,7 +179,7 @@ public ref struct MinecraftBuffer
         return _backingBuffer.ReadString(maxLength);
     }
 
-    public void WriteString(string value)
+    public void WriteString(ReadOnlySpan<char> value)
     {
         _backingBuffer.WriteString(value);
     }


### PR DESCRIPTION
## Summary
Switch string-based WriteString methods to ReadOnlySpan<char> to reduce allocations.

## Rationale
Span-based overloads avoid unnecessary string allocations while keeping existing call sites compatible.

## Changes
- Accept ReadOnlySpan<char> in WriteString extensions
- Accept ReadOnlySpan<char> in MinecraftBuffer
- Accept ReadOnlySpan<char> in MinecraftBackingBuffer

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No explicit measurements, but reduced allocations expected when writing from spans.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
No breaking changes; existing string call sites still work via implicit conversion.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bb3f3e518832bb7ee93af72d4af54