### PR TITLE
docs(articles): 📝 disable edit links

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -3,6 +3,7 @@ title: How to Set Up Void Minecraft Proxy in Docker for Modded & Vanilla Servers
 description: Learn how to run the Void Minecraft Proxy in Docker with a clean, fast setup for both modded and vanilla servers, plus tips for plugins, forwarding, and smooth production use.
 template: splash
 pagefind: false
+editUrl: false
 ---
 
 # Setting up Minecraft Proxy — Void (In Docker)

--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -3,6 +3,7 @@ title: "Void on Kubernetes: the setup I wish I’d had from day one"
 description: Production-ready guide for running Void proxy on Kubernetes with health checks, graceful rollouts, and plugin management.
 template: splash
 pagefind: false
+editUrl: false
 ---
 
 # Void on Kubernetes: the setup I wish I’d had from day one


### PR DESCRIPTION
## Summary
Hide edit links on documentation articles.

## Rationale
Articles should not show edit links by default.

## Changes
- set `editUrl` to `false` in article frontmatter

## Verification
- `dotnet build`
- `dotnet test`

## Performance
n/a

## Risks & Rollback
Revert commit to restore edit links.

## Breaking/Migration
n/a

## Links
n/a

------
https://chatgpt.com/codex/tasks/task_e_689ceaa23d20832b8427c8342c980c7e