### PR TITLE
docs(articles): 📝 link forwarding overview

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -16,7 +16,7 @@ Let me walk you through exactly how I run Void in Docker, why I chose the flags 
 
 ## Why Void for a Docker-friendly proxy
 
-I like proxies that don’t fight me. Void boots fast, has sensible flags, and plays nicely with both legacy and modern forwarding models. It’s comfortable in a container, which means fewer moving parts on the host and easier rollbacks. Most importantly, it behaves the same on my laptop and on the node in the rack.
+I like proxies that don’t fight me. Void boots fast, has sensible flags, and plays nicely with both legacy and modern [**forwarding models**](/docs/forwardings/forwarding-overview). It’s comfortable in a container, which means fewer moving parts on the host and easier rollbacks. Most importantly, it behaves the same on my laptop and on the node in the rack.
 
 If you’re running modded servers, you know the routine: weird handshakes, changing headers, and that one forge build that decides it’s special. Void handles the chaos without turning your launch script into a novella.
 


### PR DESCRIPTION
## Summary
Docker article referenced forwarding models without navigation; linking clarifies path.

## Rationale
Improves doc usability; no better alternatives needed.

## Changes
- link forwarding models phrase to forwarding overview

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to remove link.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689d3e7d81cc832b8dfc8c7d639f7502