### PR TITLE
docs(containers): 📝 link offline flag to program arguments

### DIFF
--- a/docs/astro/src/content/docs/docs/containers.md
+++ b/docs/astro/src/content/docs/docs/containers.md
@@ -27,7 +27,7 @@ docker run --name void --network host --pull=always --rm caunt/void:dev \
 ```
 
 :::tip[Offline Mode]
-Add `--offline` to allow players to connect without Mojang authentication.
+Add [**--offline**](/docs/configuration/program-arguments/) to allow players to connect without Mojang authentication.
 :::
 
 ## Running Void in Kubernetes


### PR DESCRIPTION
## Summary
Linked the --offline flag in containers guide to the program arguments page.

## Rationale
Helps readers discover where the --offline option is documented; leaving it unlinked made navigation harder.

## Changes
- Add link from containers guide's Offline Mode tip to program arguments page.

## Verification
- `dotnet test` *(hung during execution)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if navigation issue arises.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689de5b39bec832ba85052032d5b0c7f