### PR TITLE
docs(guidelines): 📝 clarify commit body naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Follow the existing C# style rules:
   - `test` — Tests
   - `build` — Build System
   - `ci` — Continuous Integration
-- Commit descriptions are required and must include a brief note about any observable behavior change.
+- Commit bodies are required and must include a brief note about any observable behavior change.
 - Use the `fix` or `feat` type only when your changes modify the proxy code in `./src`. For documentation, CI, or other unrelated updates, choose a more appropriate type such as `docs` or `chore`.
 - Append a [gitmoji](https://gitmoji.dev/specification) after the commit scope, e.g., `feat(api): ✨ add new endpoint`.
 - Pull request titles should follow the same Conventional Commits format.


### PR DESCRIPTION
## Summary
Fix terminology in contribution guidelines to refer to commit bodies.

## Rationale
Clarifies commit message requirements and avoids confusion with descriptions.

## Changes
- Replace "commit descriptions" with "commit bodies" in AGENTS.md.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal; revert commit if necessary.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bc959edb8832bbca293f70237dade