### PR TITLE
test(proxies): 🧪 allow naming VoidProxy instances

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.Fixture fixture) : Co
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
-            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(_workingDirectory, targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, instanceName: nameof(VoidProxy), cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -60,7 +60,7 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var mineflayerClientTask = MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             var paperServer1Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
-            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            var voidProxyTask = VoidProxy.CreateAsync(_workingDirectory, [$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, instanceName: nameof(VoidProxy), cancellationToken: cancellationTokenSource.Token);
 
             MineflayerClient = await mineflayerClientTask;
             PaperServer1 = await paperServer1Task;


### PR DESCRIPTION
## Summary
Allow integration tests to provide a unique name for VoidProxy instances so configs don't clash.

## Rationale
Concurrent proxies wrote to the same settings file, causing file locks during tests. Naming isolates each proxy into its own folder.

## Changes
- Add `instanceName` and working directory handling to `VoidProxy.CreateAsync`
- Pass unique names from proxied connection tests
- Use per-proxy folders in redirection tests

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert the commit to restore previous behavior.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68a1fccb6afc832baba96f9500b5a23b