### PR TITLE
test(integration): 🧪 add Mineflayer redirection e2e tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Connections;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ServerRedirectionTests(ServerRedirectionTests.RedirectionFixture fixture) : ConnectionUnitBase, IClassFixture<ServerRedirectionTests.RedirectionFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+    private const string Server1Name = "args-server-1";
+    private const string Server2Name = "args-server-2";
+    private const string ExpectedText = "hello redirection";
+
+    [ProxiedFact]
+    public async Task MineflayerMovesBetweenServers()
+    {
+        var firstMessage = $"{ExpectedText} #1 #{Random.Shared.Next()}";
+        var secondMessage = $"{ExpectedText} #2 #{Random.Shared.Next()}";
+        var thirdMessage = $"{ExpectedText} #3 #{Random.Shared.Next()}";
+
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SwitchServersAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_21_4, Server1Name, Server2Name, firstMessage, secondMessage, thirdMessage, cancellationTokenSource.Token);
+
+            await fixture.Server1.ExpectTextAsync(firstMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server2.ExpectTextAsync(secondMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server1.ExpectTextAsync(thirdMessage, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(firstMessage));
+            Assert.Contains(fixture.Server2.Logs, line => line.Contains(secondMessage));
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(thirdMessage));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.Server1, fixture.Server2);
+    }
+
+    public class RedirectionFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public RedirectionFixture() : base(nameof(ServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer Server1 { get => field ?? throw new InvalidOperationException($"{nameof(Server1)} is not initialized."); set; }
+        public PaperServer Server2 { get => field ?? throw new InvalidOperationException($"{nameof(Server2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            const string paperVersion = "1.20.4";
+            Server1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", minecraftVersion: paperVersion, cancellationToken: cancellationTokenSource.Token);
+            Server2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", minecraftVersion: paperVersion, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (Server1 is not null)
+                await Server1.DisposeAsync();
+
+            if (Server2 is not null)
+                await Server2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -20,14 +20,16 @@ public class MineflayerClient : IntegrationSideBase
 {
     private readonly string _nodePath;
     private readonly string _scriptPath;
+    private readonly string _switchScriptPath;
 
     public static TheoryData<ProtocolVersion> SupportedVersions { get; } = [.. ProtocolVersion
                 .Range(ProtocolVersion.MINECRAFT_1_21_4, ProtocolVersion.MINECRAFT_1_8)];
 
-    private MineflayerClient(string nodePath, string scriptPath)
+    private MineflayerClient(string nodePath, string scriptPath, string switchScriptPath)
     {
         _nodePath = nodePath;
         _scriptPath = scriptPath;
+        _switchScriptPath = switchScriptPath;
     }
 
     public static async Task<MineflayerClient> CreateAsync(string workingDirectory, HttpClient client, CancellationToken cancellationToken = default)
@@ -60,15 +62,63 @@ public class MineflayerClient : IntegrationSideBase
             bot.on('error', err => console.error('ERROR:' + err.message));
             """, cancellationToken);
 
-        if (!OperatingSystem.IsWindows())
-            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        var switchScriptPath = Path.Combine(workingDirectory, "bot-switch.js");
+        await File.WriteAllTextAsync(switchScriptPath, $$"""
+            const mineflayer = require('mineflayer');
+            const [address, version, server1, server2, text1, text2, text3] = process.argv.slice(2);
+            const [host, portString] = address.split(':');
+            const port = parseInt(portString ?? '25565', 10);
+            const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
-        return new(nodePath, scriptPath);
+            bot.on('spawn', () => {
+                bot.chat(text1);
+                setTimeout(() => { bot.chat(`/server ${server2}`); }, 2000);
+                setTimeout(() => { bot.chat(text2); }, 4000);
+                setTimeout(() => { bot.chat(`/server ${server1}`); }, 6000);
+                setTimeout(() => { bot.chat(text3); }, 8000);
+                setTimeout(() => {
+                    console.log('end');
+                    bot.end();
+                }, 10000);
+            });
+
+            bot.on('kicked', reason => console.error('KICK:' + reason));
+            bot.on('error', err => console.error('ERROR:' + err.message));
+            """, cancellationToken);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            File.SetUnixFileMode(switchScriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        return new(nodePath, scriptPath, switchScriptPath);
     }
 
     public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
         StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+
+        var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
+
+        if (_process is not { HasExited: false })
+            throw new IntegrationTestException("Failed to start Mineflayer bot.");
+
+        try
+        {
+            await consoleTask;
+            await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+        finally
+        {
+            if (_process is { HasExited: false })
+                await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+    }
+
+    public async Task SwitchServersAsync(string address, ProtocolVersion protocolVersion, string server1Name, string server2Name, string firstMessage, string secondMessage, string thirdMessage, CancellationToken cancellationToken = default)
+    {
+        StartApplication(_nodePath, hasInput: false, _switchScriptPath, address, protocolVersion.MostRecentSupportedVersion, server1Name, server2Name, firstMessage, secondMessage, thirdMessage);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,10 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+        => CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +39,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,28 +26,32 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string? instanceName = null, string? minecraftVersion = null, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName ?? nameof(PaperServer));
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);
 
         var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
         using var versions = JsonDocument.Parse(versionsJson);
-        var latestVersion = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
+        var versionsList = versions.RootElement.GetProperty("versions").EnumerateArray().Select(element => element.GetString()).ToList();
+        var version = minecraftVersion ?? versionsList.Last();
 
-        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}", cancellationToken);
+        if (minecraftVersion is not null && !versionsList.Contains(minecraftVersion))
+            throw new IntegrationTestException($"Paper version {minecraftVersion} not found.");
+
+        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}", cancellationToken);
         using var builds = JsonDocument.Parse(buildsJson);
         var latestBuild = builds.RootElement.GetProperty("builds").EnumerateArray().Last().GetInt32();
 
-        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}", cancellationToken);
+        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{latestBuild}", cancellationToken);
         using var buildInfo = JsonDocument.Parse(buildInfoJson);
         var jarName = buildInfo.RootElement.GetProperty("downloads").GetProperty("application").GetProperty("name").GetString();
 
-        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}/downloads/{jarName}";
+        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{latestBuild}/downloads/{jarName}";
         var paperJarPath = Path.Combine(workingDirectory, "paper.jar");
 
         await client.DownloadFileAsync(paperUrl, paperJarPath, cancellationToken);


### PR DESCRIPTION
## Summary
Add an end-to-end test verifying that a Mineflayer client can switch between Paper servers via the proxy.

## Rationale
Ensures proxy redirection works across multiple backend servers and prevents regressions in /server handling.

## Changes
- Allow PaperServer to use custom instance names and versions
- Support multiple target servers when spinning up VoidProxy in tests
- Script Mineflayer to switch servers sequentially and assert messages
- Add ServerRedirectionTests covering server1↔server2 handoffs

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter "ServerRedirectionTests"`

## Performance
No impact; test-only changes.

## Risks & Rollback
Low: affects only integration test harness. Revert commit to disable.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_689e9996da94832b860f007fbb328d0b