### PR TITLE
test(integration): 🔬 propagate parent env vars to child process

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -71,7 +71,8 @@ public abstract class IntegrationSideBase : IIntegrationSide
             UseShellExecute = false
         };
 
-        processStartInfo.Environment["DEBUG"] = "minecraft-protocol";
+        foreach (System.Collections.DictionaryEntry variable in Environment.GetEnvironmentVariables())
+            processStartInfo.Environment[(string)variable.Key] = (string?)variable.Value;
 
         foreach (var protocol in new[] { "http", "https" })
         {


### PR DESCRIPTION
## Summary
Integrate all environment variables into child processes during integration tests.

## Rationale
Ensures test-executed processes inherit host configurations rather than a fixed DEBUG flag.

## Changes
- Copy parent environment variables into `ProcessStartInfo` for integration test processes.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal; revert commit to restore previous behavior.

## Breaking/Migration
None.

## Links
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68a5b8ba1170832b9df28d5021e059cf