### PR TITLE
docs(program-arguments): 📝 remove redundant --logging example

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -79,9 +79,8 @@ Options:
   ```
 
 ## Logging
-- `--logging`  
+- `--logging`
   Sets the logging level. Valid values are Trace, Debug, Information, Warning, Error and Critical.
-  Example: `./void-linux-x64 `
 
   ```bash title="Example Usage"
   ./void-linux-x64 --logging Debug


### PR DESCRIPTION
## Summary
Remove duplicate inline example for `--logging` argument.

## Rationale
Streamlines documentation by eliminating redundant command sample.

## Changes
- delete extra `--logging` example from program arguments docs

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bc68d7fd8832b89010a963f09010a