### PR TITLE
test(integration): 🧪 add mineflayer server redirection e2e test

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedRedirectionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedRedirectionTests(ProxiedRedirectionTests.RedirectionFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedRedirectionTests.RedirectionFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerRedirectsBetweenPaperServersThroughProxy()
+    {
+        var server1Message = $"server1 {Guid.NewGuid()}";
+        var server2Message = $"server2 {Guid.NewGuid()}";
+        var server1ReturnMessage = $"server1 back {Guid.NewGuid()}";
+
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendTextMessagesAsync(
+                $"localhost:{ProxyPort}",
+                ProtocolVersion.MINECRAFT_1_21_4,
+                cancellationTokenSource.Token,
+                server1Message,
+                $"/server {fixture.Server2Name}",
+                server2Message,
+                $"/server {fixture.Server1Name}",
+                server1ReturnMessage);
+
+            await fixture.PaperServer1.ExpectTextAsync(server1Message, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer2.ExpectTextAsync(server2Message, lookupHistory: true, cancellationTokenSource.Token);
+            await fixture.PaperServer1.ExpectTextAsync(server1ReturnMessage, lookupHistory: true, cancellationTokenSource.Token);
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class RedirectionFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public RedirectionFixture() : base(nameof(ProxiedRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+        public string Server1Name { get; private set; } = "args-server-1";
+        public string Server2Name { get; private set; } = "args-server-2";
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "PaperServer1", version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "PaperServer2", version: "1.20.4", cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -43,17 +43,27 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...texts] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
             bot.on('spawn', () => {
-                bot.chat(text);
-                setTimeout(() => {
-                    console.log('end');
-                    bot.end();
-                }, 5000);
+                let index = 0;
+                const send = () => {
+                    if (index >= texts.length) {
+                        setTimeout(() => {
+                            console.log('end');
+                            bot.end();
+                        }, 5000);
+                        return;
+                    }
+
+                    bot.chat(texts[index++]);
+                    setTimeout(send, 3000);
+                };
+
+                send();
             });
 
             bot.on('kicked', reason => console.error('KICK:' + reason));
@@ -66,9 +76,12 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default) =>
+        SendTextMessagesAsync(address, protocolVersion, cancellationToken, text);
+
+    public async Task SendTextMessagesAsync(string address, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default, params string[] texts)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        StartApplication(_nodePath, hasInput: false, [_scriptPath, address, protocolVersion.MostRecentSupportedVersion, ..texts]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,10 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default) =>
+        CreateAsync(new[] { targetServer }, proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,7 +39,6 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
@@ -46,6 +48,12 @@ public class VoidProxy : IIntegrationSide
 
         if (offlineMode)
             args.Add("--offline");
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         var task = EntryPoint.RunAsync(logWriter: logWriter, cancellationToken: cancellationToken, args: [.. args]);
 

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,18 +26,18 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = "PaperServer", string? version = null, CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);
 
         var versionsJson = await client.GetStringAsync("https://api.papermc.io/v2/projects/paper", cancellationToken);
         using var versions = JsonDocument.Parse(versionsJson);
-        var latestVersion = versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
+        var latestVersion = version ?? versions.RootElement.GetProperty("versions").EnumerateArray().Last().GetString();
 
         var buildsJson = await client.GetStringAsync($"https://api.papermc.io/v2/projects/paper/versions/{latestVersion}", cancellationToken);
         using var builds = JsonDocument.Parse(buildsJson);


### PR DESCRIPTION
## Summary
Add Mineflayer integration test for proxy redirection across two Paper servers.

## Rationale
Validates that a client can hop between multiple backend servers through the proxy.

## Changes
- Added `ProxiedRedirectionTests` covering `/server` redirection.
- Updated `PaperServer` to allow named instances and version selection.
- Extended `VoidProxy` to register multiple backend servers.
- Enhanced Mineflayer client script for sequential commands.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test --filter ProxiedRedirectionTests`

## Performance
N/A

## Risks & Rollback
Test-only change; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689e83a6fed8832b9245de3e8ce459db