### PR TITLE
docs(articles): 📝 link program arguments doc

### DIFF
--- a/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
+++ b/docs/astro/src/content/docs/articles/001-void-minecraft-proxy-docker.md
@@ -10,7 +10,7 @@ editUrl: false
 
 When I first pointed my server traffic through **Void**, I expected a weekend of tinkering and a long night of regrets. What I got instead was a clean, predictable setup that took minutes, felt modern, and frankly made me a little smug. If you’ve been juggling Velocity/Bungee-era rituals, or you’re running a modded network and want something that speaks fluent .NET and plain English, this is the path I wish I’d taken sooner.
 
-Let me walk you through exactly how I run Void in [**Docker**](/docs/containers/), why I chose the flags I did, and a few real‑world notes from putting it behind production traffic.
+Let me walk you through exactly how I run Void in [**Docker**](/docs/containers/), why I chose the [**flags**](/docs/configuration/program-arguments/) I did, and a few real‑world notes from putting it behind production traffic.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds cross-link from Docker article to program arguments reference.

## Rationale
Improves navigation by connecting runtime flag mention to detailed reference.

## Changes
- Link Docker article's flag mention to program arguments docs.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e432eea44832bacc816d473a6a286