### PR TITLE
test(mineflayer-client): 🧪 add kick handling

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -75,6 +75,7 @@ public class MineflayerClient : IntegrationSideBase
             });
 
             bot.on('error', err => console.error('ERROR: ' + err.message));
+            bot.on('kicked', reason => console.error('KICK: ' + reason));
             """, cancellationToken);
 
         if (!OperatingSystem.IsWindows())
@@ -111,7 +112,7 @@ public class MineflayerClient : IntegrationSideBase
 
     private static bool HandleConsole(string line)
     {
-        if (line.StartsWith("ERROR:"))
+        if (line.StartsWith("ERROR:") || line.StartsWith("KICK:"))
             throw new IntegrationTestException(line);
 
         if (line.Contains("end"))


### PR DESCRIPTION
## Summary
Handle Mineflayer kicks as integration test failures.

## Rationale
Unifies error and kick handling so tests fail when the bot is disconnected.

## Changes
- Listen for Mineflayer `kicked` events and log them.
- Treat `KICK:` console output as an `IntegrationTestException` trigger.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if unexpected kicks occur.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68a263f04650832bbcffd2e0289827fa