### PR TITLE
docs(forwardings): clarify player information phrasing

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/forwarding-overview.md
+++ b/docs/astro/src/content/docs/docs/forwardings/forwarding-overview.md
@@ -5,10 +5,10 @@ sidebar:
   order: 0
 ---
 
-Forwarding is a feature to pass player's information from proxy to server, such as online UUID, name and IP address.  
+Forwarding passes player information from the proxy to the server, such as the online UUID, name, and IP address.
 
 ## None (Offline)
-Without any forwarding enabled, the server will use player's offline UUID, name and IP address of the Void proxy.
+Without any forwarding enabled, the server will use the player's offline UUID and name, and the IP address of the Void proxy.
 
 ## Legacy (BungeeCord)
 One of the oldest forwarding modes, developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).  


### PR DESCRIPTION
## Summary
Clarifies player information wording in forwarding overview.

## Rationale
Improves grammatical clarity for readers.

## Changes
- Refine sentences describing player information handling.

## Verification
- `dotnet test` *(fails: MSB4068: The element <Solution> is unrecognized, or not supported in this context.)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bcac8b9e8832b880b6c1ce41d53cc