### PR TITLE
test(mineflayer-client): ✅ wait for spawn or respawn on commands

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -51,17 +51,24 @@ public class MineflayerClient : IntegrationSideBase
             const WAIT_FOR_TIMEOUT_MS = 16_000;
 
             const waitFor = (text) => new Promise(resolve => {
-                const eventName = text.startsWith('/') ? 'respawn' : 'message';
+                const events = text.startsWith('/') ? ['spawn', 'respawn'] : ['message'];
 
                 const timer = setTimeout(() => {
-                    console.error('ERROR: timed out waiting for event', eventName, 'with text', text);
+                    console.error('ERROR: timed out waiting for events', events.join(' or '), 'with text', text);
                     resolve();
                 }, WAIT_FOR_TIMEOUT_MS);
-            
-                bot.once(eventName, () => {
+
+                const listener = () => {
                     clearTimeout(timer);
+
+                    for (const event of events)
+                        bot.off(event, listener);
+
                     resolve();
-                });
+                };
+
+                for (const event of events)
+                    bot.on(event, listener);
             });
 
             bot.once('spawn', async () => {


### PR DESCRIPTION
## Summary
Ensure Mineflayer test bot waits for spawn or respawn when sending slash commands.

## Rationale
Commands may not emit chat messages and can trigger a respawn cycle; listening for these events avoids timeouts and flaky tests.

## Changes
- Update Mineflayer test client to await either `spawn` or `respawn` after slash commands.

## Verification
- `dotnet build`
- `dotnet test --no-build`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore previous behavior.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a2712da9ac832b9f1fa0fc82e4bbdc