### PR TITLE
docs(forwardings): 📝 clarify player information phrasing

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/docs/forwardings/legacy.md
@@ -12,7 +12,7 @@ This forwarding is currently not implemented in Void.
 BungeeCord, also known as Legacy forwarding, is a type of forwarding player data developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).
 
 :::tip
-It is the easiest way to pass player's information from proxy to server in Handshake packet, supported by many server implementations.
+It is the easiest way to pass player information from the proxy to the server in the handshake packet, supported by many server implementations.
 Legacy forwarding may include additional data, such as forge FML markers.
 :::
 

--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -8,7 +8,7 @@ sidebar:
 Velocity, also known as Modern forwarding, is a type of forwarding player data developed by [PaperMC](https://docs.papermc.io/velocity/player-information-forwarding/).
 
 :::tip
-It is a secure way to pass player's information from proxy to server, supported by many server implementations.
+It is a secure way to pass player information from the proxy to the server, supported by many server implementations.
 Modern forwarding was updated multiple times, enabling new features and fixing bugs.
 :::
 


### PR DESCRIPTION
## Summary
Improve grammar in forwarding documentation.

## Rationale
Clarifies player data flow in forwarding docs; leaving wording as-is could confuse readers.

## Changes
- Fix player information phrasing in Legacy forwarding docs
- Fix player information phrasing in Modern forwarding docs

## Verification
- `dotnet test`
- `codespell docs/astro/src/content/docs/docs/forwardings/legacy.md docs/astro/src/content/docs/docs/forwardings/modern.md`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore previous wording.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e4b6cd674832bb76c537c5d725bc3