### PR TITLE
fix(players): skip auto-reconnect on requested stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -145,7 +145,13 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
 
+        if (@event.Reason is LinkStopReason.Requested)
+            return;
+
         if (!@event.Link.PlayerChannel.IsAlive)
+            return;
+
+        if (links.TryGetLink(@event.Player, out _))
             return;
 
         await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);


### PR DESCRIPTION
## Summary
Prevent duplicate connection log entries when switching servers.

## Rationale
Avoids race condition where auto-reconnect reissued a connect during intentional redirection.

## Changes
- Skip auto-reconnect when link stop reason is requested and link already exists.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
- No change.

## Risks & Rollback
- Low; revert commit `fix(players): skip auto-reconnect on requested stop`.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a12e891d8c832b80111e9a600e5a8b