### PR TITLE
docs(services): 📝 link singleton services

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -135,7 +135,7 @@ public class TrackerService(IPlayerService players)
 ```
 
 Most of the events that have Player property are already implemented as `IScopedEvent`.
-While you can listen to them in Scoped services, they are still available for Singleton services.
+While you can listen to them in Scoped services, they are still available for [**Singleton services**](/docs/developing-plugins/services/singleton).
 In Singleton context, you will receive events **not filtered**. Meaning you will receive events for all players in single service.
 
 If you would like to not filter events in scoped service, pass `bypassScopedFilter: true` to the `Subscribe` attribute.


### PR DESCRIPTION
## Summary
Add cross-link to singleton services doc.

## Rationale
Improve navigation between service lifetimes.

## Changes
- Link to singleton services from scoped services guide.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
No risk; revert commit.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689de5b757cc832bb1f0be713b0144c3