### PR TITLE
perf(minecraft): ♻️ use stackalloc for VarLongProperty

### DIFF
--- a/src/Minecraft/Network/Registries/Transformations/Properties/VarLongProperty.cs
+++ b/src/Minecraft/Network/Registries/Transformations/Properties/VarLongProperty.cs
@@ -10,11 +10,11 @@ public record VarLongProperty(ReadOnlyMemory<byte> Value) : IPacketProperty<VarL
 
     public static VarLongProperty FromPrimitive(long value)
     {
-        using var stream = new MemoryStream();
-        var buffer = new MinecraftBuffer(stream);
+        Span<byte> bytes = stackalloc byte[10];
+        var buffer = new MinecraftBuffer(bytes);
         buffer.WriteVarLong(value);
 
-        return new VarLongProperty(stream.ToArray());
+        return new VarLongProperty(bytes[..(int)buffer.Position].ToArray());
     }
 
     public static VarLongProperty Read(ref MinecraftBuffer buffer)


### PR DESCRIPTION
## Summary
Avoid temporary stream allocation when encoding VarLong values.

## Rationale
Reduces heap allocations by using stack memory for varlong serialization.

## Changes
- Use `stackalloc` for `VarLongProperty` serialization.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Eliminates an extra `MemoryStream` allocation during varlong encoding.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
No breaking changes.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bb9a675a4832bb4e1639e93816dfe