### PR TITLE
test(integration): 🔧 set DEBUG env var for StartApplication

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -70,6 +70,8 @@ public abstract class IntegrationSideBase : IIntegrationSide
             UseShellExecute = false
         };
 
+        processStartInfo.Environment["DEBUG"] = "minecraft-protocol";
+
         foreach (var protocol in new[] { "http", "https" })
         {
             var name = $"{protocol}_proxy";


### PR DESCRIPTION
## Summary
Ensure integration tests launch child processes with protocol debugging enabled.

## Rationale
Integration test clients rely on DEBUG to trace minecraft protocol; setting it explicitly aids diagnosis.

## Changes
- Add DEBUG=minecraft-protocol to all StartApplication process launches.

## Verification
- `dotnet build src/Tests/Void.Tests.csproj` *(fails: .NET SDK 8.0 does not support targeted frameworks 9.0/10.0)*
- `dotnet test src/Tests/Void.Tests.csproj` *(fails: .NET SDK 8.0 does not support targeted frameworks 9.0/10.0)*

## Performance
No impact.

## Risks & Rollback
Low; revert commit.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a58226d954832b97c708af76c77ef9