### PR TITLE
docs(astro): 📝 link mod loaders section

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -13,7 +13,7 @@ Modern forwarding was updated multiple times, enabling new features and fixing b
 :::
 
 :::note[Mods]
-Velocity forwarding is not supported by mod loaders, however community has created some mods implementing its protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
+Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/features/#mod-loaders), however community has created some mods implementing its protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
 :::
 
 :::caution[Limitations]


### PR DESCRIPTION
## Summary
Add internal link to mod loaders section from modern forwarding guide.

## Rationale
Improves navigation between forwarding and mod loader documentation.

## Changes
- link mod loaders reference in modern forwarding guide

## Verification
- `dotnet test` *(fails: test run did not complete; hung after starting)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_689e02e3f220832ba5867b0917d74d02