### PR TITLE
docs(astro): 📝 link event guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -11,7 +11,7 @@ Void plugins are written with many modern .NET features, so you will need to ens
 Some of them include:
 - Dependency Injection
 - Asynchronous Programming
-- Event-Driven Programming
+- [**Event-Driven Programming**](/docs/developing-plugins/events/listening-to-events/)
 - Stack-allocating and Memory Management
 - Serialization and Deserialization of data
 - Network Packets and Protocols


### PR DESCRIPTION
## Summary
Add internal link to event listener guide from development kit docs.

## Rationale
Helps readers jump from prerequisites to event usage details.

## Changes
- Link "Event-Driven Programming" to event-listening guide.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689ddf79f28c832ba7c7f1c2cc82faf1