### PR TITLE
fix(platform): 🐛 prevent composite container from disposing shared loggers

### DIFF
--- a/src/Platform/Plugins/Dependencies/DependencyService.cs
+++ b/src/Platform/Plugins/Dependencies/DependencyService.cs
@@ -329,7 +329,7 @@ public class DependencyService(ILogger<DependencyService> logger, IContainer con
                     }
 
                     return null;
-                });
+                }, setup: Setup.With(preventDisposal: true));
             }));
 
         container.Track("App Root Container");


### PR DESCRIPTION
## Summary
Logger factory was disposed when releasing player scopes, preventing new player loggers.

## Rationale
Ensures player loggers can still be created after context teardown.

## Changes
- Prevent composite DryIoc containers from disposing shared services like `ILoggerFactory`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact expected.

## Risks & Rollback
Minimal risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
- related to logger disposal issue

------
https://chatgpt.com/codex/tasks/task_e_68a1e625b1bc832b8f9754b28f863826