### PR TITLE
test(integration): ✅ add proxied server switch tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedServerSwitchTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerSwitchTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedServerSwitchTests(ProxiedServerSwitchTests.NetworkFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedServerSwitchTests.NetworkFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerSwitchesServersThroughProxy()
+    {
+        var message1 = $"server1-{Random.Shared.Next()}";
+        var message2 = $"server2-{Random.Shared.Next()}";
+        var message3 = $"server1-again-{Random.Shared.Next()}";
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SwitchServersAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_3, "args-server-1", "args-server-2", message1, message2, message3, cancellationTokenSource.Token);
+
+            await fixture.PaperServer1.ExpectTextAsync(message1, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer2.ExpectTextAsync(message2, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(message3, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.PaperServer1.Logs, line => line.Contains(message1));
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains(message2));
+            Assert.Contains(fixture.PaperServer1.Logs, line => line.Contains(message3));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class NetworkFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public NetworkFixture() : base(nameof(ProxiedServerSwitchTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: "PaperServer1", port: Server1Port, version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: "PaperServer2", port: Server2Port, version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServers: new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -20,14 +20,16 @@ public class MineflayerClient : IntegrationSideBase
 {
     private readonly string _nodePath;
     private readonly string _scriptPath;
+    private readonly string _switchServersScriptPath;
 
     public static TheoryData<ProtocolVersion> SupportedVersions { get; } = [.. ProtocolVersion
                 .Range(ProtocolVersion.MINECRAFT_1_21_4, ProtocolVersion.MINECRAFT_1_8)];
 
-    private MineflayerClient(string nodePath, string scriptPath)
+    private MineflayerClient(string nodePath, string scriptPath, string switchServersScriptPath)
     {
         _nodePath = nodePath;
         _scriptPath = scriptPath;
+        _switchServersScriptPath = switchServersScriptPath;
     }
 
     public static async Task<MineflayerClient> CreateAsync(string workingDirectory, HttpClient client, CancellationToken cancellationToken = default)
@@ -60,15 +62,68 @@ public class MineflayerClient : IntegrationSideBase
             bot.on('error', err => console.error('ERROR:' + err.message));
             """, cancellationToken);
 
-        if (!OperatingSystem.IsWindows())
-            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        var switchServersScriptPath = Path.Combine(workingDirectory, "switch.js");
+        await File.WriteAllTextAsync(switchServersScriptPath, $$"""
+            const mineflayer = require('mineflayer');
+            const [address, version, server2, server1, text1, text2, text3] = process.argv.slice(2);
+            const [host, portString] = address.split(':');
+            const port = parseInt(portString ?? '25565', 10);
+            const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
-        return new(nodePath, scriptPath);
+            bot.on('spawn', () => {
+                bot.chat(text1);
+                setTimeout(() => {
+                    bot.chat(`/server ${server2}`);
+                    setTimeout(() => {
+                        bot.chat(text2);
+                        setTimeout(() => {
+                            bot.chat(`/server ${server1}`);
+                            setTimeout(() => {
+                                bot.chat(text3);
+                                setTimeout(() => { console.log('end'); bot.end(); }, 5000);
+                            }, 5000);
+                        }, 5000);
+                    }, 5000);
+                }, 5000);
+            });
+
+            bot.on('kicked', reason => console.error('KICK:' + reason));
+            bot.on('error', err => console.error('ERROR:' + err.message));
+            """, cancellationToken);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            File.SetUnixFileMode(switchServersScriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        return new(nodePath, scriptPath, switchServersScriptPath);
     }
 
     public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
         StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+
+        var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
+
+        if (_process is not { HasExited: false })
+            throw new IntegrationTestException("Failed to start Mineflayer bot.");
+
+        try
+        {
+            await consoleTask;
+            await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+        finally
+        {
+            if (_process is { HasExited: false })
+                await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+    }
+
+    public async Task SwitchServersAsync(string address, ProtocolVersion protocolVersion, string server1Name, string server2Name, string text1, string text2, string text3, CancellationToken cancellationToken = default)
+    {
+        StartApplication(_nodePath, hasInput: false, _switchServersScriptPath, address, protocolVersion.MostRecentSupportedVersion, server2Name, server1Name, text1, text2, text3);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,10 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default) =>
+        CreateAsync(new[] { targetServer }, proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,7 +39,6 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
@@ -46,6 +48,12 @@ public class VoidProxy : IIntegrationSide
 
         if (offlineMode)
             args.Add("--offline");
+
+        foreach (var targetServer in targetServers)
+        {
+            args.Add("--server");
+            args.Add(targetServer);
+        }
 
         var task = EntryPoint.RunAsync(logWriter: logWriter, cancellationToken: cancellationToken, args: [.. args]);
 


### PR DESCRIPTION
## Summary
Add integration tests verifying proxied server switching between Paper instances.

## Rationale
Ensures proxy properly redirects clients across multiple backend servers.

## Changes
- allow PaperServer to use named working directories and custom version
- support multiple target servers in VoidProxy
- extend Mineflayer client with scripted server switching
- add proxied server switch integration test

## Verification
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter FullyQualifiedName~ProxiedServerSwitchTests`

## Performance
N/A

## Risks & Rollback
Low risk; revert commits to remove tests and helpers.

## Breaking/Migration
None.

## Links
- Related to integration test coverage

------
https://chatgpt.com/codex/tasks/task_e_689e99ba24d4832baa2d6fe23e63fccf