### PR TITLE
docs(articles): 📝 link Docker guide to containers page

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -10,7 +10,7 @@ editUrl: false
 
 When I first pointed my server traffic through **Void**, I expected a weekend of tinkering and a long night of regrets. What I got instead was a clean, predictable setup that took minutes, felt modern, and frankly made me a little smug. If you’ve been juggling Velocity/Bungee-era rituals, or you’re running a modded network and want something that speaks fluent .NET and plain English, this is the path I wish I’d taken sooner.
 
-Let me walk you through exactly how I run Void in Docker, why I chose the flags I did, and a few real‑world notes from putting it behind production traffic.
+Let me walk you through exactly how I run Void in [**Docker**](/docs/containers/), why I chose the flags I did, and a few real‑world notes from putting it behind production traffic.
 
 ---
 


### PR DESCRIPTION
## Summary
Add cross-reference from Docker setup article to containers guide.

## Rationale
Offers readers quick access to general container guidance.

## Changes
- Link Docker mention to containers documentation.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if unintended.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_689dee181014832ba3b5d03f9e1508da