### PR TITLE
docs(developing-plugins): 📝 fix documentation typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -3,7 +3,7 @@ title: Development Kit
 description: Learn how to use the Plugin Development Kit to create plugins for Void.
 ---
 
-Plugin Development Kit is a set of predefined configurations that simplifies the development process of plugins.
+Plugin Development Kit is a set of predefined configurations that simplify the development process of plugins.
 It can be used with any MSBuild-compatible IDE, such as Visual Studio or JetBrains Rider.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
Fixes subject-verb agreement in development kit guide.

## Rationale
Corrects documentation grammar for clarity; no alternative considered.

## Changes
- Align development kit docs with proper subject-verb agreement

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint tests)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues occur.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68aa6d723b24832ba87249620f33e39a