### PR TITLE
fix(platform): 🐛 isolate working directory per proxy instance

### DIFF
--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -47,11 +47,19 @@ public static class EntryPoint
 
     private static async Task<int> Main(string[] args)
     {
-        return await RunAsync(logWriter: null, cancellationToken: default, [.. args]);
+        return await RunAsync(logWriter: null, cancellationToken: default, args: [.. args]);
     }
 
-    public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, params string[] args)
+    public static async Task<int> RunAsync(TextWriter? logWriter = null, CancellationToken cancellationToken = default, string? workingDirectory = null, params string[] args)
     {
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            if (!Directory.Exists(workingDirectory))
+                Directory.CreateDirectory(workingDirectory);
+
+            Directory.SetCurrentDirectory(workingDirectory);
+        }
+
         var logger = ConfigureLogging(logWriter);
 
         try

--- a/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedConnectionTests.cs
@@ -95,7 +95,7 @@ public class ProxiedConnectionTests(ProxiedConnectionTests.Fixture fixture) : Co
             MinecraftConsoleClient = await MinecraftConsoleClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             MineflayerClient = await MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             PaperServer = await PaperServer.CreateAsync(_workingDirectory, _httpClient, port: ServerPort, cancellationToken: cancellationTokenSource.Token);
-            VoidProxy = await VoidProxy.CreateAsync(targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            VoidProxy = await VoidProxy.CreateAsync(_workingDirectory, targetServer: $"localhost:{ServerPort}", proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
         }
 
         public async Task DisposeAsync()

--- a/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
+++ b/src/Tests/Integration/Connections/Units/ProxiedServerRedirectionTests.cs
@@ -60,7 +60,7 @@ public class ProxiedServerRedirectionTests(ProxiedServerRedirectionTests.Fixture
             var mineflayerClientTask = MineflayerClient.CreateAsync(_workingDirectory, _httpClient, cancellationToken: cancellationTokenSource.Token);
             var paperServer1Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server1Port, instanceName: "server1", cancellationToken: cancellationTokenSource.Token);
             var paperServer2Task = PaperServer.CreateAsync(_workingDirectory, _httpClient, port: Server2Port, instanceName: "server2", cancellationToken: cancellationTokenSource.Token);
-            var voidProxyTask = VoidProxy.CreateAsync([$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
+            var voidProxyTask = VoidProxy.CreateAsync(_workingDirectory, [$"localhost:{Server1Port}", $"localhost:{Server2Port}"], proxyPort: ProxyPort, cancellationToken: cancellationTokenSource.Token);
 
             MineflayerClient = await mineflayerClientTask;
             PaperServer1 = await paperServer1Task;


### PR DESCRIPTION
## Summary
Prevent configuration file conflicts when running multiple proxy instances.

## Rationale
Integration tests could interfere with each other by sharing the same settings file. Allowing each proxy instance to run in its own directory isolates configuration writes.

## Changes
- Add optional working directory to `EntryPoint.RunAsync`.
- Create per-instance directories in test `VoidProxy` helper and forward them to the proxy.
- Update integration tests to supply the fixture's directory.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact expected.

## Risks & Rollback
Low; revert this commit.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a1f53d79bc832baa0776937dbf5f5f