### PR TITLE
docs(modifying-data): ✏️ fix pluralization for implementers

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/modifying-data.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/modifying-data.md
@@ -8,7 +8,7 @@ sidebar:
 After you have [**defined your packets**](/docs/developing-plugins/network/packets), you can modify, cancel or build and send them manually.
 
 :::note
-Void allows modifying packets in-place only for [**ILink**](/docs/developing-plugins/network/links) implementer.
+Void allows modifying packets in-place only for [**ILink**](/docs/developing-plugins/network/links) implementers.
 
 However, you can still manipulate [**packets**](/docs/developing-plugins/network/packets) by canceling them and sending a modified copy manually.
 In this page, we will proceed with this approach.


### PR DESCRIPTION
## Summary
Correct pluralization in network modification docs.

## Rationale
Improves clarity and professionalism for developers.

## Changes
- Reworded networking documentation to use plural "implementers".

## Verification
- `dotnet test` *(hangs: process terminated after extended wait)*

## Performance
N/A

## Risks & Rollback
Low; revert commit.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bb8afc724832bb5ec3f33e91feaa5