### PR TITLE
fix(plugins): 🧹 ensure aggressive GC for unload

### DIFF
--- a/src/Platform/Plugins/PluginService.cs
+++ b/src/Platform/Plugins/PluginService.cs
@@ -326,7 +326,7 @@ public class PluginService(ILogger<PluginService> logger, IRunOptions runOptions
 
         do
         {
-            GC.Collect();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
             GC.WaitForPendingFinalizers();
 
             if (!container.IsAlive)


### PR DESCRIPTION
## Summary
Reduce plugin shutdown failures by forcing full garbage collection during container unload.

## Rationale
Occasional teardown errors were triggered when plugin assembly load contexts remained alive; a more aggressive GC improves reliability. Alternative considered: swallowing the exception entirely.

## Changes
- force blocking, compacting GC in the plugin unload loop

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No measurable impact; GC occurs only during shutdown.

## Risks & Rollback
Low: affects shutdown path only. Revert commit to restore prior behavior.

## Breaking/Migration
None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a5f33396f4832b96f91db4bc0e7316