### PR TITLE
docs(events): 📝 fix typos in event listening guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -39,7 +39,7 @@ public async ValueTask OnPlayerConnected(PlayerConnectedEvent @event, Cancellati
 ```
 
 ## Listening to events
-For your managed services include `IEventListener` interface on your service class.
+For your managed services, include the `IEventListener` interface on your service class.
 ```csharp
 public class MySingletonService : IEventListener
 {
@@ -62,7 +62,7 @@ public class MyScopedService(IPlayerContext context, ILogger logger) : IEventLis
     [Subscribe]
     public void OnPlayerConnected(PlayerConnectedEvent @event)
     {
-        // Code here will be executed only when @event.Player and context.Player are same player.
+        // Code here will be executed only when @event.Player and context.Player are the same player.
         logger.LogInformation("Player {Player} is in its own context? {Result}", @event.Player.Name, @event.Player == context.Player);
     }
 


### PR DESCRIPTION
## Summary
Fix minor typos in event listening documentation.

## Rationale
Improves documentation clarity for plugin authors.

## Changes
- Correct wording around `IEventListener` interface usage
- Clarify player context comment in event listening example

## Verification
- `codespell docs README.md --skip "docs/astro/package-lock.json"`
- `dotnet build`
- `dotnet test`

## Performance
n/a

## Risks & Rollback
Minimal; revert commit if needed.

## Breaking/Migration
None.

## Links
n/a

------
https://chatgpt.com/codex/tasks/task_e_68a8072bbf20832b833981dcfffad048