### PR TITLE
test(integration): 🧪 add instance name for VoidProxy

### DIFF
--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.Fixture fixture) : Co
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
-            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(_workingDirectory, targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, instanceName: nameof(ProxiedConnectionTests), cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -60,7 +60,7 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var mineflayerClientTask = MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             var paperServer1Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
-            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            var voidProxyTask = VoidProxy.CreateAsync(_workingDirectory, [$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, instanceName: nameof(ProxiedServerRedirectionTests), cancellationToken: cancellationTokenSource.Token);
 
             MineflayerClient = await mineflayerClientTask;
             PaperServer1 = await paperServer1Task;


### PR DESCRIPTION
## Summary
Allow naming VoidProxy instances to isolate configuration files during integration tests.

## Rationale
Parallel tests created competing `settings.toml` files. Providing instance-specific directories avoids file contention.

## Changes
- Extend `VoidProxy.CreateAsync` with working directory and optional name.
- Pass new parameters in proxied integration test fixtures.

## Verification
- `dotnet build` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*
- `dotnet test` *(fails: Restore canceled!)*

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit if proxy setup misbehaves.

## Breaking/Migration
Tests using `VoidProxy.CreateAsync` must supply working directory and optional name.

## Links
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68a1fcca3fdc832ba95e9de9763e290e