### PR TITLE
docs(program-arguments): ✏️ capitalize URL acronym

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -21,7 +21,7 @@ Options:
   -r, --repository <repository>                                    Provides a URI to NuGet repository [--repository
                                                                    https://nuget.example.com/v3/index.json or --repository
                                                                    https://username:password@nuget.example.com/v3/index.json].
-  -p, --plugin <plugin>                                            Provides a path to the file, directory or url to load plugin.
+  -p, --plugin <plugin>                                            Provides a path to the file, directory or URL to load plugin.
   --ignore-file-servers                                            Ignore servers specified in configuration files
   --server <server>                                                Registers an additional server in format <host>:<port>
   --interface <interface>                                          Sets the listening network interface


### PR DESCRIPTION
## Summary
Capitalize the URL acronym in program arguments documentation.

## Rationale
Improves readability and maintains correct terminology.

## Changes
- Capitalized "URL" acronym in program arguments docs.

## Verification
- `dotnet test`
- `dotnet build`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if needed.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bcace7c98832bac9f90f2ceeeb4b9