### PR TITLE
docs(configuration): 📝 correct authentication term

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/docs/configuration/environment-variables.md
@@ -25,7 +25,7 @@ However, they might be used from the terminal directly as well.
 
 ## Proxy
 - `VOID_OFFLINE`
-  Allows players to connect without Mojang authorization.
+  Allows players to connect without Mojang authentication.
   Example: `true`
 
 ## Mojang

--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -24,7 +24,7 @@ CompressionThreshold = 256
 # General per player timeout for many operations (in milliseconds)
 KickTimeout = 10000
 
-# Allow players to connect without Mojang authorization
+# Allow players to connect without Mojang authentication
 Offline = false
 
 # Logging level (valid values are Trace, Debug, Information, Warning, Error, Critical)

--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -21,12 +21,12 @@ Options:
   -r, --repository <repository>                                    Provides a URI to NuGet repository [--repository
                                                                    https://nuget.example.com/v3/index.json or --repository
                                                                    https://username:password@nuget.example.com/v3/index.json].
-  -p, --plugin <plugin>                                            Provides a path to the file, directory or url to load plugin.
+  -p, --plugin <plugin>                                            Provides a path to the file, directory or URL to load plugin.
   --ignore-file-servers                                            Ignore servers specified in configuration files
   --server <server>                                                Registers an additional server in format <host>:<port>
   --interface <interface>                                          Sets the listening network interface
   --port <port>                                                    Sets the listening port
-  --offline                                                        Allows players to connect without Mojang authorization
+  --offline                                                        Allows players to connect without Mojang authentication
   --logging <Critical|Debug|Error|Information|None|Trace|Warning>  Sets the logging level
   --version                                                        Show version information
   -?, -h, --help                                                   Show help and usage information
@@ -34,7 +34,7 @@ Options:
 
 ## Authentication
 - `--offline`  
-  Allows players to connect without Mojang authorization.
+  Allows players to connect without Mojang authentication.
 
   ```bash title="Example Usage"
   ./void-linux-x64 --offline


### PR DESCRIPTION
## Summary
Fix terminology around offline mode in configuration docs.

## Rationale
Keeps documentation accurate and consistent.

## Changes
- Replace "authorization" with "authentication" in offline mode references
- Capitalize "URL" in plugin argument description

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bcad4ee7c832bb8e7c0866e4e0bd1