### PR TITLE
test(tests): ✅ enable test parallelization

### DIFF
--- a/src/Tests/AssemblyAttributes.cs
+++ b/src/Tests/AssemblyAttributes.cs
@@ -1,3 +1,3 @@
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(DisableTestParallelization = false)]


### PR DESCRIPTION
## Summary
Allow tests to run in parallel.

## Rationale
Reduce test execution time by leveraging xUnit's parallelization.

## Changes
- Enable xUnit's parallel test execution.

## Verification
- `dotnet build`
- `dotnet test` *(hung after "Starting test execution"; no results observed)*

## Performance
N/A

## Risks & Rollback
Parallel tests may interfere if they share state. Revert this commit to restore sequential execution.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68a04569e1c4832b87a856f794bec1b2