### PR TITLE
docs(env-vars): 🔗 link watchdog doc

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/docs/configuration/environment-variables.md
@@ -20,7 +20,7 @@ However, they might be used from the terminal directly as well.
 
 ## Watchdog
 - `VOID_WATCHDOG_ENABLE`
-  Enables the watchdog.
+  Enables the [**watchdog**](/docs/watchdog).
   Example: `true`
 
 ## Proxy


### PR DESCRIPTION
## Summary
Add cross-reference to Watchdog doc.

## Rationale
Improves navigation by linking environment variable docs to related content.

## Changes
- Link to Watchdog doc from environment variables guide.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689d1d4cfc38832b914876f6bf218fc0