### PR TITLE
docs(astro): 📝 link environment variables

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -24,7 +24,7 @@ Void is a .NET proxy that speaks to your backend Paper/Purpur/Fabric servers and
 There are a few knobs I use every day:
 
 * Program arguments like `--server`, `--port`, `--interface`, and `--plugin`.
-* Environment variables for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
+* [**Environment variables**](/docs/configuration/environment-variables/) for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
 * File config remains available if you prefer, but I keep the container immutable and do overrides via args and env.
 
 That’s the gist. Now let’s put it into a Deployment that ships.


### PR DESCRIPTION
## Summary
Add internal link to environment variables documentation.

## Rationale
Improves navigation to configuration guidance.

## Changes
- Link "Environment variables" in Kubernetes article to dedicated doc.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689ddf7e8970832ba18d41237f15b6dc