### PR TITLE
docs(articles): 📝 link container doc in kubernetes guide

### DIFF
--- a/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
+++ b/docs/astro/src/content/docs/articles/002-void-on-kubernetes.md
@@ -288,7 +288,7 @@ I tag images carefully (`latest` for stable, separate channels for development).
 * **Pod is “ready” but players can’t join**: check `/bound`. If it’s `503`, the socket isn’t accepting yet—investigate port collisions or security policies. Your Service might also be pointing at the wrong `targetPort`.
 * **Liveness keeps restarting the pod**: if `/health` flaps under load, look at CPU limits first. Then check GC pressure. Increase memory limit by a notch and retest.
 * **Rolling restart still kicked players**: confirm that `preStop` executed. If your node was evicted hard, the lifecycle hook may not run; consider PodDisruptionBudgets to avoid simultaneous evictions.
-* **Plugins didn’t load**: verify URLs and that the container has egress. If dependencies are private, set `VOID_NUGET_REPOSITORIES` to reachable feeds.
+* **Plugins didn’t load**: verify URLs and that the [**container**](/docs/containers/) has egress. If dependencies are private, set `VOID_NUGET_REPOSITORIES` to reachable feeds.
 
 ---
 


### PR DESCRIPTION
## Summary
Add container reference link for plugin troubleshooting.

## Rationale
Provides quick navigation to container docs when resolving plugin issues.

## Changes
- Link Kubernetes troubleshooting note to container documentation.

## Verification
- `dotnet test Void.slnx` *(fails: element <Solution> unrecognized)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if problems arise.

## Breaking/Migration
None

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_689e43311150832b940f47c588cfa1ab