### PR TITLE
test(integration): 🧪 add mineflayer server redirection tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.MultiServerFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedServerRedirectionTests.MultiServerFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerSwitchesBetweenServers()
+    {
+        var text1 = $"hello from server1 #{Random.Shared.Next()}";
+        var text2 = $"hello from server2 #{Random.Shared.Next()}";
+        var text3 = $"hello again from server1 #{Random.Shared.Next()}";
+
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendServerSwitchMessagesAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_3, fixture.Server1Name, fixture.Server2Name, text1, text2, text3, cancellationTokenSource.Token);
+
+            await fixture.PaperServer1.ExpectTextAsync(text1, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer2.ExpectTextAsync(text2, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(text3, lookupHistory: true, cancellationTokenSource.Token);
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class MultiServerFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public MultiServerFixture() : base(nameof(ProxiedServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public string Server1Name => "args-server-1";
+        public string Server2Name => "args-server-2";
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, name: "server1", port: Server1Port, version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, name: "server2", port: Server2Port, version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +36,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");
@@ -55,6 +60,9 @@ public class VoidProxy : IIntegrationSide
 
         return new VoidProxy(logWriter, task, cancellationTokenSource);
     }
+
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+        => CreateAsync(new[] { targetServer }, proxyPort, ignoreFileServers, offlineMode, cancellationToken);
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -1,115 +1,123 @@
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using Void.Tests.Exceptions;
-using Void.Tests.Extensions;
-
-namespace Void.Tests.Integration.Sides.Servers;
-
-public class PaperServer : IntegrationSideBase
-{
-    private const string ViaVersionRepositoryOwnerName = "ViaVersion";
-    private const string ViaVersionRepositoryName = "ViaVersion";
-    private const string ViaBackwardsRepositoryName = "ViaBackwards";
-    private const string ViaRewindRepositoryName = "ViaRewind";
-
-    private readonly string _binaryPath;
-
-    private PaperServer(string binaryPath, string jreBinaryPath)
-    {
-        _binaryPath = binaryPath;
-        _jreBinaryPath = jreBinaryPath;
-
-        StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
-    }
-
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Tests.Exceptions;
+using Void.Tests.Extensions;
+
+namespace Void.Tests.Integration.Sides.Servers;
+
+public class PaperServer : IntegrationSideBase
+{
+    private const string ViaVersionRepositoryOwnerName = "ViaVersion";
+    private const string ViaVersionRepositoryName = "ViaVersion";
+    private const string ViaBackwardsRepositoryName = "ViaBackwards";
+    private const string ViaRewindRepositoryName = "ViaRewind";
+
+    private readonly string _binaryPath;
+
+    private PaperServer(string binaryPath, string jreBinaryPath)
+    {
+        _binaryPath = binaryPath;
+        _jreBinaryPath = jreBinaryPath;
+
+        StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
+    }
+
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, string name = "PaperServer", int port = 25565, PaperPlugins plugins = PaperPlugins.All, string? version = null, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, name);
 
-        if (!Directory.Exists(workingDirectory))
-            Directory.CreateDirectory(workingDirectory);
+        if (!Directory.Exists(workingDirectory))
+            Directory.CreateDirectory(workingDirectory);
+
+        string targetVersion;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
+            using var versions = JsonDocument.Parse(versionsJson);
+            targetVersion = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
+        }
+        else
+        {
+            targetVersion = version;
+        }
 
-        var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
-        using var versions = JsonDocument.Parse(versionsJson);
-        var latestVersion = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
-
-        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}", cancellationToken);
+        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{targetVersion}", cancellationToken);
         using var builds = JsonDocument.Parse(buildsJson);
         var latestBuild = builds.RootElement.GetProperty("builds").EnumerateArray().Last().GetInt32();
 
-        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}", cancellationToken);
-        using var buildInfo = JsonDocument.Parse(buildInfoJson);
-        var jarName = buildInfo.RootElement.GetProperty("downloads").GetProperty("application").GetProperty("name").GetString();
-
-        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}/downloads/{jarName}";
-        var paperJarPath = Path.Combine(workingDirectory, "paper.jar");
-
-        await client.DownloadFileAsync(paperUrl, paperJarPath, cancellationToken);
-        await SetupCompatibilityPluginsAsync(workingDirectory, client, plugins, cancellationToken);
-
-        await File.WriteAllTextAsync(Path.Combine(workingDirectory, "eula.txt"), "eula=true", cancellationToken);
-        await File.WriteAllTextAsync(Path.Combine(workingDirectory, "server.properties"), $"server-port={port}\nonline-mode=false\ndifficulty=0\n", cancellationToken);
-
-        var instance = new PaperServer(paperJarPath, jreBinaryPath);
-        await instance.ExpectTextAsync("For help, type \"help\"", lookupHistory: true, cancellationToken);
-
-        return instance;
-    }
-
-    public async Task ExpectTextAsync(string text, bool lookupHistory = true, CancellationToken cancellationToken = default)
-    {
-        if (_process is not { HasExited: false })
-            throw new IntegrationTestException("Failed to start Paper server.");
-
-        if (lookupHistory && Logs.Any(log => log.Contains(text)))
-            return;
-
-        await ReceiveOutputAsync(line => HandleConsole(line, text), cancellationToken);
-    }
-
-    private static bool HandleConsole(string line, string expectedText)
-    {
-        if (line.Contains("java.lang.UnsupportedClassVersionError"))
-            throw new IntegrationTestException("Incompatible Java version for the server");
-
-        if (line.Contains("You need to agree to the EULA in order to run the server"))
-            throw new IntegrationTestException("Server EULA not accepted");
-
-        if (line.Contains(expectedText))
-            return true;
-
-        return false;
-    }
-
-    private static async Task SetupCompatibilityPluginsAsync(string workingDirectory, HttpClient client, PaperPlugins plugins, CancellationToken cancellationToken)
-    {
-        var pluginsDirectory = Path.Combine(workingDirectory, "plugins");
-
-        if (!Directory.Exists(pluginsDirectory))
-            Directory.CreateDirectory(pluginsDirectory);
-
-        if (plugins.HasFlag(PaperPlugins.ViaVersion))
-        {
-            var viaVersion = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaVersionRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
-            await client.DownloadFileAsync(viaVersion, Path.Combine(pluginsDirectory, "ViaVersion.jar"), cancellationToken);
-        }
-
-        if (plugins.HasFlag(PaperPlugins.ViaBackwards))
-        {
-            var viaBackwards = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaBackwardsRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
-            await client.DownloadFileAsync(viaBackwards, Path.Combine(pluginsDirectory, "ViaBackwards.jar"), cancellationToken);
-        }
-
-        if (plugins.HasFlag(PaperPlugins.ViaRewind))
-        {
-            var viaRewind = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaRewindRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
-            await client.DownloadFileAsync(viaRewind, Path.Combine(pluginsDirectory, "ViaRewind.jar"), cancellationToken);
-        }
-    }
-}
+        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{targetVersion}/builds/{latestBuild}", cancellationToken);
+        using var buildInfo = JsonDocument.Parse(buildInfoJson);
+        var jarName = buildInfo.RootElement.GetProperty("downloads").GetProperty("application").GetProperty("name").GetString();
+
+        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{targetVersion}/builds/{latestBuild}/downloads/{jarName}";
+        var paperJarPath = Path.Combine(workingDirectory, "paper.jar");
+
+        await client.DownloadFileAsync(paperUrl, paperJarPath, cancellationToken);
+        await SetupCompatibilityPluginsAsync(workingDirectory, client, plugins, cancellationToken);
+
+        await File.WriteAllTextAsync(Path.Combine(workingDirectory, "eula.txt"), "eula=true", cancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(workingDirectory, "server.properties"), $"server-port={port}\nonline-mode=false\ndifficulty=0\n", cancellationToken);
+
+        var instance = new PaperServer(paperJarPath, jreBinaryPath);
+        await instance.ExpectTextAsync("For help, type \"help\"", lookupHistory: true, cancellationToken);
+
+        return instance;
+    }
+
+    public async Task ExpectTextAsync(string text, bool lookupHistory = true, CancellationToken cancellationToken = default)
+    {
+        if (_process is not { HasExited: false })
+            throw new IntegrationTestException("Failed to start Paper server.");
+
+        if (lookupHistory && Logs.Any(log => log.Contains(text)))
+            return;
+
+        await ReceiveOutputAsync(line => HandleConsole(line, text), cancellationToken);
+    }
+
+    private static bool HandleConsole(string line, string expectedText)
+    {
+        if (line.Contains("java.lang.UnsupportedClassVersionError"))
+            throw new IntegrationTestException("Incompatible Java version for the server");
+
+        if (line.Contains("You need to agree to the EULA in order to run the server"))
+            throw new IntegrationTestException("Server EULA not accepted");
+
+        if (line.Contains(expectedText))
+            return true;
+
+        return false;
+    }
+
+    private static async Task SetupCompatibilityPluginsAsync(string workingDirectory, HttpClient client, PaperPlugins plugins, CancellationToken cancellationToken)
+    {
+        var pluginsDirectory = Path.Combine(workingDirectory, "plugins");
+
+        if (!Directory.Exists(pluginsDirectory))
+            Directory.CreateDirectory(pluginsDirectory);
+
+        if (plugins.HasFlag(PaperPlugins.ViaVersion))
+        {
+            var viaVersion = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaVersionRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
+            await client.DownloadFileAsync(viaVersion, Path.Combine(pluginsDirectory, "ViaVersion.jar"), cancellationToken);
+        }
+
+        if (plugins.HasFlag(PaperPlugins.ViaBackwards))
+        {
+            var viaBackwards = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaBackwardsRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
+            await client.DownloadFileAsync(viaBackwards, Path.Combine(pluginsDirectory, "ViaBackwards.jar"), cancellationToken);
+        }
+
+        if (plugins.HasFlag(PaperPlugins.ViaRewind))
+        {
+            var viaRewind = await GetGitHubRepositoryLatestReleaseAssetAsync(ViaVersionRepositoryOwnerName, ViaRewindRepositoryName, name => name.EndsWith(".jar"), cancellationToken);
+            await client.DownloadFileAsync(viaRewind, Path.Combine(pluginsDirectory, "ViaRewind.jar"), cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add end-to-end test verifying Mineflayer client can hop between Paper servers via proxy.

## Rationale
Ensures multi-server routing works through the proxy.

## Changes
- Allow PaperServer to accept instance name and optional version.
- Support multiple target servers in VoidProxy.
- Add Mineflayer helper for server switching.
- Add ProxiedServerRedirectionTests.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ProxiedServerRedirectionTests`

## Performance
N/A

## Risks & Rollback
Low risk: confined to tests. Revert commit to rollback.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e99adaee0832b93f40b655b43f82a