### PR TITLE
docs(articles): 📝 link watchdog docs

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -231,7 +231,7 @@ For the control plane, I keep the [**watchdog**](/docs/watchdog) on a ClusterIP 
 
 ## Observability that fits in your head
 
-The watchdog answers a handful of HTTP calls:
+The [**watchdog**](/docs/watchdog) answers a handful of HTTP calls:
 
 * `GET /health` tells you if the process is healthy.
 * `GET /bound` tells you if player sockets are being accepted.


### PR DESCRIPTION
## Summary
Add cross-link to Watchdog documentation from Kubernetes article.

## Rationale
Surface existing docs so readers can easily find Watchdog reference material.

## Changes
- Link "watchdog" term to existing documentation page.

## Verification
- `dotnet test src/Tests/Void.Tests.csproj` *(fails: .NET SDK 10.0 required)*

## Performance
N/A

## Risks & Rollback
Low risk. Revert commit if needed.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e432d7968832b9dbf4620f82e9d2d