### PR TITLE
docs(commands): 📝 clarify slot argument wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/commands.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/commands.md
@@ -126,7 +126,7 @@ class MyService(ICommandService commands)
 
         if (!context.TryGetArgument<int>("index", out var slot))
         {
-            // If slot argument is not provided, we will use random one
+            // If the slot argument is not provided, we will use a random one
             slot = Random.Shared.Next(0, 9);
         }
 


### PR DESCRIPTION
## Summary
Fix a minor grammar issue in the commands documentation.

## Rationale
Improves clarity when describing how default slots are chosen.

## Changes
- clarify wording around selecting a random slot when none is provided

## Verification
- `dotnet build`
- `dotnet test` *(fails: MSBUILD : error MSB4166: Child node exited prematurely)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68a8072e9100832baadc2f17ad4eb5e5