### PR TITLE
fix(platform): 🐛 avoid global console redirection

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -14,7 +14,10 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
 
     public void Setup()
     {
-        SystemConsole.SetOut(consoleRedirectConfiguration.TextWriter ?? _reader.TextWriter);
+        if (consoleRedirectConfiguration.TextWriter is not null)
+            return;
+
+        SystemConsole.SetOut(_reader.TextWriter);
 
         if (!IsEnabled)
             return;

--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -51,7 +51,7 @@ public static class EntryPoint
 
     public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, params string[] args)
     {
-        ConfigureLogging();
+        ConfigureLogging(logWriter);
 
         try
         {
@@ -66,13 +66,22 @@ public static class EntryPoint
             Log.CloseAndFlush();
         }
 
-        static void ConfigureLogging()
+        static void ConfigureLogging(TextWriter? logWriter)
         {
-            Log.Logger = new LoggerConfiguration()
+            var configuration = new LoggerConfiguration()
                 .Enrich.FromLogContext()
-                .MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch)
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}")
-                .CreateLogger();
+                .MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch);
+
+            if (logWriter is not null)
+            {
+                configuration = configuration.WriteTo.TextWriter(logWriter, outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+            }
+            else
+            {
+                configuration = configuration.WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+            }
+
+            Log.Logger = configuration.CreateLogger();
         }
 
         static void SetupHost(IHostBuilder builder, TextWriter? logWriter)


### PR DESCRIPTION
## Summary
Prevent ConsoleService from redirecting System.Console when a custom log writer is provided so multiple proxies can run concurrently.

## Rationale
Concurrent proxies previously overwrote each other's Console.Out, causing log contention. Skipping global console redirection and logging directly to the provided writer isolates each instance.

## Changes
- Log to a supplied TextWriter instead of the shared console.
- Skip Console.Out replacement when a custom writer is configured.

## Verification
- `dotnet build src/Platform/Void.Proxy.csproj` *(fails: InternalLoggerException)*
- `dotnet test src/Tests/Void.Tests.csproj` *(fails: InternalLoggerException)*

## Performance
N/A

## Risks & Rollback
Minimal; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a158517680832ba96bbd8211a48dbb