### PR TITLE
perf(common): ♻️ use span-based stream write

### DIFF
--- a/src/Plugins/Common/Network/Streams/Compression/SharpZipLibCompressionMessageStream.cs
+++ b/src/Plugins/Common/Network/Streams/Compression/SharpZipLibCompressionMessageStream.cs
@@ -248,7 +248,7 @@ public class SharpZipLibCompressionMessageStream : RecyclableStream, ICompleteMe
                     _compressor.SetInput(chunkArray, 0, chunkLength);
 
                     while (!_compressor.IsNeedingInput && _compressor.Deflate(buffer) is var compressedLength and not 0)
-                        stream.Write(buffer, 0, compressedLength);
+                        stream.Write(buffer.AsSpan(0, compressedLength));
                 }
                 finally
                 {


### PR DESCRIPTION
## Summary
Optimize compression stream write path.

## Rationale
Span overload avoids array-based Stream.Write overhead.

## Changes
- Use `stream.Write` ReadOnlySpan overload when flushing compressor output.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No measured change; removes one allocation opportunity.

## Risks & Rollback
Low risk; revert commit to restore previous behavior.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689e4bb73d94832b95086adfed113625