### PR TITLE
fix(platform): 🐛 avoid auto reconnect after requested link stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -145,6 +145,9 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
 
+        if (@event.Reason is LinkStopReason.Requested)
+            return;
+
         if (!@event.Link.PlayerChannel.IsAlive)
             return;
 


### PR DESCRIPTION
## Summary
Prevent duplicate connection logs by avoiding automatic reconnection after a manual link stop.

## Rationale
Auto reconnect on requested link stops caused the proxy to connect twice, producing duplicate logs.

## Changes
- Skip automatic reconnection when a link stops for `Requested` reason.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if unexpected connection handling occurs.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a12111f1e8832ba919cd5187604ae8