### PR TITLE
fix(tests): ♻️ inherit environment variables in spawned processes

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Tar;
@@ -71,7 +72,8 @@ public abstract class IntegrationSideBase : IIntegrationSide
             UseShellExecute = false
         };
 
-        processStartInfo.Environment["DEBUG"] = "minecraft-protocol";
+        foreach (DictionaryEntry variable in Environment.GetEnvironmentVariables())
+            processStartInfo.Environment[(string)variable.Key] = (string)variable.Value;
 
         foreach (var protocol in new[] { "http", "https" })
         {


### PR DESCRIPTION
## Summary
Ensure integration test processes inherit parent environment variables for consistent configuration.

## Rationale
Hardcoded DEBUG variable limited visibility and ignored other environment-dependent settings. Copying all variables keeps tests aligned with runtime environment.

## Changes
- Copy all current environment variables to spawned integration test processes.
- Import System.Collections to enumerate variables.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No impact; test harness only.

## Risks & Rollback
Low risk; revert commit if integration tests misbehave.

## Breaking/Migration
None.

## Links
-

------
https://chatgpt.com/codex/tasks/task_e_68a5b8b19b58832b8e2ba13eb9dd8c2d