### PR TITLE
docs(articles): 📝 link watchdog doc

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -225,7 +225,7 @@ If you want to steer certain regions to specific pods, add multiple `Service` ob
 
 Most HTTP ingress controllers won’t help for raw TCP Minecraft traffic unless they support TCP services. If you already run something like NGINX Ingress or Traefik with TCP routing enabled, point it at `void-proxy`. Otherwise, a direct `LoadBalancer` on the Service keeps the path short and avoids head‑of‑line quirks.
 
-For the control plane, I keep the watchdog on a ClusterIP Service and reach it from inside the cluster. If you want remote control for a small team, put an authentication layer in front of it and publish it over HTTPS with your reverse proxy of choice. Keep the attack surface tiny.
+For the control plane, I keep the [**watchdog**](/docs/watchdog) on a ClusterIP Service and reach it from inside the cluster. If you want remote control for a small team, put an authentication layer in front of it and publish it over HTTPS with your reverse proxy of choice. Keep the attack surface tiny.
 
 ---
 


### PR DESCRIPTION
## Summary
Link watchdog reference in Kubernetes article for easier navigation.

## Rationale
Helps readers discover watchdog details without searching; leaving it plain was less helpful.

## Changes
- Link Kubernetes article's control plane mention to watchdog docs.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e36290be8832ba180320ee755024c