### PR TITLE
docs(events): 📝 refine player events wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
@@ -3,9 +3,9 @@ title: Player Events
 description: Learn types of Player Events.
 ---
 
-Very first event that is triggered when a player connects to the server.  
-It is used to create a new player instance and set up the player context with scoped services.  
-Do not change `Result` property of this event, until you are very sure what you are doing.  
+The very first event that is triggered when a player connects to the server.
+It is used to create a new player instance and set up the player context with scoped services.
+Do not change the `Result` property of this event until you are very sure what you are doing.
 You can use this event to modify the player instance implementation.
 ```csharp
 class PlayerConnectingEvent(TcpClient Client, Func<IPlayer, IServiceProvider> GetServices) : IEventWithResult<IPlayer>;
@@ -21,9 +21,9 @@ Tells when a player is disconnected from the proxy.
 class PlayerDisconnectedEvent(IPlayer Player) : IScopedEvent;
 ```
 
-Triggers protocol plugins to send `Disconnect` packet to the client.  
-Property `Result` tells whether the packet was sent successfully.  
-Do not change `Result` property of this event, until you are very sure what you are doing.
+Triggers protocol plugins to send the `Disconnect` packet to the client.
+Property `Result` tells whether the packet was sent successfully.
+Do not change the `Result` property of this event until you are very sure what you are doing.
 ```csharp
 class PlayerKickEvent(IPlayer Player, string? Text = null) : IScopedEventWithResult<bool>;
 ```


### PR DESCRIPTION
## Summary
Clarifies grammar in player event documentation.

## Rationale
Improves readability for developers integrating player events.

## Changes
- Refine wording and punctuation in player events doc

## Verification
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Minimal risk; revert commit if needed.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bb8bbf73c832bb7c79146ad53c2d3