### PR TITLE
test(tests): ⏱️ add delay before GitHub release retries

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -20,6 +20,7 @@ public abstract class IntegrationSideBase : IIntegrationSide
 {
     private const int MaxGitHubReleasesToConsider = 3;
     private const int MaxGitHubReleaseRetries = 5;
+    private const int GitHubReleaseRetryDelaySeconds = 20;
 
     private static readonly AsyncLock _lock = new();
     private static readonly GitHubClient _gitHubClient = new(new ProductHeaderValue($"{nameof(Void)}.{nameof(Tests)}"));
@@ -318,7 +319,10 @@ public abstract class IntegrationSideBase : IIntegrationSide
                 .FirstOrDefault(asset => assetFilter(asset.Name));
 
             if (asset is null)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(GitHubReleaseRetryDelaySeconds), cancellationToken);
                 continue;
+            }
 
             return asset.BrowserDownloadUrl;
         }


### PR DESCRIPTION
## Summary
Introduce a wait before retrying GitHub release asset lookups.

## Rationale
Retries were immediate, contributing to flakiness when assets were not yet available.

## Changes
- define a 20-second retry delay constant
- pause before each subsequent GitHub asset lookup

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore prior behavior.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a5af156280832b9d1771eded3f528d