### PR TITLE
test(integration): 🧪 await mineflayer events

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -49,18 +49,24 @@ public class MineflayerClient : IntegrationSideBase
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
+            const waitForMessage = () => new Promise(resolve => {
+                const timer = setTimeout(resolve, 1000);
+                bot.once('message', () => {
+                    clearTimeout(timer);
+                    resolve();
+                });
+            });
+
             bot.on('spawn', async () => {
                 for (const text of texts) {
                     bot.chat(text);
-                    await new Promise(r => setTimeout(r, 2000));
+                    await waitForMessage();
                 }
 
-                setTimeout(() => {
-                    bot.end();
-                }, 5000);
+                console.log('end');
+                bot.end();
             });
 
-            bot.on('end', () => console.log('end'));
             bot.on('error', err => console.error('ERROR:' + err.message));
             """, cancellationToken);
 


### PR DESCRIPTION
## Summary
Replace fixed delays in Mineflayer test client with event‑driven waits.

## Rationale
Avoid relying on arbitrary sleeps so the bot closes once expected output is observed.

## Changes
- Wait for chat messages or a short timeout before issuing the next command.
- Log completion before terminating the bot process.

## Verification
- `dotnet build`
- `VOID_INTEGRATION_PROXIED_TESTS_ENABLED=true dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert this commit if instability appears.

## Breaking/Migration
None.

## Links
N/A.

------
https://chatgpt.com/codex/tasks/task_e_689fc1ce01d4832b8e4113c4f1c4cbf5