### PR TITLE
fix(platform): 🧵 make log redirection thread-safe

### DIFF
--- a/src/Platform/Console/ConsoleService.cs
+++ b/src/Platform/Console/ConsoleService.cs
@@ -14,7 +14,10 @@ public class ConsoleService(ILogger<ConsoleService> logger, ConsoleRedirectConfi
 
     public void Setup()
     {
-        SystemConsole.SetOut(consoleRedirectConfiguration.TextWriter ?? _reader.TextWriter);
+        if (consoleRedirectConfiguration.TextWriter is not null)
+            return;
+
+        SystemConsole.SetOut(_reader.TextWriter);
 
         if (!IsEnabled)
             return;

--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -51,7 +51,7 @@ public static class EntryPoint
 
     public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, params string[] args)
     {
-        ConfigureLogging();
+        ConfigureLogging(logWriter);
 
         try
         {
@@ -66,13 +66,18 @@ public static class EntryPoint
             Log.CloseAndFlush();
         }
 
-        static void ConfigureLogging()
+        static void ConfigureLogging(TextWriter? logWriter)
         {
-            Log.Logger = new LoggerConfiguration()
+            var configuration = new LoggerConfiguration()
                 .Enrich.FromLogContext()
-                .MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch)
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}")
-                .CreateLogger();
+                .MinimumLevel.ControlledBy(Platform.LoggingLevelSwitch);
+
+            if (logWriter is null)
+                configuration = configuration.WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+            else
+                configuration = configuration.WriteTo.TextWriter(logWriter, outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj} {NewLine}{Exception}");
+
+            Log.Logger = configuration.CreateLogger();
         }
 
         static void SetupHost(IHostBuilder builder, TextWriter? logWriter)

--- a/src/Platform/Void.Proxy.csproj
+++ b/src/Platform/Void.Proxy.csproj
@@ -55,11 +55,12 @@
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.7" />
 		<PackageReference Include="NuGet.PackageManagement" Version="6.14.0" />
 		<PackageReference Include="Samboy063.Tomlet" Version="6.1.0" />
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-		<PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
-		<PackageReference Include="ZLinq" Version="1.5.2" />
-	</ItemGroup>
+                <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+                <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+                <PackageReference Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
+                <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
+                <PackageReference Include="ZLinq" Version="1.5.2" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Api\Void.Proxy.Api.csproj" />

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -48,10 +48,15 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
         {
         }
 
-        public MineflayerClient MineflayerClient { get => field ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized."); set; }
-        public PaperServer PaperServer1 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized."); set; }
-        public PaperServer PaperServer2 { get => field ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized."); set; }
-        public VoidProxy VoidProxy { get => field ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized."); set; }
+        private MineflayerClient? _mineflayerClient;
+        private PaperServer? _paperServer1;
+        private PaperServer? _paperServer2;
+        private VoidProxy? _voidProxy;
+
+        public MineflayerClient MineflayerClient => _mineflayerClient ?? throw new InvalidOperationException($"{nameof(MineflayerClient)} is not initialized.");
+        public PaperServer PaperServer1 => _paperServer1 ?? throw new InvalidOperationException($"{nameof(PaperServer1)} is not initialized.");
+        public PaperServer PaperServer2 => _paperServer2 ?? throw new InvalidOperationException($"{nameof(PaperServer2)} is not initialized.");
+        public VoidProxy VoidProxy => _voidProxy ?? throw new InvalidOperationException($"{nameof(VoidProxy)} is not initialized.");
 
         public async Task InitializeAsync()
         {
@@ -62,25 +67,25 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
             var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
 
-            MineflayerClient = await mineflayerClientTask;
-            PaperServer1 = await paperServer1Task;
-            PaperServer2 = await paperServer2Task;
-            VoidProxy = await voidProxyTask;
+            _mineflayerClient = await mineflayerClientTask;
+            _paperServer1 = await paperServer1Task;
+            _paperServer2 = await paperServer2Task;
+            _voidProxy = await voidProxyTask;
         }
 
         public async Task DisposeAsync()
         {
-            if (MineflayerClient is not null)
-                await MineflayerClient.DisposeAsync();
+            if (_mineflayerClient is not null)
+                await _mineflayerClient.DisposeAsync();
 
-            if (PaperServer1 is not null)
-                await PaperServer1.DisposeAsync();
+            if (_paperServer1 is not null)
+                await _paperServer1.DisposeAsync();
 
-            if (PaperServer2 is not null)
-                await PaperServer2.DisposeAsync();
+            if (_paperServer2 is not null)
+                await _paperServer2.DisposeAsync();
 
-            if (VoidProxy is not null)
-                await VoidProxy.DisposeAsync();
+            if (_voidProxy is not null)
+                await _voidProxy.DisposeAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
Ensure VoidProxy logs are isolated so multiple instances can run in parallel.

## Rationale
Previously, passing a CollectingTextWriter replaced Console.Out, causing conflicts when several proxies ran at once.

## Changes
- route logs to optional TextWriter via Serilog
- skip Console.Out redirection when a log writer is supplied
- guard ProxiedServerRedirectionTests disposal against uninitialized fixtures

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No change observed.

## Risks & Rollback
Minimal; revert commit to restore previous logging behavior.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a158517680832ba96bbd8211a48dbb