### PR TITLE
docs(articles): 🔗 link config docs in Docker guide

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -26,7 +26,7 @@ If you’re running modded servers, you know the routine: weird handshakes, chan
 
 I keep Void as a single ephemeral container that owns the public port and forwards to whatever backend I declare. That’s it. No sidecars. No mystery env sprawl. If I want to swap configurations or try a different plugin, I kill and run again.
 
-A few ground rules I follow: stateless by default, no mounting config volumes unless I must, and host networking when I want port handling to be predictable.
+A few ground rules I follow: stateless by default, no mounting [**config volumes**](/docs/configuration/in-file/) unless I must, and host networking when I want port handling to be predictable.
 
 ---
 


### PR DESCRIPTION
## Summary
Link Docker article config volumes phrase to in-file configuration doc.

## Rationale
Provides quick access to configuration documentation from Docker guide.

## Changes
- Link "config volumes" to /docs/configuration/in-file/.

## Verification
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit to undo.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e25da43e0832bb37ff9f37d98ca40