### PR TITLE
docs(kubernetes): 🔗 link configuration file guide

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -193,7 +193,7 @@ Want to test a single plugin quickly? Pass `--plugin` as an arg alongside the en
 
 Void can register servers from config files or via `--server`. In clusters, using `--server` keeps boot deterministic because you don’t wait on config materialization. I usually point it at a Service that fronts a Paper or Purpur Deployment.
 
-If you use Velocity-style modern forwarding, enable it in the configuration file once and match the secret on backends. I keep the file inside the image during build time when I need it, but it’s equally fine to set that once in a golden image and forget about it—there’s nothing dynamic there.
+If you use Velocity-style modern forwarding, enable it in the [**configuration file**](/docs/configuration/in-file/) once and match the secret on backends. I keep the file inside the image during build time when I need it, but it’s equally fine to set that once in a golden image and forget about it—there’s nothing dynamic there.
 
 If you run in offline mode for testing, `VOID_OFFLINE=true` makes that a one-line toggle. In public, flip it off. Simple switches save mistakes.
 


### PR DESCRIPTION
## Summary
Adds internal link to configuration file documentation from Kubernetes article.

## Rationale
Improves navigation to configuration references; alternatives considered briefly.

## Changes
- Link "configuration file" to existing configuration file guide in Kubernetes doc.

## Verification
- `dotnet test`
- `npm run build` *(fails: connect ENETUNREACH 140.82.112.5:443 - Local (0.0.0.0:0))*

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert commit to remove link.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689de9a7b8a8832b9778671c77cd1eae