### PR TITLE
fix(platform): 🐛 prevent duplicate connection logs

### DIFF
--- a/src/Platform/Links/Link.cs
+++ b/src/Platform/Links/Link.cs
@@ -74,6 +74,8 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
 
     public async ValueTask DisposeAsync()
     {
+        _stopReason ??= LinkStopReason.Requested;
+
         await DisposeClientboundAsync();
         await DisposeServerboundAsync();
 
@@ -155,7 +157,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
             }
             catch (Exception exception) when (exception is StreamClosedException or TaskCanceledException or OperationCanceledException or ObjectDisposedException)
             {
-                _stopReason = direction switch
+                _stopReason ??= direction switch
                 {
                     Direction.Serverbound => LinkStopReason.PlayerDisconnected, // source (player) disconnected
                     Direction.Clientbound => LinkStopReason.ServerDisconnected, // source (server) disconnected
@@ -180,7 +182,7 @@ public class Link(IPlayer player, IServer server, INetworkChannel playerChannel,
             }
             catch (Exception exception) when (exception is StreamClosedException or TaskCanceledException or OperationCanceledException or ObjectDisposedException)
             {
-                _stopReason = direction switch
+                _stopReason ??= direction switch
                 {
                     Direction.Serverbound => LinkStopReason.ServerDisconnected, // destination (server) disconnected
                     Direction.Clientbound => LinkStopReason.PlayerDisconnected, // destination (player) disconnected

--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -142,8 +142,15 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     public async ValueTask OnLinkStopped(LinkStoppedEvent @event, CancellationToken cancellationToken)
     {
         // All other reasons should throw player disconnected event themselves
+
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
+            return;
+        }
+
+        if (@event.Reason is LinkStopReason.Requested)
+            return;
 
         if (!@event.Link.PlayerChannel.IsAlive)
             return;


### PR DESCRIPTION
## Summary
Avoids duplicate connection messages when switching proxied servers.

## Rationale
Concurrent auto-reconnects raced with manual server switches, leading to repeated connection logs.

## Changes
- Preserve `Requested` stop reason when shutting down links
- Skip auto-reconnect when link stop is requested

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No change expected.

## Risks & Rollback
- Low risk; revert commit if unexpected disconnect behavior appears.

## Breaking/Migration
- None.

## Links
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a129f32e80832b84c78567dc3c7a22