### PR TITLE
ci(docs): 🐛 fix gh auth token input

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -49,7 +49,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh auth login --with-token <<< "$env:GITHUB_TOKEN"
+          echo $env:GITHUB_TOKEN | gh auth login --with-token
           gh auth refresh -h github.com -s read:packages
 
           $latestDocfxVersion = gh api /orgs/dotnet/packages/nuget/docfx/versions --jq '.[0].name'


### PR DESCRIPTION
## Summary
Resolve authentication failure in docs workflow.

## Rationale
PowerShell can't handle bash-style stdin redirection, causing DocFX install to error.

## Changes
- Pipe `GITHUB_TOKEN` into `gh auth login --with-token`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Minimal; revert commit `3f002692` if workflow issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a7488448f0832b860e99b781e6c524