### PR TITLE
test(integration): 🧪 add proxied server redirection test

### DIFF
--- a/src/Tests/Integration/ProxiedServerSwitchTests.cs
+++ b/src/Tests/Integration/ProxiedServerSwitchTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Connections;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration;
+
+public class ProxiedServerSwitchTests(ProxiedServerSwitchTests.Fixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedServerSwitchTests.Fixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+    private const string Server1Name = "args-server-1";
+    private const string Server2Name = "args-server-2";
+
+    [ProxiedFact]
+    public async Task Mineflayer_RedirectsBetweenServers()
+    {
+        var server2Message = $"server2 {Random.Shared.Next()}";
+        var server1Message = $"server1 {Random.Shared.Next()}";
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendTextMessagesAsync(
+                $"localhost:{ProxyPort}",
+                ProtocolVersion.MINECRAFT_1_20_3,
+                new[]
+                {
+                    $"/server {Server2Name}",
+                    server2Message,
+                    $"/server {Server1Name}",
+                    server1Message
+                },
+                cancellationTokenSource.Token);
+
+            await fixture.PaperServer2.ExpectTextAsync(server2Message, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(server1Message, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains(server2Message));
+            Assert.Contains(fixture.PaperServer1.Logs, line => line.Contains(server1Message));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class Fixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public Fixture() : base(nameof(ProxiedServerSwitchTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{Server1Port}", proxyPort: ProxyPort, additionalServers: new[] { $"localhost:{Server2Port}" }, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Void.Minecraft.Network;
 using Void.Tests.Exceptions;
 using Void.Tests.Extensions;
@@ -43,17 +44,27 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...texts] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
             bot.on('spawn', () => {
-                bot.chat(text);
-                setTimeout(() => {
-                    console.log('end');
-                    bot.end();
-                }, 5000);
+                const sendNext = () => {
+                    if (texts.length === 0) {
+                        setTimeout(() => {
+                            console.log('end');
+                            bot.end();
+                        }, 5000);
+                        return;
+                    }
+
+                    const message = texts.shift();
+                    bot.chat(message);
+                    setTimeout(sendNext, 2000);
+                };
+
+                sendNext();
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -66,9 +77,20 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        return SendTextMessagesAsync(address, protocolVersion, new[] { text }, cancellationToken);
+    }
+
+    public async Task SendTextMessagesAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> texts, CancellationToken cancellationToken = default)
+    {
+        var arguments = new List<string> { address, protocolVersion.MostRecentSupportedVersion };
+        arguments.AddRange(texts);
+
+        var allArguments = new List<string> { _scriptPath };
+        allArguments.AddRange(arguments);
+
+        StartApplication(_nodePath, hasInput: false, [.. allArguments]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, IEnumerable<string>? additionalServers = null, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -40,6 +40,15 @@ public class VoidProxy : IIntegrationSide
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        if (additionalServers is not null)
+        {
+            foreach (var server in additionalServers)
+            {
+                args.Add("--server");
+                args.Add(server);
+            }
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = "PaperServer", CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Adds an end-to-end test verifying proxy redirection between Paper servers.

## Rationale
Ensures cross-server routing works through the proxy.

## Changes
- Add PaperServer instance naming.
- Allow VoidProxy to accept multiple backend servers.
- Enable Mineflayer client to send message sequences.
- Add ProxiedServerSwitchTests covering server hop via /server.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ProxiedServerSwitchTests`

## Performance
N/A

## Risks & Rollback
Revert commit if the new integration test proves unstable.

## Breaking/Migration
None

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_689e99817ed0832bbb607c71dc46f97e