### PR TITLE
docs(packets): 📝 link to modifying data page

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -8,7 +8,7 @@ sidebar:
 Minecraft Packets [**(called Messages in Void)**](https://github.com/caunt/Void/blob/main/src/Minecraft/Network/Messages/Packets/IMinecraftPacket.cs#L7) describe the data that is sent between the player and server.
 These messages contain information about player actions, world events, and other game mechanics.
 
-Typically, you describe existing packets in game, so you can read, modify, or cancel them.
+Typically, you describe existing packets in game, so you can read, [**modify**](/docs/developing-plugins/network/modifying-data), or cancel them.
 However you are not limited to this, you can also define your own packets for your own Minecraft mod or plugin.
 
 Packets can be defined with `IMinecraftClientboundPacket<TPacket>` or `IMinecraftServerboundPacket<TPacket>` interface. If your packet is same for both client and server, you can use `IMinecraftPacket<TPacket>` interface.


### PR DESCRIPTION
## Summary
Add internal cross-link from packet overview to Modifying Data doc.

## Rationale
Improves navigation by connecting packet and modification docs; avoids disjoint instructions.

## Changes
- link "modify" in packet documentation to Modifying Data page

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689de9a3d918832baecbf651a96060c5