### PR TITLE
perf(components): ⚡ use span for hex color check

### DIFF
--- a/src/Minecraft/Components/Text/Colors/TextColor.cs
+++ b/src/Minecraft/Components/Text/Colors/TextColor.cs
@@ -62,7 +62,7 @@ public record TextColor(byte Red, byte Green, byte Blue)
     public static TextColor FromString(string value)
     {
         var span = value.AsSpan();
-        if (value.StartsWith('#') && value.Length == 7)
+        if (span.Length == 7 && span[0] == '#')
         {
             if (byte.TryParse(span[1..3], NumberStyles.HexNumber, null, out var red) && byte.TryParse(span[3..5], NumberStyles.HexNumber, null, out var green) && byte.TryParse(span[5..7], NumberStyles.HexNumber, null, out var blue))
             {


### PR DESCRIPTION
## Summary
Reduce overhead in color parsing by switching to span-based check.

## Rationale
Avoids extra string processing when detecting hex color formats.

## Changes
- Use span length and indexing for hex prefix detection

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No measurements, but removes a string method call.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689bcb96dd5c832b8389be88a97d141f