### PR TITLE
fix(config): 🧹 ensure all plugin configurations are removed

### DIFF
--- a/src/Platform/Configurations/ConfigurationService.cs
+++ b/src/Platform/Configurations/ConfigurationService.cs
@@ -32,7 +32,7 @@ public class ConfigurationService(ILogger<ConfigurationService> logger, IPluginS
 
         lock (this)
         {
-            for (var i = _configurations.Count - 1; i > 0; i--)
+            for (var i = _configurations.Count - 1; i >= 0; i--)
             {
                 var (key, configuration) = _configurations.ElementAt(i);
                 var configurationType = configuration.GetType();


### PR DESCRIPTION
## Summary
Fix intermittent plugin unload failures by clearing all configuration entries on plugin unload.

## Rationale
Leftover configuration objects held references to plugin assemblies, occasionally blocking unload and causing shutdown exceptions.

## Changes
- Remove every configuration entry for unloading plugins.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a5f333267c832bb690318a1b9d1d1b