### PR TITLE
docs(configuration): 📝 link forwarding overview

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -55,7 +55,7 @@ Port = 80
 ```
 
 ## Forwarding
-Forwarding helps to forward player data (IP, UUID, Skin, etc.) to the backend server.
+[**Forwarding**](/docs/forwardings/forwarding-overview) helps to forward player data (IP, UUID, Skin, etc.) to the backend server.
 
 ### Modern (Velocity)
 Read more in [**Modern (Velocity)**](/docs/forwardings/modern) forwarding.


### PR DESCRIPTION
## Summary
Link in-file config docs to forwarding overview for easier navigation.

## Rationale
Adds missing cross-reference within documentation; no alternatives considered.

## Changes
- Link "Forwarding" section to forwarding overview page.

## Verification
- `dotnet build`
- `dotnet test`
- `npm --prefix docs/astro run build` *(fails: connect ENETUNREACH 140.82.113.5:443)*

## Performance
N/A docs only.

## Risks & Rollback
Minimal risk; revert commit to remove link if needed.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689d3e7a88fc832ba0275bcda6e2ccf6