### PR TITLE
docs(astro): 🔗 link program arguments guide

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -23,7 +23,7 @@ Void is a .NET proxy that speaks to your backend Paper/Purpur/Fabric servers and
 
 There are a few knobs I use every day:
 
-* Program arguments like `--server`, `--port`, `--interface`, and `--plugin`.
+* [**Program arguments**](/docs/configuration/program-arguments) like `--server`, `--port`, `--interface`, and `--plugin`.
 * Environment variables for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
 * File config remains available if you prefer, but I keep the container immutable and do overrides via args and env.
 


### PR DESCRIPTION
## Summary
Link Kubernetes article to program arguments configuration page.

## Rationale
Improves navigation within the docs; leaving text unlinked makes the guide less useful.

## Changes
- Link "Program arguments" mention in Kubernetes article to configuration guide.

## Verification
- `dotnet test`

## Performance
- N/A

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_689ddf81fec4832bb89470b078717328