### PR TITLE
docs(astro): 🔗 link packets doc from features

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/features.md
+++ b/docs/astro/src/content/docs/docs/getting-started/features.md
@@ -12,7 +12,7 @@ Here's a quick look at what the Void proxy already supports and what's planned f
 #### Terms
 - **Proxying** lets you play through the proxy.
 - **Redirects** move players between servers.
-- **API** exposes the Services API to plugins (Chat, [**Commands**](/docs/developing-plugins/commands), Events, Content, Packets).
+- **API** exposes the Services API to plugins (Chat, [**Commands**](/docs/developing-plugins/commands), Events, Content, [**Packets**](/docs/developing-plugins/network/packets)).
 - **WIP** marks a feature still under development.
 
 ### Game Versions


### PR DESCRIPTION
## Summary
Adds internal link to packet development docs from features overview.

## Rationale
Improves navigation by connecting feature list to packet development documentation.

## Changes
- Link **Packets** to `/docs/developing-plugins/network/packets` in features page.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low; revert commit if docs link incorrect.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689ddf76fe84832baed06984f235481a