### PR TITLE
docs(astro): 🔗 link to service guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -9,7 +9,7 @@ It can be used with any MSBuild-compatible IDE, such as Visual Studio or JetBrai
 ## Prerequisites
 Void plugins are written with many modern .NET features, so you will need to ensure that you have experience with them or at least know what you are doing.
 Some of them include:
-- Dependency Injection
+- [**Dependency Injection**](/docs/developing-plugins/services/creating-a-service/)
 - Asynchronous Programming
 - [**Event-Driven Programming**](/docs/developing-plugins/events/listening-to-events/)
 - Stack-allocating and Memory Management


### PR DESCRIPTION
## Summary
Link dependency injection prerequisite to service creation guide for easier navigation.

## Rationale
Improves documentation discoverability by connecting related guides.

## Changes
- link dependency injection prerequisite to service creation guide

## Verification
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert this commit to roll back.

## Breaking/Migration
None.

## Links
-

------
https://chatgpt.com/codex/tasks/task_e_689de253a4bc832b91502bf4d06f8fcb