### PR TITLE
docs(scoped-service): 📝 fix comment typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -100,7 +100,7 @@ public class PlayerPositionService(IPlayerContext context) : IEventListener
     [Subscribe]
     public void OnMessageReceived(MessageReceivedEvent @event)
     {
-        // This code is pure example.
+        // This code is a pure example.
         // If you need player positions, make sure to implement this packet yourself.
 
         if (@event.Message is not PlayerPositionPacket packet)


### PR DESCRIPTION
## Summary
Corrects a minor typo in the scoped service documentation.

## Rationale
Improves clarity by fixing a grammatical mistake in example code comments; no alternative was necessary.

## Changes
- Replace "This code is pure example" with "This code is a pure example" in scoped service docs.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bc0892698832b9a17deb72a33bca1