### PR TITLE
docs(getting-started): 📝 fix typo in features page

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/features.mdx
+++ b/docs/astro/src/content/docs/docs/getting-started/features.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Badge } from '@astrojs/starlight/components';
 
-**A quick look on what the Void proxy already supports and what's is in development.**
+**A quick look at what the Void proxy already supports and what's in development.**
 
 ## Terms
 <Badge text="Proxying" variant="tip" /> - lets you play through the proxy.  


### PR DESCRIPTION
## Summary
Fix typo on features overview.

## Rationale
Improves clarity in documentation.

## Changes
- Corrected wording in features page.

## Verification
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert if issues arise.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68a7da759fe4832bac5e0e73f031f4bb