### PR TITLE
docs(transformations): 📝 fix packet transformations typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/transformations.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/transformations.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-When you have defined packet, it might be changed in future versions of Minecraft. There are two ways to handle this:
+When you have defined a packet, it might change in future versions of Minecraft. There are two ways to handle this:
 - Define conditional packet transformation
 - Define flat packet transformation
 


### PR DESCRIPTION
## Summary
Correct minor grammar in packet transformations guide.

## Rationale
Improves clarity for developers; no other alternatives considered.

## Changes
- fix wording in packet transformations documentation

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_689bcacc65d0832b9037f9292b5fdb6e