### PR TITLE
fix(platform): avoid duplicate reconnection

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -143,7 +143,14 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     {
         // All other reasons should throw player disconnected event themselves
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
+
+            return;
+        }
+
+        if (@event.Reason is not LinkStopReason.ServerDisconnected)
+            return;
 
         if (!@event.Link.PlayerChannel.IsAlive)
             return;


### PR DESCRIPTION
## Summary
Prevent duplicate connection log when switching servers.

## Rationale
Avoids race where PlayerService reconnects after intentional link stop, leading to double connection events.

## Changes
- Skip automatic reconnect unless server disconnects unexpectedly.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact expected.

## Risks & Rollback
Low risk; revert commit if issues occur.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68a12a078030832bbd35fe02d40d74fe