### PR TITLE
ci(main-pr): 🔧 run workflow on pull requests to any branch

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -2,7 +2,6 @@ name: ".NET PR Workflow"
 
 on:
   pull_request:
-    branches: ["main"]
 
 jobs:
   semver:


### PR DESCRIPTION
## Summary
Enable main-pr workflow to execute on pull requests targeting any branch.

## Rationale
Previously, CI ran only for PRs against `main`, which left feature branches unvalidated.

## Changes
- Remove branch restriction from `.github/workflows/main-pr.yaml`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal risk; revert this commit to restore the previous branch filter.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_689fd9e4cd70832ba3bb8b0c02256a72