### PR TITLE
fix(platform): 🧵 isolate log and console writers per instance

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -14,7 +14,10 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
 
     public void Setup()
     {
-        SystemConsole.SetOut(consoleRedirectConfiguration.TextWriter ?? _reader.TextWriter);
+        if (consoleRedirectConfiguration.TextWriter is not null)
+            return;
+
+        SystemConsole.SetOut(_reader.TextWriter);
 
         if (!IsEnabled)
             return;

--- a/src/Platform/Void.Proxy.csproj
+++ b/src/Platform/Void.Proxy.csproj
@@ -57,6 +57,7 @@
 		<PackageReference Include="Samboy063.Tomlet" Version="6.1.0" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
 		<PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
 		<PackageReference Include="ZLinq" Version="1.5.2" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
Allow concurrent proxy hosts without cross-contaminating console or log writers.

## Rationale
Multiple integration test proxies previously overwrote `Console.Out` and Serilog's global logger, causing conflicts.

## Changes
- Configure Serilog per host instead of via static logger.
- Skip console redirection when a custom writer is supplied.

## Verification
- `dotnet build src/Platform/Void.Proxy.csproj` *(fails: SDK 9.0 required)*
- `dotnet test src/Platform/Void.Proxy.csproj` *(fails: SDK 9.0 required)*

## Performance
No performance impact expected.

## Risks & Rollback
Low risk; revert commit to restore prior console and logging behavior.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a15878c748832b9ae978f88c7992f4