### PR TITLE
docs(astro): 📝 link player events page

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 Events are a great way to communicate between different plugins and proxy. 
-They allow you to respond to specific actions or changes in the game, such as a player joining or leaving.
+They allow you to respond to specific actions or changes in the game, such as a [**player joining or leaving**](/docs/developing-plugins/events/player-events).
 
 ## Subscribing to events
 You can subscribe to events by applying the `Subscribe` attribute to a method in your class that inherits `IEventListener` interface.


### PR DESCRIPTION
## Summary
Add cross-reference to player events documentation.

## Rationale
Helps developers discover player event reference when reading the listening guide.

## Changes
- link player events page from event listening guide

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
-

------
https://chatgpt.com/codex/tasks/task_e_689dee08f4a4832b98089683f07a74cc