### PR TITLE
perf(commands): ⚡️ avoid lower-case allocation in bool suggestions

### DIFF
--- a/src/Minecraft/Commands/Brigadier/ArgumentTypes/BoolArgumentType.cs
+++ b/src/Minecraft/Commands/Brigadier/ArgumentTypes/BoolArgumentType.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Void.Minecraft.Commands.Brigadier.Context;
@@ -33,7 +34,7 @@ public record BoolArgumentType : IArgumentType<bool>
     {
         foreach (var example in Examples)
         {
-            if (example.StartsWith(builder.RemainingLowerCase))
+            if (example.StartsWith(builder.Remaining, StringComparison.OrdinalIgnoreCase))
                 builder.Suggest(example);
         }
 


### PR DESCRIPTION
## Summary
Replaced lowercase-based checks in boolean suggestion logic with an ordinal, case-insensitive comparison to avoid extra string allocations.

## Rationale
Avoids unnecessary string allocations in hot command suggestion paths, improving efficiency.

## Changes
- Use `StartsWith(..., StringComparison.OrdinalIgnoreCase)` when matching boolean suggestions.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Reduces temporary string allocations during boolean suggestion matching.

## Risks & Rollback
Low risk; revert via `git revert` of the commit.

## Breaking/Migration
None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_689bcb9d5aac832b8f3adacdb6cd7b90