### PR TITLE
fix(platform): avoid duplicate connection logs

### DIFF
--- a/src/Platform/Links/LinkService.cs
+++ b/src/Platform/Links/LinkService.cs
@@ -43,7 +43,15 @@ public class LinkService(ILogger<LinkService> logger, IServerService servers, IE
         var unwrappedPlayer = player.Unwrap();
 
         if (TryGetLink(unwrappedPlayer, out var link))
+        {
+            if (link.Server == server)
+            {
+                logger.LogTrace("Player {Player} is already connected to {Server}", unwrappedPlayer, server);
+                return ConnectionResult.Connected;
+            }
+
             await link.StopAsync(cancellationToken);
+        }
 
         logger.LogTrace("Connecting {Player} player to a {Server} server", unwrappedPlayer, server);
 


### PR DESCRIPTION
## Summary
Prevent redundant player reconnections that produced duplicate "connected" logs.

## Rationale
Occasional duplicate connection events caused integration test flakiness; skipping reconnection when already linked removes the issue.

## Changes
- Detect existing link to target server and skip reconnecting, logging at trace level instead.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit if unintended behavior occurs.

## Breaking/Migration
None.

## Links
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a120fe34ec832ba2307e558cb7c51b