### PR TITLE
fix(platform): 🛠️ isolate console output per proxy instance

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -14,7 +14,10 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
 
     public void Setup()
     {
-        SystemConsole.SetOut(consoleRedirectConfiguration.TextWriter ?? _reader.TextWriter);
+        if (consoleRedirectConfiguration.TextWriter is not null)
+            return;
+
+        SystemConsole.SetOut(_reader.TextWriter);
 
         if (!IsEnabled)
             return;

--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Parsing;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 using Serilog;
+using Serilog.Core;
 using Void.Proxy.Api;
 using Void.Proxy.Api.Commands;
 using Void.Proxy.Api.Configurations;
@@ -51,37 +52,35 @@ public static class EntryPoint
 
     public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, params string[] args)
     {
-        ConfigureLogging();
+        using var logger = CreateLogger(logWriter);
 
-        try
-        {
-            return await BuildCommandLine(cancellationToken)
-                .UseDefaults()
-                .UseHost(builder => SetupHost(builder, logWriter))
-                .Build()
-                .InvokeAsync(args);
-        }
-        finally
-        {
-            Log.CloseAndFlush();
-        }
+        return await BuildCommandLine(cancellationToken)
+            .UseDefaults()
+            .UseHost(builder => SetupHost(builder, logWriter, logger))
+            .Build()
+            .InvokeAsync(args);
 
-        static void ConfigureLogging()
+        static Logger CreateLogger(TextWriter? logWriter)
         {
-            Log.Logger = new LoggerConfiguration()
+            var configuration = new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch)
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}")
-                .CreateLogger();
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+
+            if (logWriter is not null)
+                configuration = configuration.WriteTo.TextWriter(logWriter, outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+
+            return configuration.CreateLogger();
         }
 
-        static void SetupHost(IHostBuilder builder, TextWriter? logWriter)
+        static void SetupHost(IHostBuilder builder, TextWriter? logWriter, Logger logger)
         {
             builder
+                .UseSerilog(logger, dispose: false, preserveStaticLogger: true)
                 .UseServiceProviderFactory(new DryIocServiceProviderFactory(new Container(Rules.MicrosoftDependencyInjectionRules)))
                 .UseConsoleLifetime(options => options.SuppressStatusMessages = true)
                 .ConfigureServices(services => services
-                    .AddSerilog()
+                    .AddSerilog(logger, dispose: false)
                     .AddJsonOptions()
                     .AddHttpClient()
                     .AddSettings()


### PR DESCRIPTION
## Summary
Prevent concurrent proxies from clobbering each other's console and logger configuration.

## Rationale
Multiple test proxies previously redirected `Console.Out` and reconfigured the global Serilog logger, causing conflicts when run in parallel.

## Changes
- Initialize a per-instance Serilog logger without altering the global logger.
- Skip `Console.Out` redirection when a custom log writer is supplied.

## Verification
- `/root/.dotnet/dotnet build src/Platform/Void.Proxy.csproj` *(fails: The remote certificate is invalid because of errors in the certificate chain)*
- `/root/.dotnet/dotnet test src/Tests/Void.Tests.csproj` *(fails: The remote certificate is invalid because of errors in the certificate chain)*

## Performance
- No impact expected.

## Risks & Rollback
- Low risk; revert commit if console output routing regresses.

## Breaking/Migration
- None.

## Links
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68a1584c440c832bbb5c810f8469fbec