### PR TITLE
test(voidproxy): 🧪 show startup logs on failure

### DIFF
--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -58,8 +58,17 @@ public class VoidProxy : IIntegrationSide
         var task = EntryPoint.RunAsync(logWriter: logWriter, cancellationToken: cancellationToken, args: [.. args]);
 
         // Wait for the proxy to start, because it takes some time to listen on the port
-        while (logWriter.Lines.All(line => !line.Contains("Proxy started")))
-            await Task.Delay(1_000, cancellationToken);
+
+        try
+        {
+            while (logWriter.Lines.All(line => !line.Contains("Proxy started")))
+                await Task.Delay(1_000, cancellationToken);
+        }
+        catch
+        {
+            Console.WriteLine(logWriter.Text);
+            throw;
+        }
 
         return new VoidProxy(logWriter, task, cancellationTokenSource);
     }


### PR DESCRIPTION
## Summary
Expose buffered logs when waiting for the proxy to start fails.

## Rationale
Eases debugging of integration tests by surfacing startup logs on errors.

## Changes
- Print collected logWriter contents if the startup wait throws and rethrow.

## Verification
- `dotnet build`
- `dotnet test` *(hangs: terminated after waiting with no output)*

## Performance
Not applicable.

## Risks & Rollback
Low risk; affects only test infrastructure. Revert commit to roll back.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a09a928840832b81c689c5b17a662e