### PR TITLE
test(mineflayer-client): 🧪 suppress buggy physics packets

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -51,9 +51,25 @@ public class MineflayerClient : IntegrationSideBase
               host,
               port,
               username: '{{nameof(MineflayerClient)}}',
-              version,
-              physicsEnabled: false // physics has a bug that sends position packet in configuration phase, when such phase requested by server from previous play phase
+              version
             });
+
+            const suppressedPackets = new Set([
+              'position',
+              'look',
+              'position_look',
+              'flying'
+            ]);
+
+            // physics has a bug that sends position packet in configuration phase, when such phase requested by server from previous play phase
+            const originalWrite = bot._client.write.bind(bot._client);
+            bot._client.write = (packetName, packetPayload) => {
+              if (suppressedPackets.has(packetName))
+                return;
+
+              return originalWrite(packetName, packetPayload);
+            };
+
             const eventNamesToLog = [
               'chat',
               'whisper',


### PR DESCRIPTION
## Summary
Replace mineflayer physics flag with manual packet suppression to avoid mis-sent position packets during configuration.

## Rationale
Mineflayer's physics sends position updates during configuration, breaking tests; suppressing those packets keeps the client idle.

## Changes
- Remove `physicsEnabled` option from Mineflayer script
- Suppress position-related packets through custom write wrapper

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore previous flag behavior.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68a5939c4b80832bad56c1e653349720