### PR TITLE
perf(tests): ⚡ avoid params allocation in CollectingTextWriter

### DIFF
--- a/src/Tests/Streams/CollectingTextWriter.cs
+++ b/src/Tests/Streams/CollectingTextWriter.cs
@@ -27,7 +27,8 @@ public class CollectingTextWriter : TextWriter
         get
         {
             var text = Text;
-            return text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in text.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                yield return line.TrimEnd('\r');
         }
     }
 


### PR DESCRIPTION
## Summary
Reduce splitting overhead in CollectingTextWriter.

## Rationale
Avoids allocating a separator array when splitting lines.

## Changes
- Use char-based Split and trim carriage returns in CollectingTextWriter

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Eliminates small separator array allocations during line parsing.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689e4ba137c0832bad2d372729995311