### PR TITLE
test(integration): 🧪 add Mineflayer redirection tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ServerRedirectionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ServerRedirectionTests(ServerRedirectionTests.Fixture fixture) : ConnectionUnitBase, IClassFixture<ServerRedirectionTests.Fixture>
+{
+    private const int ProxyPort = 35100;
+    private const int Server1Port = 35101;
+    private const int Server2Port = 35102;
+
+    [ProxiedFact]
+    public async Task MineflayerSwitchesBetweenServers()
+    {
+        var expected1 = $"hello server1 test #{Random.Shared.Next()}";
+        var expected2 = $"hello server2 test #{Random.Shared.Next()}";
+        var expected3 = $"hello again server1 test #{Random.Shared.Next()}";
+
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SwitchServersAsync(
+                $"localhost:{ProxyPort}",
+                ProtocolVersion.MINECRAFT_1_20_3,
+                new[] { "args-server-1", "args-server-2", "args-server-1" },
+                new[] { expected1, expected2, expected3 },
+                cancellationTokenSource.Token);
+
+            await fixture.Server1.ExpectTextAsync(expected1, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server2.ExpectTextAsync(expected2, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.Server1.ExpectTextAsync(expected3, lookupHistory: true, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(expected1));
+            Assert.Contains(fixture.Server2.Logs, line => line.Contains(expected2));
+            Assert.Contains(fixture.Server1.Logs, line => line.Contains(expected3));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.Server1, fixture.Server2);
+    }
+
+    public class Fixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public Fixture() : base(nameof(ServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer Server1 { get => field ?? throw new InvalidOperationException($"{nameof(Server1)} is not initialized."); set; }
+        public PaperServer Server2 { get => field ?? throw new InvalidOperationException($"{nameof(Server2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            Server1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            Server2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{Server1Port}", proxyPort: ProxyPort, additionalServers: new[] { $"localhost:{Server2Port}" }, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (Server1 is not null)
+                await Server1.DisposeAsync();
+
+            if (Server2 is not null)
+                await Server2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -87,6 +87,69 @@ public class MineflayerClient : IntegrationSideBase
         }
     }
 
+    public async Task SwitchServersAsync(string address, ProtocolVersion protocolVersion, string[] serverNames, string[] messages, CancellationToken cancellationToken = default)
+    {
+        if (serverNames.Length != messages.Length)
+            throw new ArgumentException("Server names and messages length must match");
+
+        var workingDirectory = Path.GetDirectoryName(_scriptPath) ?? throw new IntegrationTestException("Invalid script path");
+        var scriptPath = Path.Combine(workingDirectory, "switch-server.js");
+
+        var steps = string.Join(",", serverNames.Zip(messages, (s, m) => $"{{server: '{s}', message: '{m}'}}"));
+
+        await File.WriteAllTextAsync(scriptPath, $$"""
+            const mineflayer = require('mineflayer');
+            const [address, version] = process.argv.slice(2);
+            const [host, portString] = address.split(':');
+            const port = parseInt(portString ?? '25565', 10);
+            const steps = [{{steps}}];
+            const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
+            let index = 0;
+            function executeStep() {
+                const step = steps[index];
+                bot.chat(step.message);
+                index++;
+                if (index < steps.length) {
+                    setTimeout(() => {
+                        bot.chat('/server ' + steps[index].server);
+                        setTimeout(executeStep, 8000);
+                    }, 1000);
+                } else {
+                    setTimeout(() => {
+                        console.log('end');
+                        bot.end();
+                    }, 5000);
+                }
+            }
+            bot.once('spawn', () => {
+                setTimeout(executeStep, 2000);
+            });
+            bot.on('kicked', reason => console.error('KICK:' + reason));
+            bot.on('error', err => console.error('ERROR:' + err.message));
+            """, cancellationToken);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        StartApplication(_nodePath, hasInput: false, scriptPath, address, protocolVersion.MostRecentSupportedVersion);
+
+        var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
+
+        if (_process is not { HasExited: false })
+            throw new IntegrationTestException("Failed to start Mineflayer bot.");
+
+        try
+        {
+            await consoleTask;
+            await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+        finally
+        {
+            if (_process is { HasExited: false })
+                await _process.ExitAsync(entireProcessTree: true, cancellationToken);
+        }
+    }
+
     private static bool HandleConsole(string line)
     {
         if (line.StartsWith("ERROR:"))

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,7 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, IEnumerable<string>? additionalServers = null, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -40,6 +40,15 @@ public class VoidProxy : IIntegrationSide
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        if (additionalServers is not null)
+        {
+            foreach (var server in additionalServers)
+            {
+                args.Add("--server");
+                args.Add(server);
+            }
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,28 +26,30 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = "PaperServer", string? version = null, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);
 
-        var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
-        using var versions = JsonDocument.Parse(versionsJson);
-        var latestVersion = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
+        if (version is null)
+        {
+            var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
+            using var versions = JsonDocument.Parse(versionsJson);
+            version = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
+        }
 
-        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}", cancellationToken);
+        var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}", cancellationToken);
         using var builds = JsonDocument.Parse(buildsJson);
         var latestBuild = builds.RootElement.GetProperty("builds").EnumerateArray().Last().GetInt32();
-
-        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}", cancellationToken);
+        var buildInfoJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{latestBuild}", cancellationToken);
         using var buildInfo = JsonDocument.Parse(buildInfoJson);
         var jarName = buildInfo.RootElement.GetProperty("downloads").GetProperty("application").GetProperty("name").GetString();
 
-        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}/builds/{latestBuild}/downloads/{jarName}";
+        var paperUrl = $"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{latestBuild}/downloads/{jarName}";
         var paperJarPath = Path.Combine(workingDirectory, "paper.jar");
 
         await client.DownloadFileAsync(paperUrl, paperJarPath, cancellationToken);


### PR DESCRIPTION
## Summary
Add end-to-end Mineflayer redirection tests.

## Rationale
Validates proxy can shuttle clients between multiple Paper servers.

## Changes
- Parameterize PaperServer with instance name and version.
- Allow VoidProxy to register multiple backend servers.
- Add Mineflayer helper for sequential server switching.
- Cover server hopping in new ServerRedirectionTests.

## Verification
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter FullyQualifiedName~ServerRedirectionTests`

## Performance
N/A

## Risks & Rollback
Risk of longer CI due to server downloads; revert commit to remove tests.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e83b7eb78832b84afa795d2e5744b