### PR TITLE
perf(components): ⚡ avoid params allocation in legacy serializer

### DIFF
--- a/src/Minecraft/Components/Text/Serializers/ComponentLegacySerializer.cs
+++ b/src/Minecraft/Components/Text/Serializers/ComponentLegacySerializer.cs
@@ -39,7 +39,7 @@ public static class ComponentLegacySerializer
                 KeybindContent content => content.Value,
                 SelectorContent content => content.Value,
                 TranslatableContent content => content.Translate, // skipped child component
-                ScoreContent content => string.Join(':', [content.Name, content.Objective]),
+                ScoreContent content => string.Concat(content.Name, ":", content.Objective),
                 NbtContent content => string.Join(':', [content.Source, content.Path, content.Interpret, content.Block, content.Entity, content.Storage]),  // skipped child component
                 var content => content.ToString()
             };


### PR DESCRIPTION
## Summary
Reduce allocation when serializing score content.

## Rationale
Eliminates an intermediate array created by `string.Join`, lowering overhead.

## Changes
- Avoid params array in `ComponentLegacySerializer` score serialization.

## Verification
- `dotnet build`
- `dotnet test` *(terminated: Build failed with 1 warning(s) in 41.5s)*

## Performance
Removes a small allocation during legacy text serialization.

## Risks & Rollback
Low risk; revert commit if unexpected serialization issues arise.

## Breaking/Migration
No breaking changes.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689bb9b5c8f4832b95a7772562ed20b5