### PR TITLE
docs(configuration): 📝 document file config auto-sync

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -91,6 +91,6 @@ Each plugin may [**define one or subset of keyed configuration files**](/docs/de
 Plugins are not required to save or load configurations manually. 
 
 All changes on the disk are automatically loaded into existing instance in the memory.
-Vice versa, all changes in the memory are automatically saved to the disk.
+Vice versa, all changes in the memory are automatically saved to the disk. This automatic saving can be disabled via [**program argument**](/docs/configuration/program-arguments/#file-configuration).
 
 Currently, only TOML format is supported.


### PR DESCRIPTION
## Summary
Clarify auto-sync between configuration files and in-memory settings.

## Rationale
Helps users understand how file configurations update the running proxy and how to disable disk writes when desired.

## Changes
- Document automatic loading/saving of configuration changes.
- Link to program argument that disables saving.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ad3f8dc388832ba936ae666f5a1103