### PR TITLE
docs(articles): 📝 link file config guide

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -25,7 +25,7 @@ There are a few knobs I use every day:
 
 * [**Program arguments**](/docs/configuration/program-arguments/) like `--server`, `--port`, `--interface`, and `--plugin`.
 * [**Environment variables**](/docs/configuration/environment-variables/) for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
-* File config remains available if you prefer, but I keep the container immutable and do overrides via args and env.
+* [**File config**](/docs/configuration/in-file/) remains available if you prefer, but I keep the container immutable and do overrides via args and env.
 
 That’s the gist. Now let’s put it into a Deployment that ships.
 


### PR DESCRIPTION
## Summary
Link file configuration guide from Kubernetes article for easier navigation.

## Rationale
Helps readers discover detailed file-based configuration docs when deploying on Kubernetes.

## Changes
- Link "File config" phrase to the in-file configuration guide.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to remove link.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689de9b340c0832b89b0c84441f37c1f