### PR TITLE
perf(commands): ⚡ avoid lowercase allocation

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Tree/Nodes/LiteralCommandNode.cs
+++ b/src/Minecraft/Commands/Brigadier/Tree/Nodes/LiteralCommandNode.cs
@@ -11,7 +11,6 @@ namespace Void.Minecraft.Commands.Brigadier.Tree.Nodes;
 
 public class LiteralCommandNode(string literal, CommandExecutor? executor, CommandRequirement? requirement, CommandNode? redirectTarget, RedirectModifier? redirectModifier, bool isForks) : CommandNode(executor, requirement, redirectTarget, redirectModifier, isForks)
 {
-    private readonly string _literalLowerCase = literal.ToLower();
 
     public string Literal { get; } = literal;
     public override string Name => Literal;
@@ -34,7 +33,7 @@ public class LiteralCommandNode(string literal, CommandExecutor? executor, Comma
 
     public override async ValueTask<Suggestions> ListSuggestionsAsync(CommandContext context, SuggestionsBuilder builder, CancellationToken cancellationToken)
     {
-        if (_literalLowerCase.StartsWith(builder.RemainingLowerCase))
+        if (Literal.StartsWith(builder.Remaining, StringComparison.OrdinalIgnoreCase))
             return await builder.Suggest(Literal).BuildAsync(cancellationToken);
         else
             return Suggestions.Empty;


### PR DESCRIPTION
## Summary
Avoid ToLower allocations when matching command literals.

## Rationale
Reduces per-comparison string allocations during suggestion matching.

## Changes
- Use `StartsWith(..., StringComparison.OrdinalIgnoreCase)` for literal suggestions

## Verification
- `dotnet build`
- `dotnet test --no-build -v m`

## Performance
No benchmarks, but avoids string allocation during suggestions.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689bcb8bde2c832b8eff00404e318250