### PR TITLE
fix(console): 🐛 remove unreachable null check

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -31,9 +31,6 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
             return;
         }
 
-        if (_reader is null)
-            throw new InvalidOperationException($"{nameof(ConsoleService)} is not set up. Call {nameof(Setup)}() before using this method.");
-
         var command = await _reader.ReadLineAsync(SuggestAsync, cancellationToken);
         logger.LogInformation("Proxy issued command: {command}", command);
 


### PR DESCRIPTION
## Summary
Remove unreachable null check from console command handler.

## Rationale
Eliminates dead code and clarifies setup requirements.

## Changes
- drop impossible `_reader` null check in `ConsoleService.HandleCommandsAsync`

## Verification
- `dotnet build`
- `dotnet test` *(fails: terminated early)*

## Performance
N/A

## Risks & Rollback
Low; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e4cc417cc832b90f557fd1ab56df8