### PR TITLE
test(mineflayer-client): ⚡ remove player join delay

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -188,7 +188,6 @@ public class MineflayerClient : IntegrationSideBase
 
                 bot.once(event, async () => {
                     clearTimeout(timer);
-                    if (event === 'playerJoined') await new Promise(r => setTimeout(r, 10 * 1000));
                     resolve();
                 });
             });


### PR DESCRIPTION
## Summary
Eliminate unnecessary join delay in Mineflayer client tests.

## Rationale
Speeds up integration tests by avoiding an artificial 10‑second wait after players join.

## Changes
- remove `playerJoined` event delay in `MineflayerClient`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert commit if unexpected test timing issues arise.

## Breaking/Migration
None.

## Links
N/A.

------
https://chatgpt.com/codex/tasks/task_e_68a59923edc8832ba268c37e4194eb53