### PR TITLE
fix(players): 🐛 skip auto reconnect for requested link stops

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -148,6 +148,9 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
         if (!@event.Link.PlayerChannel.IsAlive)
             return;
 
+        if (@event.Reason is LinkStopReason.Requested)
+            return;
+
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);
     }
 


### PR DESCRIPTION
## Summary
Prevent duplicate proxy connection logs when players intentionally switch servers.

## Rationale
Auto-reconnection on every link stop caused race conditions and duplicate connections. Skipping it when the stop was requested avoids redundant reconnects without relying on artificial delays.

## Changes
- Skip automatic reconnection if a link stops with `LinkStopReason.Requested`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No impact observed.

## Risks & Rollback
- Low risk; rollback by reverting commit.

## Breaking/Migration
- None.

## Links
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a129ff78f4832bba1e96ea342db092