### PR TITLE
ci(docs): 🔐 use PAT_READ_PACKAGES secret for docfx

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install DocFX nightly (GitHub Packages)
         shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_READ_PACKAGES }}
         run: |
           echo $env:GITHUB_TOKEN | gh auth login --with-token
           gh auth refresh -h github.com -s read:packages


### PR DESCRIPTION
## Summary
Switch DocFX workflow auth to PAT.

## Rationale
GITHUB_SECRET lacks package permissions; PAT_READ_PACKAGES allows DocFX nightly pull.

## Changes
- Use `PAT_READ_PACKAGES` secret when authenticating with GitHub Packages in `docs.yaml`.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if DocFX access breaks.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a7a92c55a8832b84e83811023200ac