### PR TITLE
docs(astro): 🔗 link to watchdog page

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -19,7 +19,7 @@ What follows is the exact layout I run in production. It’s simple, repeatable,
 Void is a .NET proxy that speaks to your backend Paper/Purpur/Fabric servers and presents a single TCP entry point for players. It exposes two important ports:
 
 * **25565/TCP** for Minecraft traffic.
-* **80/TCP** for a tiny HTTP control surface I’ll call the *watchdog*. It answers health, bound-state, and graceful control requests.
+* **80/TCP** for a tiny HTTP control surface I’ll call the [**watchdog**](/docs/watchdog). It answers health, bound-state, and graceful control requests.
 
 There are a few knobs I use every day:
 


### PR DESCRIPTION
## Summary
Adds cross-link from Kubernetes article to Watchdog docs.

## Rationale
Improves navigation between related documentation pages.

## Changes
- Link watchdog mention in Kubernetes setup guide to Watchdog page.

## Verification
- `dotnet test`

## Performance
- Not applicable

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_689d3e85d570832bb2d89d7cb8cf399f