### PR TITLE
perf(forwarding-support): ⚡ eliminate string allocation

### DIFF
--- a/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
+++ b/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
@@ -56,7 +56,7 @@ public class ForwardingService(IPlayerContext context, ILogger logger, Settings 
         var remoteEndPoint = context.Player.RemoteEndPoint.AsSpan();
         var colonIndex = remoteEndPoint.IndexOf(':');
 
-        buffer.WriteString((colonIndex >= 0 ? remoteEndPoint[..colonIndex] : remoteEndPoint).ToString());
+        buffer.WriteString(colonIndex >= 0 ? remoteEndPoint[..colonIndex] : remoteEndPoint);
 
         if (context.Player.Profile is not { } profile)
         {


### PR DESCRIPTION
## Summary
Removed temporary string allocation when composing Velocity forwarding payload.

## Rationale
Eliminates unnecessary allocation during login forwarding.

## Changes
- Write remote endpoint directly from span instead of allocating string.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- Avoids one string allocation per forwarded login.

## Risks & Rollback
- Low risk; rollback by restoring previous WriteString call.

## Breaking/Migration
- None.

## Links
- n/a


------
https://chatgpt.com/codex/tasks/task_e_689bcba1e7f0832b981b978d86b62c14