### PR TITLE
ci(workflows): ♻️ install multiple dotnet versions

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.release-please.outputs.tag_name }}
 
 env:
-  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || '10.0.100-preview.6.25358.103' }}
+  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || join(fromJSON('["9.x","10.x"]'), '\n') }}
 
 jobs:
   dev:
@@ -37,7 +37,7 @@ jobs:
       - name: Set .NET SDK version
         id: dotnet-version
         run: |
-          echo "result=$DOTNET_VERSION" >> $GITHUB_OUTPUT
+          printf 'result<<EOF\n%s\nEOF\n' "$DOTNET_VERSION" >> "$GITHUB_OUTPUT"
       - name: Set Void fallback version
         id: void-fallback-version
         run: |

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.release-please.outputs.tag_name }}
 
 env:
-  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || join(fromJSON('["9.x","10.x"]'), '\n') }}
+  DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || join(fromJSON('["9.0.x","10.0.x"]'), '\n') }}
 
 jobs:
   dev:
@@ -37,7 +37,7 @@ jobs:
       - name: Set .NET SDK version
         id: dotnet-version
         run: |
-          printf 'result<<EOF\n%s\nEOF\n' "$DOTNET_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'result<<EOF\n%b\nEOF\n' "$DOTNET_VERSION" >> "$GITHUB_OUTPUT"
       - name: Set Void fallback version
         id: void-fallback-version
         run: |


### PR DESCRIPTION
## Summary
Install both .NET 9 and 10 SDKs during CI runs.

## Rationale
Ensures workflows validate against current and next major .NET versions without manual updates.

## Changes
- Default `DOTNET_VERSION` now expands to `9.x` and `10.x`.
- Output handling updated for multiline `dotnet-version` strings.

## Verification
- `dotnet build`
- `dotnet test` *(hangs under container limits)*

## Performance
N/A

## Risks & Rollback
Longer setup time for installing two SDKs. Revert commit to restore single-version installs.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a7aed2a094832baa00663d5c72b112