### PR TITLE
docs(articles): ✏️ link container docs in kubernetes guide

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -25,7 +25,7 @@ There are a few knobs I use every day:
 
 * [**Program arguments**](/docs/configuration/program-arguments/) like `--server`, `--port`, `--interface`, and `--plugin`.
 * [**Environment variables**](/docs/configuration/environment-variables/) for container-friendly config, including `VOID_PLUGINS`, `VOID_WATCHDOG_ENABLE`, and `VOID_OFFLINE`.
-* [**File config**](/docs/configuration/in-file/) remains available if you prefer, but I keep the container immutable and do overrides via args and env.
+* [**File config**](/docs/configuration/in-file/) remains available if you prefer, but I keep the [**container**](/docs/containers) immutable and do overrides via args and env.
 
 That’s the gist. Now let’s put it into a Deployment that ships.
 


### PR DESCRIPTION
## Summary
Add cross-link to container docs from Kubernetes article.

## Rationale
Improves navigation by referencing container setup guidance where Kubernetes deployment notes mention containers.

## Changes
- Link to `/docs/containers` in Kubernetes guide.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e3ef77d2c832b9f5c5b136cefb706