### PR TITLE
docs(containers): 📝 correct offline mode description

### DIFF
--- a/docs/astro/src/content/docs/docs/containers.md
+++ b/docs/astro/src/content/docs/docs/containers.md
@@ -27,7 +27,7 @@ docker run --name void --network host --pull=always --rm caunt/void:dev \
 ```
 
 :::tip[Offline Mode]
-Add `--offline` to allow players to connect without Mojang authorization.
+Add `--offline` to allow players to connect without Mojang authentication.
 :::
 
 ## Running Void in Kubernetes


### PR DESCRIPTION
## Summary
Corrects offline mode tip to use "authentication" instead of "authorization".

## Rationale
Uses the accurate term for Mojang login checks, improving clarity.

## Changes
- Replace "authorization" with "authentication" in the containers guide.

## Verification
- `dotnet test` *(hangs after starting tests)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_689bc08d2880832bb2f8968f4806ae8d