### PR TITLE
docs(astro): 🔗 cross-link plugin configuration

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Learn how to define configuration for your plugin.
 ---
 
-Void exposes a configuration API that allows you to define in-file configuration options for your plugin. 
+Void exposes a configuration API that allows you to define [**in-file configuration**](/docs/configuration/in-file) options for your plugin.
 
 ## Defining Configuration
 To define configuration for your plugin, create any class with any parameters and default values.


### PR DESCRIPTION
## Summary
Link plugin configuration docs to the in-file configuration guide.

## Rationale
Improves navigation between plugin configuration and general configuration docs.

## Changes
- Link "in-file configuration" phrase to existing configuration guide

## Verification
- `npm test` *(fails: Missing script "test")*
- `dotnet test` *(fails: Test Class Cleanup Failure)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689d3e783ee8832b981a45041402423f