### PR TITLE
docs(articles): 🔗 add container reference

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -24,7 +24,7 @@ If you’re running modded servers, you know the routine: weird handshakes, chan
 
 ## My mental model: one clean container, one clear port
 
-I keep Void as a single ephemeral container that owns the public port and forwards to whatever backend I declare. That’s it. No sidecars. No mystery env sprawl. If I want to swap configurations or try a different plugin, I kill and run again.
+I keep Void as a single ephemeral [**container**](/docs/containers/) that owns the public port and forwards to whatever backend I declare. That’s it. No sidecars. No mystery env sprawl. If I want to swap configurations or try a different plugin, I kill and run again.
 
 A few ground rules I follow: stateless by default, no mounting [**config volumes**](/docs/configuration/in-file/) unless I must, and host networking when I want port handling to be predictable.
 


### PR DESCRIPTION
## Summary
Adds cross-reference to container documentation in Docker setup article for easier navigation.

## Rationale
Helps readers quickly find container documentation without searching.

## Changes
- Link 'container' term in Docker setup article to container docs.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No performance impact; documentation only.

## Risks & Rollback
Low risk; revert commit to remove link.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689e3f211fa0832ba477453a4eccc33f