### PR TITLE
docs(features): 📝 link commands documentation

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/features.md
+++ b/docs/astro/src/content/docs/docs/getting-started/features.md
@@ -12,7 +12,7 @@ Here's a quick look at what the Void proxy already supports and what's planned f
 #### Terms
 - **Proxying** lets you play through the proxy.
 - **Redirects** move players between servers.
-- **API** exposes the Services API to plugins (Chat, Commands, Events, Content, Packets).
+- **API** exposes the Services API to plugins (Chat, [**Commands**](/docs/developing-plugins/commands), Events, Content, Packets).
 - **WIP** marks a feature still under development.
 
 ### Game Versions


### PR DESCRIPTION
## Summary
Link commands documentation from features page.

## Rationale
Improves navigation to command reference.

## Changes
- Add internal link to commands doc in features page.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689d4225a7c0832b863fd527cd51a382