### PR TITLE
fix(platform): 🐛 avoid duplicate reconnect on link stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -142,10 +142,18 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     public async ValueTask OnLinkStopped(LinkStoppedEvent @event, CancellationToken cancellationToken)
     {
         // All other reasons should throw player disconnected event themselves
+
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
 
+            return;
+        }
+
         if (!@event.Link.PlayerChannel.IsAlive)
+            return;
+
+        if (links.TryGetLink(@event.Player, out var currentLink) && currentLink != @event.Link)
             return;
 
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);


### PR DESCRIPTION
## Summary
Fix duplicate connection log when switching servers through the proxy.

## Rationale
Prevents automatic reconnection from firing after a manual server change, eliminating duplicated connection messages.

## Changes
- Skip auto-reconnect when a different link already exists during `LinkStopped`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No change.

## Risks & Rollback
- Players might remain disconnected if reconnection suppression triggers unexpectedly; revert the commit to restore prior behavior.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a1210b7254832b943c1e5169ff855d