### PR TITLE
fix(platform): prevent auto-reconnect on requested link stop

### DIFF
--- a/src/Platform/Players/PlayerService.cs
+++ b/src/Platform/Players/PlayerService.cs
@@ -143,12 +143,13 @@ public class PlayerService(ILogger<PlayerService> logger, IDependencyService dep
     {
         // All other reasons should throw player disconnected event themselves
         if (@event.Reason is LinkStopReason.PlayerDisconnected)
+        {
             await events.ThrowAsync(new PlayerDisconnectedEvent(@event.Player), cancellationToken);
-
-        if (!@event.Link.PlayerChannel.IsAlive)
-            return;
-
-        await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);
+        }
+        else if (@event.Link.PlayerChannel.IsAlive && @event.Reason is not LinkStopReason.Requested)
+        {
+            await links.ConnectPlayerAnywhereAsync(@event.Player, cancellationToken);
+        }
     }
 
     [Subscribe(PostOrder.Last)]


### PR DESCRIPTION
## Summary
Eliminate duplicate server connection logs when switching servers.

## Rationale
Auto-reconnection triggered on every link stop caused a race with manual redirection, producing duplicate "connected to" entries.

## Changes
- Skip automatic fallback when a link is intentionally stopped.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact expected.

## Risks & Rollback
Minimal; revert commit to restore previous behavior if issues arise.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a12e9649c4832b91c33c5094b601ed