### PR TITLE
docs(astro): 🔗 link modern forwarding page

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -79,7 +79,7 @@ docker run --network host --rm caunt/void:dev \
 
 ## Forwarding models and common pitfalls
 
-Void supports both legacy and modern forwarding. Just make sure your backend’s forwarding setting matches the proxy. Mismatches are the main cause of timeouts right after login.
+Void supports both legacy and [**modern forwarding**](/docs/forwardings/modern). Just make sure your backend’s forwarding setting matches the proxy. Mismatches are the main cause of timeouts right after login.
 
 ---
 


### PR DESCRIPTION
## Summary
Link Docker article to modern forwarding docs.

## Rationale
Improves navigation for readers wanting detailed forwarding guidance.

## Changes
- Link Docker setup article to modern forwarding page.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689d42207fc4832ba90d0fff85dda9f0