### PR TITLE
test(integration): 🧪 await playerJoined or spawn after slash messages

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -179,17 +179,20 @@ public class MineflayerClient : IntegrationSideBase
             const WAIT_FOR_TIMEOUT_MS = 16 * 1000;
 
             const waitFor = (text) => new Promise(resolve => {
-                const event = text.startsWith('/') ? 'playerJoined' : 'messagestr';
+                const events = text.startsWith('/') ? ['playerJoined', 'spawn'] : ['messagestr'];
 
                 const timer = setTimeout(() => {
-                    console.error(`ERROR: timed out waiting for event`, event, 'with text', text);
+                    console.error(`ERROR: timed out waiting for event`, events.join(' or '), 'with text', text);
                     resolve();
                 }, WAIT_FOR_TIMEOUT_MS);
 
-                bot.once(event, async () => {
+                const resolveAndClear = () => {
                     clearTimeout(timer);
                     resolve();
-                });
+                };
+
+                for (const event of events)
+                    bot.once(event, resolveAndClear);
             });
 
             bot.once('spawn', async () => {


### PR DESCRIPTION
## Summary
Ensure Mineflayer tests wait for the correct event when commands trigger spawns.

## Rationale
Commands that move the bot can fire a `spawn` instead of `playerJoined`, causing timeouts during tests.

## Changes
- Wait for `playerJoined` or `spawn` in Mineflayer client when sending slash-prefixed messages.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68a5c76c1488832b83ec3b5c2a0b08e6