### PR TITLE
test(integration): 🧪 await spawn for commands

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -49,9 +49,10 @@ public class MineflayerClient : IntegrationSideBase
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
 
-            const waitForMessage = () => new Promise(resolve => {
+            const waitFor = (text) => new Promise(resolve => {
                 const timer = setTimeout(resolve, 1000);
-                bot.once('message', () => {
+                const eventName = text.startsWith('/') ? 'spawn' : 'message';
+                bot.once(eventName, () => {
                     clearTimeout(timer);
                     resolve();
                 });
@@ -60,7 +61,7 @@ public class MineflayerClient : IntegrationSideBase
             bot.on('spawn', async () => {
                 for (const text of texts) {
                     bot.chat(text);
-                    await waitForMessage();
+                    await waitFor(text);
                 }
 
                 console.log('end');


### PR DESCRIPTION
## Summary
Adjust Mineflayer client script to await respawn for command messages.

## Rationale
Commands may trigger respawn instead of chat feedback, requiring a spawn event wait.

## Changes
- Wait for `spawn` when messages start with `/`
- Continue waiting for chat messages otherwise

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a04e71daa0832ba20167deb734913b