### PR TITLE
test(integration): 🧪 add proxied redirection e2e test

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedRedirectionTests(ProxiedRedirectionTests.MultiplePaperVoidMineflayerFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedRedirectionTests.MultiplePaperVoidMineflayerFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+    private const string Server1Name = "args-server-1";
+    private const string Server2Name = "args-server-2";
+
+    [ProxiedFact]
+    public async Task MineflayerMovesBetweenServers()
+    {
+        var server2Text = $"server2 test #{Random.Shared.Next()}";
+        var server1Text = $"server1 test #{Random.Shared.Next()}";
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendTextMessagesAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_21_4, [
+                $"/server {Server2Name}",
+                server2Text,
+                $"/server {Server1Name}",
+                server1Text
+            ], cancellationTokenSource.Token);
+
+            await fixture.PaperServer2.ExpectTextAsync(server2Text, lookupHistory: true, cancellationToken: cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(server1Text, lookupHistory: true, cancellationToken: cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains(server2Text));
+            Assert.Contains(fixture.PaperServer1.Logs, line => line.Contains(server1Text));
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class MultiplePaperVoidMineflayerFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public MultiplePaperVoidMineflayerFixture() : base(nameof(ProxiedRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: Server1Name, cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: Server2Name, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}
+

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -1,6 +1,7 @@
 namespace Void.Tests.Integration.Sides.Clients;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO;
@@ -43,17 +44,17 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...texts] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
             bot.on('spawn', () => {
-                bot.chat(text);
+                texts.forEach((text, index) => setTimeout(() => bot.chat(text), index * 2000));
                 setTimeout(() => {
                     console.log('end');
                     bot.end();
-                }, 5000);
+                }, texts.length * 2000 + 5000);
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -66,9 +67,14 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        return SendTextMessagesAsync(address, protocolVersion, [text], cancellationToken);
+    }
+
+    public async Task SendTextMessagesAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> texts, CancellationToken cancellationToken = default)
+    {
+        StartApplication(_nodePath, hasInput: false, [ _scriptPath, address, protocolVersion.MostRecentSupportedVersion, ..texts ]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,12 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    {
+        return CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+    }
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +41,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = nameof(PaperServer), CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Add Mineflayer redirection test verifying proxy /server switching.

## Rationale
Ensures the proxy correctly shuttles players between backend servers.

## Changes
- Allow naming PaperServer instances to separate work dirs
- Enable Mineflayer to send multiple chat messages
- Support multiple upstream servers in VoidProxy harness
- Add E2E test covering /server redirection

## Verification
- `/root/.dotnet/dotnet build Void.slnx`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true /root/.dotnet/dotnet test Void.slnx --filter FullyQualifiedName~ProxiedRedirectionTests`

## Performance
N/A

## Risks & Rollback
Low: touches only test infrastructure. Revert the commits to roll back.

## Breaking/Migration
None

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_689e83ace55c832bb05170c6b4de2d2a