### PR TITLE
docs(forwarding): 📝 document forwarding plugin CLI option

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -26,6 +26,7 @@ Options:
   --port <port>                                                    Sets the listening port
   --offline                                                        Allows players to connect without Mojang authorization
   --logging <Critical|Debug|Error|Information|None|Trace|Warning>  Sets the logging level
+  --forwarding-modern-key <forwarding-modern-key>                  Sets the secret key for modern forwarding
   --version                                                        Show version information
   -?, -h, --help                                                   Show help and usage information
 ```
@@ -51,7 +52,7 @@ Options:
   ```
 
 ## Servers
-- `--server`  
+- `--server`
   Registers a server in format `<host>:<port>` where the port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
 - `--ignore-file-servers`
   Ignore servers specified in [**configuration files**](/docs/configuration/in-file).
@@ -63,10 +64,18 @@ Options:
     --server [2001:db8::1]:25565
   ```
 
+## Forwarding
+- `--forwarding-modern-key`
+  Sets the secret key for [**Modern (Velocity)**](/docs/forwardings/modern) forwarding.
+
+  ```bash title="Example Usage"
+  ./void-linux-x64 --forwarding-modern-key YourSecretKeyHere
+  ```
+
 ## Plugins
-- `--plugin`  
+- `--plugin`
   Allows you to specify plugins to load.
-- `--repository`  
+- `--repository`
   Allows you to specify NuGet repositories to resolve plugin dependencies.
 
   ```bash title="Example Usage"

--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -25,3 +25,9 @@ Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/
 ## Configuration
 To configure the Velocity forwarding, you need to set up a 'Secret' key on both the proxy and server sides.
 Check the [**In-file configuration**](/docs/configuration/in-file/#modern-velocity) for more details.
+
+You can also provide the key via the `--forwarding-modern-key` program argument:
+
+```bash title="Example Usage"
+./void-linux-x64 --forwarding-modern-key YourSecretKeyHere
+```

--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -26,7 +26,7 @@ Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/
 To configure the Velocity forwarding, you need to set up a 'Secret' key on both the proxy and server sides.
 Check the [**In-file configuration**](/docs/configuration/in-file/#modern-velocity) for more details.
 
-You can also provide the key via the `--forwarding-modern-key` program argument:
+You can also provide the key via the `--forwarding-modern-key` [program argument](/docs/configuration/program-arguments):
 
 ```bash title="Example Usage"
 ./void-linux-x64 --forwarding-modern-key YourSecretKeyHere


### PR DESCRIPTION
## Summary
Document modern forwarding CLI flag in Astro docs.

## Rationale
Helps users configure forwarding without editing files.

## Changes
- add `--forwarding-modern-key` to program arguments guide
- note CLI usage in modern forwarding docs

## Verification
- `dotnet test Void.slnx` *(fails: The element <Solution> is unrecognized)*

## Performance
N/A

## Risks & Rollback
Low risk; revert if issues arise.

## Breaking/Migration
None.

## Links
None

------
https://chatgpt.com/codex/tasks/task_e_68aba1045c94832ba82e261a81c65f81