### PR TITLE
test(integration): 🧪 surface logs when output missing

### DIFF
--- a/src/Tests/Integration/Sides/IntegrationSideBase.cs
+++ b/src/Tests/Integration/Sides/IntegrationSideBase.cs
@@ -180,6 +180,10 @@ public abstract class IntegrationSideBase : IIntegrationSide
         {
             await taskCompletionSource.Task;
         }
+        catch (Exception exception)
+        {
+            throw new IntegrationTestException($"{exception}\nCannot find expected text. Logs:\n{string.Join("\n", Logs)}");
+        }
         finally
         {
             _process.OutputDataReceived -= OnDataReceived;


### PR DESCRIPTION
## Summary
Ensure integration tests expose captured logs when expected text is absent.

## Rationale
Diagnosing failed output matching was difficult without including process logs.

## Changes
- rethrow `IntegrationTestException` with collected logs when output handler fails

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal; revert commit `aeceb125`.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a66ec6d178832b9f8ad517a503470f