### PR TITLE
docs(forwardings): 📝 improve clarity in forwarding docs

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/docs/forwardings/legacy.md
@@ -9,7 +9,7 @@ sidebar:
 This forwarding is currently not implemented in Void.
 :::
 
-BungeeCord also known as Legacy forwarding is a type of forwarding player data developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).
+BungeeCord, also known as Legacy forwarding, is a type of forwarding player data developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).
 
 :::tip
 It is the easiest way to pass player's information from proxy to server in Handshake packet, supported by many server implementations.

--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-Velocity also known as Modern forwarding is a type of forwarding player data developed by [PaperMC](https://docs.papermc.io/velocity/player-information-forwarding/).
+Velocity, also known as Modern forwarding, is a type of forwarding player data developed by [PaperMC](https://docs.papermc.io/velocity/player-information-forwarding/).
 
 :::tip
 It is a secure way to pass player's information from proxy to server, supported by many server implementations.


### PR DESCRIPTION
## Summary
Clarifies wording in forwarding guides.

## Rationale
Improves readability for users referencing alternative forwarding names.

## Changes
- add commas around alternative names in Legacy and Modern forwarding docs

## Verification
- `dotnet test Void.slnx` *(fails: element <Solution> unrecognized)*

## Performance
- n/a

## Risks & Rollback
- low risk; revert commit

## Breaking/Migration
- none

## Links
- n/a


------
https://chatgpt.com/codex/tasks/task_e_689bcad18b04832ba12c276b92a469b7