### PR TITLE
test(integration): 🧪 remove lock from release asset retrieval

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -305,8 +305,6 @@ public abstract class IntegrationSideBase : IIntegrationSide
 
         while (--retries > 0)
         {
-            using var disposable = await _lock.LockAsync(cancellationToken);
-
             var releases = await _gitHubClient.Repository.Release.GetAll(ownerName, repositoryName, options);
 
             if (releases.Count is 0)


### PR DESCRIPTION
## Summary
Eliminate unnecessary locking in GitHub release asset helper for integration tests.

## Rationale
Locking serialized GitHub API calls during tests, slowing parallel runs. Removing it allows concurrent downloads without contention.

## Changes
- Drop `AsyncLock` usage in `GetGitHubRepositoryLatestReleaseAssetAsync`.

## Verification
- `dotnet build`
- `dotnet test` *(hangs; aborted after prolonged wait)*

## Performance
No impact measured.

## Risks & Rollback
Minimal risk; revert commit if concurrency issues appear.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68a535b9f0a0832bad4987812cbfbe33