### PR TITLE
docs(astro): 📝 link network packets guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -14,7 +14,7 @@ Some of them include:
 - [**Event-Driven Programming**](/docs/developing-plugins/events/listening-to-events/)
 - Stack-allocating and Memory Management
 - [**Serialization and Deserialization of data**](/docs/developing-plugins/serializers/)
-- Network Packets and Protocols
+- [**Network Packets**](/docs/developing-plugins/network/packets/) and Protocols
 
 ## Installation
 1) [**Download**](https://github.com/caunt/Void/releases/latest/download/plugin-devkit.zip) the latest **Plugin Development Kit**.


### PR DESCRIPTION
## Summary
Add missing cross-reference in plugin development kit guide.

## Rationale
Helps readers find the network packets documentation.

## Changes
- Link Network Packets entry in development kit prerequisites

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No performance impact.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689dee06c9b4832bb2f7874f3aa16c03