### PR TITLE
docs(index): ✏️ fix article in containers card

### DIFF
--- a/docs/astro/src/content/docs/index.mdx
+++ b/docs/astro/src/content/docs/index.mdx
@@ -34,6 +34,6 @@ import { Card, LinkCard, CardGrid } from '@astrojs/starlight/components';
 		Designed to support any Minecraft Edition, including Bedrock, Java, Pocket and [more](/docs/getting-started/features/#game-versions).
 	</Card>
 	<Card title="Containers" icon="seti:docker">
-		Built with [Containers](/docs/containers) in mind, easy to deploy to Docker or Kubernetes cluster.
+		Built with [Containers](/docs/containers) in mind, easy to deploy to a Docker or Kubernetes cluster.
 	</Card>
 </CardGrid>


### PR DESCRIPTION
## Summary
Add missing article in container feature description for clarity.

## Rationale
Improves grammatical correctness and readability on the landing page; no alternatives considered.

## Changes
- add "a" before "Docker or Kubernetes cluster" on landing page

## Verification
- `dotnet test Void.slnx` *(fails: The element <Solution> is unrecognized)*

## Performance
N/A

## Risks & Rollback
Low risk; revert the commit if issues arise.

## Breaking/Migration
None.

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_68a8072923b0832b926197b3bc0232fe