### PR TITLE
test(integration): 🔧 allow VoidProxy instance naming

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.Fixture fixture) : Co
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
-            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, name: nameof(ProxiedConnectionTests), cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -60,7 +60,7 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var mineflayerClientTask = MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             var paperServer1Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
-            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, name: nameof(ProxiedServerRedirectionTests), cancellationToken: cancellationTokenSource.Token);
 
             MineflayerClient = await mineflayerClientTask;
             PaperServer1 = await paperServer1Task;

--- a/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
+++ b/src/Tests/Integration/Sides/Proxies/VoidProxy.cs
@@ -2,7 +2,9 @@ namespace Void.Tests.Integration.Sides.Proxies;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Void.Proxy;
@@ -14,6 +16,8 @@ public class VoidProxy : IIntegrationSide
     private readonly CollectingTextWriter _logWriter;
     private readonly Task _task;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly string _originalWorkingDirectory;
+    private readonly string _workingDirectory;
 
     public IEnumerable<string> Logs => _logWriter.Lines;
 
@@ -22,20 +26,31 @@ public class VoidProxy : IIntegrationSide
         _logWriter.Clear();
     }
 
-    private VoidProxy(CollectingTextWriter logWriter, Task task, CancellationTokenSource cancellationTokenSource)
+    private VoidProxy(CollectingTextWriter logWriter, Task task, CancellationTokenSource cancellationTokenSource, string originalWorkingDirectory, string workingDirectory)
     {
         _logWriter = logWriter;
         _task = task;
         _cancellationTokenSource = cancellationTokenSource;
+        _originalWorkingDirectory = originalWorkingDirectory;
+        _workingDirectory = workingDirectory;
     }
 
-    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static Task<VoidProxy> CreateAsync(string targetServer, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, string? name = null, CancellationToken cancellationToken = default)
     {
-        return CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, cancellationToken);
+        return CreateAsync([targetServer], proxyPort, ignoreFileServers, offlineMode, name, cancellationToken);
     }
 
-    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, CancellationToken cancellationToken = default)
+    public static async Task<VoidProxy> CreateAsync(IEnumerable<string> targetServers, int proxyPort, bool ignoreFileServers = true, bool offlineMode = true, string? name = null, CancellationToken cancellationToken = default)
     {
+        name ??= nameof(VoidProxy);
+
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"{nameof(Tests)}", "IntegrationTests", name);
+        RuntimeHelpers.RunClassConstructor(typeof(EntryPoint).TypeHandle);
+        if (!Directory.Exists(workingDirectory))
+            Directory.CreateDirectory(workingDirectory);
+        var originalWorkingDirectory = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(workingDirectory);
+
         var logWriter = new CollectingTextWriter();
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cancellationToken = cancellationTokenSource.Token;
@@ -72,7 +87,7 @@ public class VoidProxy : IIntegrationSide
             Assert.Fail($"{nameof(VoidProxy)} failed to start. Logs:\n{logWriter.Text}\n{exception}");
         }
 
-        return new VoidProxy(logWriter, task, cancellationTokenSource);
+        return new VoidProxy(logWriter, task, cancellationTokenSource, originalWorkingDirectory, workingDirectory);
     }
 
     public async ValueTask DisposeAsync()
@@ -81,5 +96,10 @@ public class VoidProxy : IIntegrationSide
 
         await _cancellationTokenSource.CancelAsync();
         await _task;
+
+        Directory.SetCurrentDirectory(_originalWorkingDirectory);
+
+        if (Directory.Exists(_workingDirectory))
+            Directory.Delete(_workingDirectory, true);
     }
 }


### PR DESCRIPTION
## Summary
Isolates test proxy instances to avoid configuration file conflicts.

## Rationale
Parallel tests previously shared `settings.toml`, causing IO errors.

## Changes
- add optional name parameter to test `VoidProxy`
- use unique working directories in integration tests

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low; revert the commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a1f73f3794832bb030c73b90346dcc