### PR TITLE
perf(plugins): ⚡ use span copy for IV rotation

### DIFF
--- a/src/Plugins/Common/Network/Streams/Encryption/AesCfb8BufferedStream.cs
+++ b/src/Plugins/Common/Network/Streams/Encryption/AesCfb8BufferedStream.cs
@@ -254,7 +254,7 @@ public class AesCfb8BufferedStream : RecyclableStream, IBufferedMessageStream
             var current = (byte)(buffer[0] ^ input[idx]);
             output[idx] = current;
 
-            Buffer.BlockCopy(_writeStreamIv, 1, _writeStreamIv, 0, BlockSize - 1);
+            _writeStreamIv.AsSpan(1, BlockSize - 1).CopyTo(_writeStreamIv);
             _writeStreamIv[BlockSize - 1] = current;
         }
     }
@@ -269,7 +269,7 @@ public class AesCfb8BufferedStream : RecyclableStream, IBufferedMessageStream
             var current = (byte)(buffer[0] ^ input[idx]);
             output[idx] = current;
 
-            Buffer.BlockCopy(_readStreamIv, 1, _readStreamIv, 0, BlockSize - 1);
+            _readStreamIv.AsSpan(1, BlockSize - 1).CopyTo(_readStreamIv);
             _readStreamIv[BlockSize - 1] = input[idx];
         }
     }


### PR DESCRIPTION
## Summary
Improve encryption stream IV shifting efficiency.

## Rationale
Span-based copy avoids array-specific helpers and reduces overhead compared to `Buffer.BlockCopy`.

## Changes
- Switch `Buffer.BlockCopy` calls to `Span` slicing with `CopyTo` for IV rotation.

## Verification
- `dotnet build Void.slnx` *(fails: element <Solution> unrecognized)*
- `dotnet test` *(fails: specify a project or solution file)*

## Performance
No benchmarks run; change removes an array helper call per byte during encryption/decryption.

## Risks & Rollback
Low risk; revert commit to restore `Buffer.BlockCopy` usage.

## Breaking/Migration
None.

## Links
- n/a

------
https://chatgpt.com/codex/tasks/task_e_689bb9bfa924832b8fdd9714c5a5c4d6