### PR TITLE
ci(docs): 👷 use nightly DocFX from GitHub Packages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,8 +42,22 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
-      - name: Setup DocFX
-        run: dotnet tool update -g docfx
+      # - name: Setup DocFX
+      #   run: dotnet tool update -g docfx
+      - name: Install DocFX nightly (GitHub Packages)
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth login --with-token <<< "$env:GITHUB_TOKEN"
+          gh auth refresh -h github.com -s read:packages
+
+          $latestDocfxVersion = gh api /orgs/dotnet/packages/nuget/docfx/versions --jq '.[0].name'
+          $docfxDownloadUrl = "https://nuget.pkg.github.com/dotnet/download/docfx/$latestDocfxVersion/$latestDocfxVersion.nupkg"
+          $docfxLocalPackageFile = "docfx.$latestDocfxVersion.nupkg"
+
+          Invoke-RestMethod -Uri $docfxDownloadUrl -OutFile $docfxLocalPackageFile -Headers @{ Authorization = "Bearer $env:GITHUB_TOKEN" }
+          dotnet tool update -g docfx --prerelease --source ./
       - name: Build with DocFX
         run: docfx docs/docfx/docfx.json --verbose
         continue-on-error: true


### PR DESCRIPTION
## Summary
Use nightly DocFX installer via GitHub Packages to keep docs build up-to-date.

## Rationale
Ensures documentation pipeline runs against the latest DocFX bits while investigating issues.

## Changes
- comment out existing DocFX installation
- fetch and install DocFX nightly from GitHub Packages

## Verification
- `/root/.dotnet/dotnet test`

## Performance
N/A

## Risks & Rollback
Nightly builds may introduce instability; revert to the previous commit to restore the stable installer.

## Breaking/Migration
None

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a6b6edf588832b805d9a3dce875ef2