### PR TITLE
perf(minecraft): ⚡ avoid substring allocation in long parser

### DIFF
--- a/src/Minecraft/Commands/Brigadier/StringReader.cs
+++ b/src/Minecraft/Commands/Brigadier/StringReader.cs
@@ -91,12 +91,12 @@ public class StringReader(string source, int cursor = 0) : IImmutableStringReade
         while (CanRead && IsAllowedNumber(Peek))
             Skip();
 
-        var number = Source[start..Cursor];
+        var span = Source.AsSpan(start, Cursor - start);
 
-        if (number.Length is 0)
+        if (span.Length is 0)
             throw CommandSyntaxException.BuiltInExceptions.ReaderExpectedLong.CreateWithContext(this);
 
-        if (long.TryParse(number, out var result))
+        if (long.TryParse(span, out var result))
             return result;
 
         Cursor = start;


### PR DESCRIPTION
## Summary
Avoids string allocation when parsing longs.

## Rationale
Reduces temporary allocations in command parsing.

## Changes
- Use `ReadOnlySpan<char>` in `StringReader.ReadLong` to avoid substring allocation.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Removes a temporary string allocation during long parsing.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e4badf928832bbf65b88812a25808