### PR TITLE
docs(astro): 📝 quote Kubernetes article title

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Void on Kubernetes: the setup I wish I’d had from day one
+title: "Void on Kubernetes: the setup I wish I’d had from day one"
 description: Production-ready guide for running Void proxy on Kubernetes with health checks, graceful rollouts, and plugin management.
 template: splash
 pagefind: false


### PR DESCRIPTION
## Summary
Wrap YAML frontmatter title in quotes to fix colon parsing error in Astro docs build.

## Rationale
Unquoted colon in article title produced YAML parsing failure during Astro content sync; quoting resolves the issue.

## Changes
- quote `title` frontmatter in `002-void-on-kubernetes.md`

## Verification
- `npm run build` (fails: connect ENETUNREACH 140.82.112.6:443 - Local (0.0.0.0:0))
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore prior state.

## Breaking/Migration
None.

## Links
None


------
https://chatgpt.com/codex/tasks/task_e_689ce3822094832b9f60e3a665691191