### PR TITLE
ci(docs): 👷 enable manual docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,12 @@ on:
       dotnet-version:
         type: string
         required: true
+  workflow_dispatch:
+    inputs:
+      dotnet-version:
+        description: "Full version of .NET SDK"
+        required: true
+        type: string
 
 jobs:
   push:


### PR DESCRIPTION
## Summary
Add manual trigger to documentation workflow so it can be run on demand.

## Rationale
Allows rebuilding documentation without invoking the full CI pipeline.

## Changes
- add `workflow_dispatch` trigger with `.NET` version input

## Verification
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Void.slnx` *(fails: The element <Solution> is unrecognized)*
- `dotnet test` *(fails: Specify a project or solution file)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to remove manual trigger.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a7440621e0832bb40a4b3c57fcbccd