### PR TITLE
docs(events): 🔗 link scoped listener guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
@@ -38,7 +38,7 @@ public record MyEvent(string SomeValue) : IEventWithResult<bool>
 ## Scoped Event
 Your event can be scoped to a specific player. You can do this by implementing the `IScopedEvent` interface.
 With this interface you are required to specify the Player to which this event is scoped.
-This event will be filtered across scoped listeners and passed to all non-scoped listeners.
+This event will be filtered across [**scoped listeners**](/docs/developing-plugins/services/scoped) and passed to all non-scoped listeners.
 However, scoped listeners can still receive that event out of their scope, by applying `bypassScopedFilter: true` to the `Subscribe` attribute.
 ```csharp
 public record MyEvent(IPlayer Player, string SomeValue) : IScopedEvent;


### PR DESCRIPTION
## Summary
Cross-link event creation docs to scoped services for clearer navigation.

## Rationale
Helps readers jump from scoped events to scoped services without manual searching.

## Changes
- Link scoped listener mention in event creation guide to scoped services page

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
N/A

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e02eaac4c832b96455581db1ab9f8