### PR TITLE
docs(watchdog): 📝 fix link typo

### DIFF
--- a/docs/astro/src/content/docs/docs/watchdog.md
+++ b/docs/astro/src/content/docs/docs/watchdog.md
@@ -7,7 +7,7 @@ The Watchdog feature in Void is designed to monitor the health of the Void Proxy
 This is particularly useful for long-running processes or when running Void in a [**production environment**](/docs/containers/).
 
 ## Enable Watchdog
-Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or [**environment variable**](/docs/configuration/in-file/#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
+Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or [**environment variable**](/docs/configuration/in-file#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
 
 ## Health Check
 `/health` endpoint is used to check the health of the Void Proxy.


### PR DESCRIPTION
## Summary
Correct a malformed Watchdog documentation link so it directs to the configuration section.

## Rationale
Ensures readers can navigate to the intended configuration anchor without confusion.

## Changes
- Remove extraneous slash from Watchdog environment variable link.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a7da7101ec832b845374cf76f78bcf