### PR TITLE
fix(platform): 🐛 prevent duplicate reconnections

### DIFF
--- a/src/Platform/Links/Link.cs
+++ b/src/Platform/Links/Link.cs
@@ -74,6 +74,8 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
 
     public async ValueTask DisposeAsync()
     {
+        _stopReason ??= LinkStopReason.Requested;
+
         await DisposeClientboundAsync();
         await DisposeServerboundAsync();
 
@@ -155,7 +157,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
             }
             catch (Exception exception) when (exception is StreamClosedException or TaskCanceledException or OperationCanceledException or ObjectDisposedException)
             {
-                _stopReason = direction switch
+                _stopReason ??= direction switch
                 {
                     Direction.Serverbound => LinkStopReason.PlayerDisconnected, // source (player) disconnected
                     Direction.Clientbound => LinkStopReason.ServerDisconnected, // source (server) disconnected
@@ -180,7 +182,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
             }
             catch (Exception exception) when (exception is StreamClosedException or TaskCanceledException or OperationCanceledException or ObjectDisposedException)
             {
-                _stopReason = direction switch
+                _stopReason ??= direction switch
                 {
                     Direction.Serverbound => LinkStopReason.ServerDisconnected, // destination (server) disconnected
                     Direction.Clientbound => LinkStopReason.PlayerDisconnected, // destination (player) disconnected

--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -145,6 +145,9 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
 
+        if (@event.Reason is not LinkStopReason.ServerDisconnected)
+            return;
+
         if (!@event.Link.PlayerChannel.IsAlive)
             return;
 


### PR DESCRIPTION
## Summary
Eliminate duplicate connection logs by avoiding automatic reconnection when a link is intentionally stopped.

## Rationale
Race conditions treated manual link shutdowns as server disconnects, triggering an unintended reconnection path and duplicate logs.

## Changes
- Preserve requested stop reason during link cancellation
- Reconnect players only when servers disconnect

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No impact expected

## Risks & Rollback
- Potential unintended behavior if other components relied on previous auto-reconnect; revert the commit to roll back.

## Breaking/Migration
- None

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a129f87328832ba596415d07551478