### PR TITLE
docs(features): 🔗 link to events guide

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/features.md
+++ b/docs/astro/src/content/docs/docs/getting-started/features.md
@@ -12,7 +12,7 @@ Here's a quick look at what the Void proxy already supports and what's planned f
 #### Terms
 - **Proxying** lets you play through the proxy.
 - **Redirects** move players between servers.
-- **API** exposes the Services API to plugins (Chat, [**Commands**](/docs/developing-plugins/commands), Events, Content, [**Packets**](/docs/developing-plugins/network/packets)).
+- **API** exposes the Services API to plugins (Chat, [**Commands**](/docs/developing-plugins/commands), [**Events**](/docs/developing-plugins/events/listening-to-events), Content, [**Packets**](/docs/developing-plugins/network/packets)).
 - **WIP** marks a feature still under development.
 
 ### Game Versions


### PR DESCRIPTION
## Summary
Adds an internal link from the features overview to the Events guide.

## Rationale
Improves navigation by letting users jump directly to event documentation; leaving it unlinked would make the guide harder to find.

## Changes
- Link the "Events" item in the features overview to the Events guide.

## Verification
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit to remove link if needed.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689de248a4cc832bb162593ffca0f800