### PR TITLE
fix(platform): 🐛 prevent stale data reuse during reconnect

### DIFF
--- a/src/Platform/Links/LinkService.cs
+++ b/src/Platform/Links/LinkService.cs
@@ -125,9 +125,8 @@ public class LinkService(ILogger<LinkService> logger, IServerService servers, IE
         // IServer channel is no longer needed
         @event.Link.ServerChannel.Close();
 
-        if (!@event.Link.PlayerChannel.IsAlive)
-            @event.Link.PlayerChannel.Close();
-        else if (!await @event.Player.IsProtocolSupportedAsync(cancellationToken))
+        if (@event.Reason is LinkStopReason.PlayerDisconnected ||
+            !await @event.Player.IsProtocolSupportedAsync(cancellationToken))
             @event.Link.PlayerChannel.Close();
 
         logger.LogTrace("Stopped forwarding {Link} traffic", @event.Link);

--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -143,10 +143,10 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     {
         // All other reasons should throw player disconnected event themselves
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
-
-        if (!@event.Link.PlayerChannel.IsAlive)
             return;
+        }
 
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);
     }


### PR DESCRIPTION
## Summary
Avoid reconnection races by clearing stale player data.

## Rationale
Buffered packets in the player channel were replayed on reconnect, causing duplicate connection logs.

## Changes
- Close player channel based on stop reason instead of probing its state
- Reconnect players only when they remain connected

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No change expected.

## Risks & Rollback
Low; rollback by reverting commit `26aeda19`.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a12a021a7c832bb9727ac79dad957f