### PR TITLE
docs(astro): 📝 link scoped services

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
@@ -4,7 +4,7 @@ description: Learn types of Player Events.
 ---
 
 The very first event that is triggered when a player connects to the server.
-It is used to create a new player instance and set up the player context with scoped services.
+It is used to create a new player instance and set up the player context with [**scoped services**](/docs/developing-plugins/services/scoped).
 Do not change the `Result` property of this event until you are very sure what you are doing.
 You can use this event to modify the player instance implementation.
 ```csharp


### PR DESCRIPTION
## Summary
Link player events doc to scoped services page.

## Rationale
Improves navigation within documentation.

## Changes
- Wrap "scoped services" with internal link to services page.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if needed.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689d422362f4832b864ca41adc11d162