### PR TITLE
test(integration): 🔁 add multi-server redirection e2e tests

### DIFF
--- a/src/Tests/Integration/Connections/E2E/ProxiedRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/E2E/ProxiedRedirectionTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.E2E;
+
+public class ProxiedRedirectionTests(ProxiedRedirectionTests.TwoPaperServersFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedRedirectionTests.TwoPaperServersFixture>
+{
+    private const int ProxyPort = 35000;
+    private const int Server1Port = 35001;
+    private const int Server2Port = 35002;
+    private const string Server1Instance = "server1";
+    private const string Server2Instance = "server2";
+    private const string Server1Name = "args-server-1";
+    private const string Server2Name = "args-server-2";
+
+    [ProxiedFact]
+    public async Task MineflayerRedirectsBetweenServers()
+    {
+        var server1Text = $"server1 test #{Random.Shared.Next()}";
+        var server2Text = $"server2 test #{Random.Shared.Next()}";
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendTextMessagesAsync(
+                $"localhost:{ProxyPort}",
+                ProtocolVersion.MINECRAFT_1_20_3,
+                new[]
+                {
+                    $"/server {Server2Name}",
+                    server2Text,
+                    $"/server {Server1Name}",
+                    server1Text
+                },
+                cancellationTokenSource.Token);
+
+            await fixture.PaperServer2.ExpectTextAsync(server2Text, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(server1Text, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains(server2Text));
+            Assert.Contains(fixture.PaperServer1.Logs, line => line.Contains(server1Text));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class TwoPaperServersFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public TwoPaperServersFixture() : base(nameof(ProxiedRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: Server1Instance, port: Server1Port, cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, instanceName: Server2Instance, port: Server2Port, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(
+                targetServer: $"localhost:{Server1Port}",
+                additionalServers: new[] { $"localhost:{Server2Port}" },
+                proxyPort: ProxyPort,
+                cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -2,6 +2,7 @@ namespace Void.Tests.Integration.Sides.Clients;
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
@@ -43,17 +44,22 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...messages] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
             bot.on('spawn', () => {
-                bot.chat(text);
+                let delay = 0;
+                for (const message of messages) {
+                    setTimeout(() => bot.chat(message), delay);
+                    delay += 5000;
+                }
+
                 setTimeout(() => {
                     console.log('end');
                     bot.end();
-                }, 5000);
+                }, delay + 5000);
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -66,9 +72,14 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default) =>
+        SendTextMessagesAsync(address, protocolVersion, [text], cancellationToken);
+
+    public async Task SendTextMessagesAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> messages, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        var messagesArray = messages.ToArray();
+
+        StartApplication(_nodePath, hasInput: false, [ _scriptPath, address, protocolVersion.MostRecentSupportedVersion, ..messagesArray ]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, IEnumerable<string>? additionalServers = null, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -40,6 +40,15 @@ public class VoidProxy : IIntegrationSide
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        if (additionalServers is not null)
+        {
+            foreach (var server in additionalServers)
+            {
+                args.Add("--server");
+                args.Add(server);
+            }
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, string instanceName = "PaperServer", int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Add end-to-end test that redirects a client between two Paper servers through the proxy.

## Rationale
Confirms proxy redirection logic works across multiple backends using the `/server` command.

## Changes
- Add ProxiedRedirectionTests spinning up two Paper servers, one proxy and a Mineflayer client
- Allow PaperServer to use unique instance names for isolated working directories
- Extend VoidProxy and MineflayerClient for multi-server setups and sequential messages

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ProxiedRedirectionTests`

## Performance
N/A

## Risks & Rollback
Low; revert commit to remove tests and helper changes.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e83d6eab4832ba2df0bba5d4dffb1