### PR TITLE
docs(config): 📝 link to containers doc

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/docs/configuration/environment-variables.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Environment variables make configuration in container environments easier.
+Environment variables make configuration in [**container environments**](/docs/containers/) easier.
 However, they might be used from the terminal directly as well.
 
 ## Plugins


### PR DESCRIPTION
## Summary
Link environment variables documentation to containers guide.

## Rationale
Improves navigation for container users.

## Changes
- add internal link to containers doc in environment variables page

## Verification
- `dotnet test`

## Performance
n/a

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
n/a

------
https://chatgpt.com/codex/tasks/task_e_689d1d4e90ec832ba8cc62035819da37