### PR TITLE
test(integration): ✅ add Mineflayer redirection E2E

### DIFF
--- a/src/Platform/Servers/ServerService.cs
+++ b/src/Platform/Servers/ServerService.cs
@@ -35,7 +35,17 @@ public class ServerService(ILogger<ServerService> logger, ISettings settings, In
                 continue;
             }
 
-            if (!Uri.TryCreate($"tcp://{argument}", UriKind.Absolute, out var uri))
+            var name = $"args-server-{index++}";
+            var endpoint = argument;
+
+            if (argument.Contains('='))
+            {
+                var split = argument.Split('=', 2);
+                name = split[0];
+                endpoint = split[1];
+            }
+
+            if (!Uri.TryCreate($"tcp://{endpoint}", UriKind.Absolute, out var uri))
             {
                 logger.LogWarning("Invalid server {Server}", argument);
                 continue;
@@ -50,7 +60,7 @@ public class ServerService(ILogger<ServerService> logger, ISettings settings, In
                 continue;
             }
 
-            yield return new Server($"args-server-{index++}", host, port);
+            yield return new Server(name, host, port);
         }
     }
 }

--- a/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedRedirectionTests(ProxiedRedirectionTests.TwoServersFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedRedirectionTests.TwoServersFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerRedirectsBetweenTwoServers()
+    {
+        var firstMessage = $"first-{Random.Shared.Next()}";
+        var secondMessage = $"second-{Random.Shared.Next()}";
+        var thirdMessage = $"third-{Random.Shared.Next()}";
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendCommandsAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_3, new[]
+            {
+                firstMessage,
+                "/server server2",
+                secondMessage,
+                "/server server1",
+                thirdMessage
+            }, cancellationTokenSource.Token);
+
+            await fixture.Server1.ExpectTextAsync(firstMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server2.ExpectTextAsync(secondMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server1.ExpectTextAsync(thirdMessage, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(firstMessage));
+            Assert.Contains(fixture.Server2.Logs, line => line.Contains(secondMessage));
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(thirdMessage));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.Server1, fixture.Server2);
+    }
+
+    public class TwoServersFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        private const string Server1Name = "server1";
+        private const string Server2Name = "server2";
+
+        public TwoServersFixture() : base(nameof(ProxiedRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer Server1 { get => field ?? throw new InvalidOperationException($"{nameof(Server1)} is not initialized."); set; }
+        public PaperServer Server2 { get => field ?? throw new InvalidOperationException($"{nameof(Server2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            Server1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: Server1Name, port: Server1Port, cancellationToken: cancellationTokenSource.Token);
+            Server2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: Server2Name, port: Server2Port, cancellationToken: cancellationTokenSource.Token);
+
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"{Server1Name}=localhost:{Server1Port}", proxyPort: ProxyPort, additionalServers: [$"{Server2Name}=localhost:{Server2Port}"], cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (Server1 is not null)
+                await Server1.DisposeAsync();
+
+            if (Server2 is not null)
+                await Server2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -2,6 +2,7 @@ namespace Void.Tests.Integration.Sides.Clients;
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
@@ -43,17 +44,29 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...texts] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
             bot.on('spawn', () => {
-                bot.chat(text);
-                setTimeout(() => {
-                    console.log('end');
-                    bot.end();
-                }, 5000);
+                let index = 0;
+
+                const sendNext = () => {
+                    if (index >= texts.length) {
+                        setTimeout(() => {
+                            console.log('end');
+                            bot.end();
+                        }, 5000);
+
+                        return;
+                    }
+
+                    bot.chat(texts[index++]);
+                    setTimeout(sendNext, 1000);
+                };
+
+                sendNext();
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -66,9 +79,16 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        return SendCommandsAsync(address, protocolVersion, [text], cancellationToken);
+    }
+
+    public async Task SendCommandsAsync(string address, ProtocolVersion protocolVersion, string[] texts, CancellationToken cancellationToken = default)
+    {
+        var arguments = new List<string> { _scriptPath, address, protocolVersion.MostRecentSupportedVersion };
+        arguments.AddRange(texts);
+        StartApplication(_nodePath, hasInput: false, arguments.ToArray());
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(string? targetServer, int proxyPort, IEnumerable<string>? additionalServers = null, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +36,24 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        if (targetServer is not null)
+        {
+            args.Add("--server");
+            args.Add(targetServer);
+        }
+
+        if (additionalServers is not null)
+        {
+            foreach (var server in additionalServers)
+            {
+                args.Add("--server");
+                args.Add(server);
+            }
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, string instanceName = "PaperServer", int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Adds end-to-end redirection test and server naming support.

## Rationale
Ensures proxy correctly swaps between backend servers when commanded.

## Changes
- allow naming CLI-defined servers
- support multi-command Mineflayer scripts
- add Mineflayer redirection test across two Paper servers

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter "FullyQualifiedName~ProxiedRedirectionTests"`

## Performance
N/A

## Risks & Rollback
Low-risk; revert commits to remove test and server CLI naming.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689e99a6b0a0832bb737788582dd92d0