### PR TITLE
docs(kubernetes): 📝 link program arguments

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -23,7 +23,7 @@ Void is a .NET proxy that speaks to your backend Paper/Purpur/Fabric servers and
 
 There are a few knobs I use every day:
 
-* Program arguments like `--server`, `--port`, `--interface`, and `--plugin`.
+* [**Program arguments**](/docs/configuration/program-arguments/) like `--server`, `--port`, `--interface`, and `--plugin`.
 * [**Environment variables**](/docs/configuration/environment-variables/) for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
 * File config remains available if you prefer, but I keep the container immutable and do overrides via args and env.
 


### PR DESCRIPTION
## Summary
Add a missing internal link in the Kubernetes article to the program arguments documentation for easier navigation.

## Rationale
Helps readers quickly access argument details without manual search.

## Changes
- Link “Program arguments” to `/docs/configuration/program-arguments/` in the Kubernetes article.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No performance impact; documentation only.

## Risks & Rollback
Low risk. Revert the commit to remove the link.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689de24c9dbc832bbc61bc44e866f4e0