### PR TITLE
test(integration): 🧪 add proxy redirection e2e tests

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Void.Minecraft.Network;
+using Void.Tests.Integration;
+using Void.Tests.Integration.Sides.Clients;
+using Void.Tests.Integration.Sides.Proxies;
+using Void.Tests.Integration.Sides.Servers;
+using Xunit;
+
+namespace Void.Tests.Integration.Connections.Units;
+
+public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.MultipleServersFixture fixture) : ConnectionUnitBase, IClassFixture<ProxiedServerRedirectionTests.MultipleServersFixture>
+{
+    private const int ProxyPort = 36000;
+    private const int Server1Port = 36001;
+    private const int Server2Port = 36002;
+
+    [ProxiedFact]
+    public async Task MineflayerSwitchesBetweenServers()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+        await LoggedExecutorAsync(async () =>
+        {
+            await fixture.MineflayerClient.SendTextMessagesAsync($"localhost:{ProxyPort}", ProtocolVersion.MINECRAFT_1_20_3, new[] { "/server args-server-2", "/server args-server-1" }, cancellationTokenSource.Token);
+
+            Assert.Contains(fixture.PaperServer2.Logs, line => line.Contains("joined the game"));
+            Assert.True(fixture.PaperServer1.Logs.Count(line => line.Contains("joined the game")) >= 2);
+        }, fixture.MineflayerClient, fixture.VoidProxy, fixture.PaperServer1, fixture.PaperServer2);
+    }
+
+    public class MultipleServersFixture : ConnectionFixtureBase, IAsyncLifetime
+    {
+        public MultipleServersFixture() : base(nameof(ProxiedServerRedirectionTests))
+        {
+        }
+
+        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
+        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
+        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
+        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+
+        public async Task InitializeAsync()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+
+            MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationTokenSource.Token);
+            PaperServer1 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: nameof(PaperServer1), cancellationToken: cancellationTokenSource.Token);
+            PaperServer2 = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: nameof(PaperServer2), cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServers: new[] { $"localhost:{Server1Port}", $"localhost:{Server2Port}" }, proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (MineflayerClient is not null)
+                await MineflayerClient.DisposeAsync();
+
+            if (PaperServer1 is not null)
+                await PaperServer1.DisposeAsync();
+
+            if (PaperServer2 is not null)
+                await PaperServer2.DisposeAsync();
+
+            if (VoidProxy is not null)
+                await VoidProxy.DisposeAsync();
+        }
+    }
+}

--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Void.Minecraft.Network;
 using Void.Tests.Exceptions;
 using Void.Tests.Extensions;
@@ -43,13 +44,16 @@ public class MineflayerClient : IntegrationSideBase
         var scriptPath = Path.Combine(workingDirectory, "bot.js");
         await File.WriteAllTextAsync(scriptPath, $$"""
             const mineflayer = require('mineflayer');
-            const [address, version, text] = process.argv.slice(2);
+            const [address, version, ...texts] = process.argv.slice(2);
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
-            bot.on('spawn', () => {
-                bot.chat(text);
+            bot.once('spawn', async () => {
+                for (const text of texts) {
+                    bot.chat(text);
+                    await new Promise(r => setTimeout(r, 3000));
+                }
                 setTimeout(() => {
                     console.log('end');
                     bot.end();
@@ -66,9 +70,15 @@ public class MineflayerClient : IntegrationSideBase
         return new(nodePath, scriptPath);
     }
 
-    public async Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+    public Task SendTextMessageAsync(string address, ProtocolVersion protocolVersion, string text, CancellationToken cancellationToken = default)
+        => SendTextMessagesAsync(address, protocolVersion, [text], cancellationToken);
+
+    public async Task SendTextMessagesAsync(string address, ProtocolVersion protocolVersion, IEnumerable<string> texts, CancellationToken cancellationToken = default)
     {
-        StartApplication(_nodePath, hasInput: false, _scriptPath, address, protocolVersion.MostRecentSupportedVersion, text);
+        var arguments = new List<string> { _scriptPath, address, protocolVersion.MostRecentSupportedVersion };
+        arguments.AddRange(texts);
+
+        StartApplication(_nodePath, hasInput: false, [.. arguments]);
 
         var consoleTask = ReceiveOutputAsync(HandleConsole, cancellationToken);
 

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -28,7 +28,10 @@ public class VoidProxy : IIntegrationSide
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public static async Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+        => CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
     {
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -36,10 +39,15 @@ public class VoidProxy : IIntegrationSide
 
         var args = new List<string>
         {
-            "--server", targetServer,
             "--port", proxyPort.ToString(),
             "--logging", "Debug" // Trace
         };
+
+        foreach (var server in targetServers)
+        {
+            args.Add("--server");
+            args.Add(server);
+        }
 
         if (ignoreFileServers)
             args.Add("--ignore-file-servers");

--- a/src/Tests/Integration/Sides/Servers/PaperServer.cs
+++ b/src/Tests/Integration/Sides/Servers/PaperServer.cs
@@ -26,11 +26,11 @@ public class PaperServer : IntegrationSideBase
         StartApplication(_binaryPath, hasInput: false, "-Dpaper.playerconnection.keepalive=120");
     }
 
-    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, CancellationToken cancellationToken = default)
+    public static async Task<PaperServer> CreateAsync(string workingDirectory, HttpClient client, int port = 25565, PaperPlugins plugins = PaperPlugins.All, string instanceName = nameof(PaperServer), CancellationToken cancellationToken = default)
     {
         var jreBinaryPath = await SetupJreAsync(workingDirectory, client, cancellationToken);
 
-        workingDirectory = Path.Combine(workingDirectory, "PaperServer");
+        workingDirectory = Path.Combine(workingDirectory, instanceName);
 
         if (!Directory.Exists(workingDirectory))
             Directory.CreateDirectory(workingDirectory);


### PR DESCRIPTION
## Summary
Adds Mineflayer-based end-to-end test verifying proxy redirects between two Paper servers.

## Rationale
Ensures proxy correctly handles /server command across multiple backends, preventing regression.

## Changes
- Accept instance names in PaperServer to isolate working directories.
- Allow VoidProxy and Mineflayer client to interact with multiple target servers.
- Add ProxiedServerRedirectionTests verifying hopping from server1→server2→server1 via proxy.

## Verification
- `dotnet test -e VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true --filter FullyQualifiedName~ProxiedServerRedirectionTests`

## Performance
N/A

## Risks & Rollback
Minimal test-only changes; revert commit to roll back.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_689e8343f760832b866eaa011c7e0a0a