### PR TITLE
test(integration): ✅ add proxied server redirection e2e test

### DIFF
--- a/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ServerRedirectionTests(ServerRedirectionTests.PaperTwoServersFixture fixture) : ConnectionUnitBase, IClassFixture<ServerRedirectionTests.PaperTwoServersFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    private const string Server1Name = "args-server-1";
+    private const string Server2Name = "args-server-2";
+
+    [ProxiedFact]
+    public async Task MineflayerChangesServersThroughProxy()
+    {
+        var firstMessage = $"first {Random.Shared.Next()}";
+        var secondMessage = $"second {Random.Shared.Next()}";
+        var thirdMessage = $"third {Random.Shared.Next()}";
+
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendCommandsAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_3,
+                new[] { firstMessage, $"/server {Server2Name}", secondMessage, $"/server {Server1Name}", thirdMessage },
+                cancellationTokenSource.Token);
+
+            await fixture.PaperServer1.ExpectTextAsync(firstMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer2.ExpectTextAsync(secondMessage, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(thirdMessage, lookupHistory: true, cancellationTokenSource.Token);
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class PaperTwoServersFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public PaperTwoServersFixture() : base(nameof(ServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{Server1Port}", proxyPort: ProxyPort, additionalServers: new[] { $"localhost:{Server2Port}" }, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -1,6 +1,7 @@
 namespace Void.Tests.Integration.Sides.Clients;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO;
@@ -43,13 +44,17 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...commands] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
-            bot.on('spawn', () => {
-                bot.chat(text);
+            bot.once('spawn', async () => {
+                for (const command of commands) {
+                    bot.chat(command);
+                    const delay = command.startsWith('/server') ? 5000 : 500;
+                    await new Promise(resolve => setTimeout(resolve, delay));
+                }
                 setTimeout(() => {
                     console.log('end');
                     bot.end();
@@ -66,9 +71,17 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        return SendCommandsAsync(address, protocolVersion, new[] { text }, cancellationToken);
+    }
+
+    public async Task SendCommandsAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> commands, CancellationToken cancellationToken = default)
+    {
+        var args = new List<string> { _scriptPath, address, protocolVersion.MostRecentSupportedVersion };
+        args.AddRange(commands);
+
+        StartApplication(_nodePath, hasInput: false, args.ToArray());
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, IEnumerable<string>? additionalServers = null, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -40,6 +40,13 @@ public class VoidProxy : IIntegrationSide
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        if (additionalServers is not null)
+            foreach (var server in additionalServers)
+            {
+                args.Add("--server");
+                args.Add(server);
+            }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = "PaperServer", CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Adds an end-to-end test that verifies server redirection across multiple Paper instances via the proxy.

## Rationale
Ensures proxy correctly handles switching players between backend servers, preventing regressions.

## Changes
- Allow PaperServer to use unique working directories.
- Enable VoidProxy to register additional backend servers.
- Extend Mineflayer client to run command sequences.
- Add integration test that hops between two Paper servers using `/server`.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ServerRedirectionTests`

## Performance
- No impact; test-only changes.

## Risks & Rollback
- Test downloads external server binaries which may fail; revert commits to remove.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_689e8439ae84832baf243623a96bd5d0