### PR TITLE
test(integration): ⏱️ extend mineflayer waitFor timeout

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -48,9 +48,10 @@ public class MineflayerClient : IntegrationSideBase
             const [host, portString] = address.split(':');
             const port = parseInt(portString ?? '25565', 10);
             const bot = mineflayer.createBot({ host, port, username: '{{nameof(MineflayerClient)}}', version });
+            const WAIT_FOR_TIMEOUT_MS = 16_000;
 
             const waitFor = (text) => new Promise(resolve => {
-                const timer = setTimeout(resolve, 1000);
+                const timer = setTimeout(resolve, WAIT_FOR_TIMEOUT_MS);
                 const eventName = text.startsWith('/') ? 'spawn' : 'message';
                 bot.once(eventName, () => {
                     clearTimeout(timer);


### PR DESCRIPTION
## Summary
Increase waitFor timeout in Mineflayer test script to 16 seconds.

## Rationale
Provides more time for asynchronous Mineflayer events, reducing test flakiness.

## Changes
- Add `WAIT_FOR_TIMEOUT_MS` constant.
- Use 16-second timeout in Mineflayer `waitFor` helper.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
No performance impact expected.

## Risks & Rollback
Minimal risk; revert the commit to rollback.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a0503454e4832bb5af20a95feb4e65