### PR TITLE
docs(astro): 🔗 link scoped services guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -52,7 +52,7 @@ public class MySingletonService : IEventListener
 
 ## Listening to events in Scoped services
 Just like with other services, you should apply `IEventListener` interface to your scoped service class.
-However, listening to events in scoped services is a bit different.
+However, listening to events in [**scoped services**](/docs/developing-plugins/services/scoped) is a bit different.
 Scoped events are filtered by the player context, so you will only receive events that are relevant to the player that owns the service.
 All other types of events will not be filtered, since they are not scoped.
 Scoped events filter can be disabled by applying `bypassScopedFilter: true` to the `Subscribe` attribute.


### PR DESCRIPTION
## Summary
Adds an internal link from events guide to scoped services documentation.

## Rationale
Improves navigation for plugin developers.

## Changes
- Link scoped services guide from events listening page.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if navigation issues arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689ddf6d0498832b9ffdf9e7edf7d08c