### PR TITLE
fix(players): 🐛 avoid auto-reconnect after requested link stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -143,9 +143,12 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     {
         // All other reasons should throw player disconnected event themselves
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
+            return;
+        }
 
-        if (!@event.Link.PlayerChannel.IsAlive)
+        if (@event.Reason is LinkStopReason.Requested || !@event.Link.PlayerChannel.IsAlive)
             return;
 
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);


### PR DESCRIPTION
## Summary
Skip automatic reconnection when a link stops due to an intentional request, preventing duplicate connection logs.

## Rationale
Manual server switches were racing against the automatic reconnect triggered on link stop, producing extra connection events.

## Changes
- Guard `PlayerService.OnLinkStopped` to ignore requested stops and only reconnect when appropriate.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No impact expected.

## Risks & Rollback
- Low risk; revert commit if unforeseen side effects arise.

## Breaking/Migration
- None.

## Links
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a129fa93ec832ba6a94c59a4359e32