### PR TITLE
docs(environment-variables): 📝 correct pluralization in plugin variable description

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/docs/configuration/environment-variables.md
@@ -10,7 +10,7 @@ However, they might be used from the terminal directly as well.
 
 ## Plugins
 - `VOID_PLUGINS`
-  Defines the list of URL's or Path's to load plugins from.  
+  Defines the list of URLs or paths to load plugins from.
   Example: `https://example.org/download/YourPlugin1.dll;/home/YourPlugin2.dll`
  
 ## NuGet


### PR DESCRIPTION
## Summary
Fixes pluralization typo in documentation of plugin environment variable.

## Rationale
Ensures documentation uses correct grammar for clarity.

## Changes
- correct `URL's or Path's` to `URLs or paths` in `VOID_PLUGINS` description.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_689bb8b6633c832b90d0f3f56adc7fda