### PR TITLE
docs(astro): 📝 link configuration files from program arguments doc

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -55,8 +55,8 @@ Options:
 ## Servers
 - `--server`  
   Registers a server in format `<host>:<port>` where the port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
-- `--ignore-file-servers`  
-  Ignore servers specified in configuration files.
+- `--ignore-file-servers`
+  Ignore servers specified in [**configuration files**](/docs/configuration/in-file).
 
   ```bash title="Example Usage"
   ./void-linux-x64 \


### PR DESCRIPTION
## Summary
Cross-reference program arguments doc to configuration file guide.

## Rationale
Improves navigation between related configuration documentation.

## Changes
- Link program-argument description to configuration file guide.

## Verification
- `dotnet test`
- `dotnet build`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689d421eb58c832ba2b7c06bcc17620d