### PR TITLE
fix(platform): 🐛 prevent duplicate reconnect on requested link stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -143,9 +143,12 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     {
         // All other reasons should throw player disconnected event themselves
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
+            return;
+        }
 
-        if (!@event.Link.PlayerChannel.IsAlive)
+        if (@event.Reason is LinkStopReason.Requested || !@event.Link.PlayerChannel.IsAlive)
             return;
 
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);


### PR DESCRIPTION
## Summary
Prevent duplicate connection logs by skipping automatic reconnect on requested link stop.

## Rationale
Tests intermittently failed due to race between manual server switches and automatic reconnection after link stop. Avoiding reconnect on requested stop resolves duplicates.

## Changes
- Skip PlayerService's auto-reconnect when a link is deliberately stopped.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if unintended behavior occurs.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a12a04dc34832b9bc47c355bfd79b7