### PR TITLE
test(platform): 🧪 update log assertions for proxy start/stop

### DIFF
--- a/src/Tests/Integration/Hosting/PlatformTests.cs
+++ b/src/Tests/Integration/Hosting/PlatformTests.cs
@@ -21,8 +21,8 @@ public class PlatformTests
         {
             Assert.Equal(0, exitCode);
 
-            Assert.Contains(logs.Lines, line => line.Contains("Hosting started"));
-            Assert.Contains(logs.Lines, line => line.Contains("Hosting stopped"));
+            Assert.Contains(logs.Lines, line => line.Contains("Proxy started"));
+            Assert.Contains(logs.Lines, line => line.Contains("Proxy stopped"));
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
## Summary
Align platform test expectations with proxy log messages.

## Rationale
Tests referenced outdated "Hosting" messages; updating them prevents false negatives.

## Changes
- Expect "Proxy started" and "Proxy stopped" in platform integration tests.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to restore previous expectations.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68acd37de454832bb7cc9dde740dfd46