### PR TITLE
perf(minecraft): ♻️ avoid StartsWith for color parsing

### DIFF
--- a/src/Minecraft/Components/Text/Colors/TextShadowColor.cs
+++ b/src/Minecraft/Components/Text/Colors/TextShadowColor.cs
@@ -21,7 +21,7 @@ public record TextShadowColor(byte Alpha, byte Red, byte Green, byte Blue)
     public static TextShadowColor FromString(string value)
     {
         var span = value.AsSpan();
-        if (value.StartsWith('#') && value.Length == 9)
+        if (span.Length == 9 && span[0] == '#')
         {
             if (byte.TryParse(span[1..3], NumberStyles.HexNumber, null, out var red) && byte.TryParse(span[3..5], NumberStyles.HexNumber, null, out var green) && byte.TryParse(span[5..7], NumberStyles.HexNumber, null, out var blue) && byte.TryParse(span[7..9], NumberStyles.HexNumber, null, out var alpha))
             {


### PR DESCRIPTION
## Summary
Streamline `TextShadowColor` parsing by removing string-based prefix checks.

## Rationale
Avoids extra string operations when validating color strings.

## Changes
- Use span length and first-character check instead of `StartsWith`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Removes a string method call during color parsing.

## Risks & Rollback
Low risk; revert commit if color parsing regresses.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689bb9b374b4832baaed8e248528df26