### PR TITLE
docs(readme): fix tagline punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <div align="center" id="toc">
   <ul style="list-style: none">
     <summary>
-      <h1>:star: Minecraft Proxy for Modded servers.</h1>
+      <h1>:star: Minecraft Proxy for Modded Servers</h1>
     </summary>
   </ul>
 </div>


### PR DESCRIPTION
## Summary
Remove trailing period and fix capitalization in README tagline.

## Rationale
Provides consistent style in the main README heading; no other approaches considered.

## Changes
- Capitalize "Servers" and drop trailing period in README tagline.

## Verification
- `dotnet test`

## Performance
No performance impact.

## Risks & Rollback
Low risk. Revert commit to restore previous wording.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e4b796518832b99f8221a1a2e6b86