### PR TITLE
docs(astro): 📝 link serializers guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -13,7 +13,7 @@ Some of them include:
 - Asynchronous Programming
 - [**Event-Driven Programming**](/docs/developing-plugins/events/listening-to-events/)
 - Stack-allocating and Memory Management
-- Serialization and Deserialization of data
+- [**Serialization and Deserialization of data**](/docs/developing-plugins/serializers/)
 - Network Packets and Protocols
 
 ## Installation


### PR DESCRIPTION
## Summary
Adds a bold internal link to the serializers guide within the development kit documentation.

## Rationale
Helps readers find serialization guidance when creating plugins.

## Changes
- Link "Serialization and Deserialization of data" to the serializers guide.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal; revert the commit if documentation builds fail.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689de991dab0832ba66c1c2d8be2d638