### PR TITLE
test(integration): 🤖 add multi-server redirection e2e

### DIFF
--- a/src/Tests/Integration/Connections/Units/DirectConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/DirectConnectionTests.cs
@@ -92,7 +92,7 @@ public class DirectConnectionTests(DirectConnectionTests.PaperMccFixture fixture
 
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
-            PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
+            PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, nameof(PaperServer), port: ServerPort, cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.PaperVoidMccFixture f
 
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
-            PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
+            PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, nameof(PaperServer), port: ServerPort, cancellationToken: cancellationTokenSource.Token);
             VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
         }
 

--- a/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedRedirectionTests(ProxiedRedirectionTests.TwoServersFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedRedirectionTests.TwoServersFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerSwitchesBetweenServers()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendCommandsAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_21_4, ["/server args-server-2", "/server args-server-1"], cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.Server2.Logs, line => line.Contains("joined the game"));
+            Assert.True(fixture.Server1.Logs.Count(line => line.Contains("joined the game")) >= 2);
+        }, fixture.MineflayerClient, fixture.Proxy, fixture.Server1, fixture.Server2);
+    }
+
+    public class TwoServersFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public TwoServersFixture() : base(nameof(ProxiedRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer Server1 { get => field ?? throw new InvalidOperationException($"{nameof(Server1)} is not initialized."); set; }
+        public PaperServer Server2 { get => field ?? throw new InvalidOperationException($"{nameof(Server2)} is not initialized."); set; }
+        public VoidProxy Proxy { get => field ?? throw new InvalidOperationException($"{nameof(Proxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            Server1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, "server1", port: Server1Port, cancellationToken: cancellationTokenSource.Token);
+            Server2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, "server2", port: Server2Port, cancellationToken: cancellationTokenSource.Token);
+            Proxy = await VoidProxy.CreateAsync([
+                    $"localhost:{Server1Port}",
+                    $"localhost:{Server2Port}"
+                ], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (Server1 is not null)
+                await Server1.DisposeAsync();
+
+            if (Server2 is not null)
+                await Server2.DisposeAsync();
+
+            if (Proxy is not null)
+                await Proxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -1,6 +1,7 @@
 namespace Void.Tests.Integration.Sides.Clients;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO;
@@ -43,17 +44,26 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...messages] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
+            let index = 0;
+            const sendNext = () => {
+                if (index < messages.length) {
+                    bot.chat(messages[index++]);
+                    setTimeout(sendNext, 5000);
+                } else {
+                    setTimeout(() => {
+                        console.log('end');
+                        bot.end();
+                    }, 5000);
+                }
+            };
+
             bot.on('spawn', () => {
-                bot.chat(text);
-                setTimeout(() => {
-                    console.log('end');
-                    bot.end();
-                }, 5000);
+                sendNext();
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -68,7 +78,15 @@ public class MineflayerClient : IntegrationSideBase
 
     public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        await SendCommandsAsync(address, protocolVersion, [text], cancellationToken);
+    }
+
+    public async Task SendCommandsAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> commands, CancellationToken cancellationToken = default)
+    {
+        var args = new List<string> { _scriptPath, address, protocolVersion.MostRecentSupportedVersion };
+        args.AddRange(commands);
+
+        StartApplication(_nodePath, hasInput: false, [.. args]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,10 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+        => CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +39,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -26,11 +27,13 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, string instanceName, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        ArgumentException.ThrowIfNullOrWhiteSpace(instanceName);
+
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Add Mineflayer E2E test covering cross-server redirection via proxy.

## Rationale
Ensures proxy correctly handles /server swaps between multiple backend Paper servers.

## Changes
- Allow naming PaperServer instances for isolated working directories.
- Support multiple target servers in VoidProxy.
- Enable Mineflayer client to send sequential commands.
- Add ProxiedRedirectionTests to validate /server hopping.

## Verification
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ProxiedRedirectionTests`

## Performance
N/A.

## Risks & Rollback
Minimal; affects test harness only. Revert commit to remove.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_689e99aad920832b94bfd196dbf87e48