### PR TITLE
docs(astro): 📝 link production environment

### DIFF
--- a/docs/astro/src/content/docs/docs/watchdog.md
+++ b/docs/astro/src/content/docs/docs/watchdog.md
@@ -4,7 +4,7 @@ description: Learn how to enable and use the Watchdog feature in Void.
 ---
 
 The Watchdog feature in Void is designed to monitor the health of the Void Proxy and schedule a restart if required. 
-This is particularly useful for long-running processes or when running Void in a production environment.
+This is particularly useful for long-running processes or when running Void in a [**production environment**](/docs/containers/).
 
 ## Enable Watchdog
 Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`.


### PR DESCRIPTION
## Summary
Link production environment phrase to containers guide in Watchdog docs.

## Rationale
Creates navigation between related documentation without new content.

## Changes
- Link "production environment" to containers guide in Watchdog docs.

## Verification
- `dotnet test` (terminated after extended execution)

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to remove link if needed.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689d3e832670832bbd2c8be3d071781b