### PR TITLE
docs(text-formatting): 📝 link to Nbt guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/text-formatting.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/text-formatting.md
@@ -54,7 +54,7 @@ public class MyScopedService(IPlayerContext context)
 ```
 
 ## Converting Components
-Components can be converted from and to many different formats like Legacy, Json, Nbt and Snbt
+Components can be converted from and to many different formats like Legacy, Json, [**Nbt**](/docs/developing-plugins/nbt) and Snbt
 ```csharp
 public class MyScopedService(IPlayerContext context)
 {


### PR DESCRIPTION
## Summary
Add cross-reference from text formatting guide to Nbt guide.

## Rationale
Helps readers navigate between related documentation pages.

## Changes
- Link "Nbt" to Nbt guide in text formatting page.

## Verification
- `dotnet test`
- `dotnet build`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to roll back.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689de250a7a8832bb28c8c4a1d69c961