### PR TITLE
docs(articles): 📝 link program arguments page

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -32,7 +32,7 @@ A few ground rules I follow: stateless by default, no mounting config volumes un
 
 ## Building the actual run command
 
-Once I’ve decided my backend target and public entry port, I start Void with the essential flags in a single `docker run` line. I skip clutter and only include what matters: backend address, interface, port, and any relevant toggles like `--ignore-file-servers`.
+Once I’ve decided my backend target and public entry port, I start Void with the essential [**flags**](/docs/configuration/program-arguments/) in a single `docker run` line. I skip clutter and only include what matters: backend address, interface, port, and any relevant toggles like `--ignore-file-servers`.
 
 Example with one backend:
 


### PR DESCRIPTION
## Summary
Add internal link from Docker article to program arguments page.

## Rationale
Improves navigation by pointing readers to argument reference.

## Changes
- Link "flags" in Docker setup article to program arguments guide.

## Verification
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: fetch failed ENETUNREACH)*
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e02e7a4e8832b8571f2339ed7ccdc