### PR TITLE
test(mineflayer): 🧪 handle spawn event once

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -59,7 +59,7 @@ public class MineflayerClient : IntegrationSideBase
                 });
             });
 
-            bot.on('spawn', async () => {
+            bot.once('spawn', async () => {
                 for (const text of texts) {
                     bot.chat(text);
                     await waitFor(text);


### PR DESCRIPTION
## Summary
Use one-time spawn subscription in Mineflayer client script.

## Rationale
Prevents multiple message runs when the client spawns repeatedly.

## Changes
- switch spawn event handler in Mineflayer client script to `once`.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
No impact expected.

## Risks & Rollback
Minimal risk; revert commit to restore previous event subscription.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a05283562c832b80ca850f5f62cd33