### PR TITLE
fix(links): 🐛 avoid duplicate connection log

### DIFF
--- a/src/Platform/Links/LinkService.cs
+++ b/src/Platform/Links/LinkService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Nito.AsyncEx;
 using Void.Minecraft.Players.Extensions;
 using Void.Proxy.Api.Events;
@@ -104,6 +105,11 @@ public class LinkService(ILogger<LinkService> logger, IServerService servers, IE
         else
         {
             await link.StartAsync(cancellationToken);
+            await Task.Yield();
+
+            if (!link.IsAlive)
+                return ConnectionResult.NotConnected;
+
             logger.LogInformation("Player {Player} connected to {Server} ({ProtocolVersion})", unwrappedPlayer, link.Server, unwrappedPlayer.ProtocolVersion);
 
             return ConnectionResult.Connected;


### PR DESCRIPTION
## Summary
Prevent duplicate connection logs by confirming link stability before announcing connection.

## Rationale
Failed handshakes could trigger immediate reconnects, producing duplicate connection log entries and flaky tests.

## Changes
- Wait for link to process an initial cycle before logging connection
- Skip logging when the link stops during startup

## Verification
- `dotnet build`
- `dotnet test --no-build`

## Performance
No impact expected; added minimal async delay.

## Risks & Rollback
Low risk; rollback by reverting the commit.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a121040158832b80a7d5cb897984e1