### PR TITLE
docs(running): 📝 clarify platform binary instructions

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/docs/getting-started/running.md
@@ -28,15 +28,15 @@ Prefer containers? See the [Containers](/docs/containers/) guide for Docker and 
 
 Run the [**Termux**](https://play.google.com/store/apps/details?id=com.termux) or any other terminal emulator.
 
-Follow instructions for Linux, but use "bionic" version of binary.
+Follow the instructions for Linux, but use the "bionic" version of the binary.
 
 ## Alpine
 
-Follow instructions for Linux, but use "musl" version of binary.
+Follow the instructions for Linux, but use the "musl" version of the binary.
 
 ## macOS
 
-Follow instructions for Linux, but use "osx" version of binary.
+Follow the instructions for Linux, but use the "osx" version of the binary.
 
 ## Windows
 


### PR DESCRIPTION
## Summary
Clarifies platform-specific binary instructions in the running guide.

## Rationale
Improves documentation clarity so users choose the correct binaries for their platforms.

## Changes
- Clarified wording around using the appropriate binary per platform in the running guide.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bb8b24d9c832bafbb257afa317036