### PR TITLE
docs(configuration): ✏️ fix runtime wording in file configuration docs

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 File configurations are the main way of configuration.
-However many options can be overridden in runtime using the API in Plugins.
+However, many options can be overridden at runtime using the API in plugins.
 
 ## Proxy
 


### PR DESCRIPTION
## Summary
Clarify runtime wording in the in-file configuration guide.

## Rationale
Improves documentation accuracy; no alternatives considered.

## Changes
- Replace "in runtime" with "at runtime" for clearer phrasing.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to rollback.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bc08711cc832b9e25148415b0b94f