### PR TITLE
test(integration): 🧪 add cross-server proxy redirection test

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedServerSwitchTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerSwitchTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedServerSwitchTests(ProxiedServerSwitchTests.PaperVoidTwoPaperFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedServerSwitchTests.PaperVoidTwoPaperFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+    private const string JoinText = "joined the game";
+
+    [ProxiedFact]
+    public async Task MineflayerMovesBetweenServersThroughProxy()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendMessagesAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_21_7, ["/server args-server-2", "/server args-server-1"], cancellationTokenSource.Token);
+
+            var server1Joins = fixture.PaperServer1.Logs.Count(line => line.Contains(JoinText, StringComparison.OrdinalIgnoreCase));
+            var server2Joins = fixture.PaperServer2.Logs.Count(line => line.Contains(JoinText, StringComparison.OrdinalIgnoreCase));
+
+            Assert.True(server2Joins >= 1, "Expected to join second server at least once.");
+            Assert.True(server1Joins >= 2, "Expected to return to first server.");
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class PaperVoidTwoPaperFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public PaperVoidTwoPaperFixture() : base(nameof(ProxiedServerSwitchTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, plugins: PaperPlugins.None, name: "ServerOne", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, plugins: PaperPlugins.None, name: "ServerTwo", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServers: new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string name = "PaperServer", CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, name);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Add integration test covering proxy redirection across multiple Paper servers.

## Rationale
Verifies the proxy can move players between backend servers using Mineflayer.

## Changes
- Allow `PaperServer` to use unique instance folders.
- Permit `VoidProxy` to start with multiple backend servers.
- Extend `MineflayerClient` to send sequential commands.
- Add end-to-end test switching a bot between two Paper servers via the proxy.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter FullyQualifiedName~ProxiedServerSwitchTests`

## Performance
N/A

## Risks & Rollback
Low; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_689e84677f7c832b8610d2f8ea3b2421