### PR TITLE
test(integration): ✅ add proxy server switch tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ServerRedirectionTests(ServerRedirectionTests.ProxyFixture fixture) : ConnectionUnitBase, IClassFixture<ServerRedirectionTests.ProxyFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerMovesBetweenServers()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SwitchServersAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_5, "args-server-1", "args-server-2", cancellationTokenSource.Token);
+            await fixture.PaperServer2.ExpectTextAsync("hello-from-server2", lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync("hello-from-server1-again", lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Equal(2, fixture.PaperServer1.Logs.Count(line => line.Contains("joined the game")));
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains("joined the game"));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class ProxyFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public ProxyFixture() : base(nameof(ServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: "server1", version: "1.20.6", port: Server1Port, cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: "server2", version: "1.20.6", port: Server2Port, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,12 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    {
+        return CreateAsync(new[] { targetServer }, proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+    }
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +41,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");
@@ -49,7 +59,6 @@ public class VoidProxy : IIntegrationSide
 
         var task = EntryPoint.RunAsync(logWriter: logWriter, cancellationToken: cancellationToken, args: [.. args]);
 
-        // Wait for the proxy to start, because it takes some time to listen on the port
         while (logWriter.Lines.All(line => !line.Contains("Proxy started")))
             await Task.Delay(1_000, cancellationToken);
 


### PR DESCRIPTION
## Summary
Adds an integration test verifying proxy server hopping via Mineflayer.

## Rationale
Ensures proxy correctly redirects players across multiple backend servers.

## Changes
- allow Paper server to use named instances and custom versions
- support multiple backend registrations in VoidProxy helper
- extend Mineflayer client with server-switch script
- add end-to-end redirection test using Mineflayer

## Verification
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter FullyQualifiedName~ServerRedirectionTests`

## Performance
N/A

## Risks & Rollback
New test infrastructure; revert commit to remove.

## Breaking/Migration
None.

## Links
-

------
https://chatgpt.com/codex/tasks/task_e_689e84042a6c832bad648708f4bd6ce4