### PR TITLE
docs(services): 📝 link to events doc

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
@@ -28,7 +28,7 @@ dependencies.Register(services =>
     services.AddTransient<ExampleTransientService>();
 });
 ```
-Your services will be automatically activated (instantiated) and subscribed to events, if not delayed explicitly.
+Your services will be automatically activated (instantiated) and subscribed to [**events**](/docs/developing-plugins/events/listening-to-events), if not delayed explicitly.
 You can delay your services activation, by providing `activate: false` parameter to the registration method:
 ```csharp
 dependencies.Register(services =>


### PR DESCRIPTION
## Summary
Link service-creation docs to events reference for easier navigation.

## Rationale
Improves discoverability of event documentation when learning about services.

## Changes
- Link "events" in service creation guide to events documentation.

## Verification
- `dotnet test` *(failed: process hung)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if needed.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689dee0dc12c832bb0f8e699cdda6139