### PR TITLE
docs(forwardings): 📝 fix wording in forwarding docs

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -13,7 +13,7 @@ Modern forwarding was updated multiple times, enabling new features and fixing b
 :::
 
 :::note[Mods]
-Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/features/#mod-loaders), however community has created some mods implementing its protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
+Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/features/#mod-loaders); however, the community has created mods implementing the protocol, such as [Proxy Compatible Forge](https://github.com/adde0109/Proxy-Compatible-Forge).
 :::
 
 :::caution[Limitations]

--- a/docs/astro/src/content/docs/docs/forwardings/online.md
+++ b/docs/astro/src/content/docs/docs/forwardings/online.md
@@ -18,7 +18,7 @@ However, there are [**examples**](https://github.com/caunt/Void/blob/main/src/Se
 
 :::caution[Limitations]
 - You have to install a plugin, mod, or server with built-in implementation.
-- Does not support redirections to online servers until release of [Transfer packet](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Transfer_(configuration)) (1.20.5) version.
+- Does not support redirections to online servers until the release of the [Transfer packet](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Transfer_(configuration)) (1.20.5).
 :::
 
 ## Configuration


### PR DESCRIPTION
## Summary
Correct minor wording in forwarding documentation.

## Rationale
Improves clarity in forwarding setup guides; no alternative approaches considered.

## Changes
- Adjust grammar in Modern forwarding guide
- Clarify Transfer packet note in Online forwarding guide

## Verification
- `codespell docs/astro/src/content/docs/docs/forwardings/modern.md docs/astro/src/content/docs/docs/forwardings/online.md`
- `dotnet build` *(fails: the element `<Solution>` is unrecognized in `Void.slnx`)*
- `dotnet test` *(fails: no project or solution file)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None required.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e4b6a6a40832ba1d021383d4f2786