### PR TITLE
test(integration): 🧪 isolate proxy instances

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.Fixture fixture) : Co
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
-            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, instanceName: nameof(ProxiedConnectionTests), cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -60,7 +60,7 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var mineflayerClientTask = MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             var paperServer1Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
-            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, instanceName: nameof(ProxiedServerRedirectionTests), cancellationToken: cancellationTokenSource.Token);
 
             MineflayerClient = await mineflayerClientTask;
             PaperServer1 = await paperServer1Task;


### PR DESCRIPTION
## Summary
Allow passing unique instance names to proxy helper so each integration test uses its own settings file.

## Rationale
Multiple integration tests starting the proxy concurrently conflicted over `settings.toml`. Naming instances isolates configurations.

## Changes
- Add optional `instanceName` parameter to `VoidProxy.CreateAsync` and isolate working directories.
- Pass unique names from connection and redirection integration tests.

## Verification
- `dotnet build Void.slnx` *(fails: element <Solution> is unrecognized)*
- `dotnet test Void.slnx` *(fails: element <Solution> is unrecognized)*

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit if tests misbehave.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a1fcc8b468832bbe27cee04452f617