### PR TITLE
docs(agents): 📝 enforce bold documentation links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,10 @@ Follow the existing C# style rules:
   ```
 - Never modify `CHANGELOG.md`; it is generated automatically by `release-please` from commit history.
 
+## Documentation
+
+- When adding links to documentation, make the link text bold. For example: `[**link text**](https://example.com)`.
+
 ## Protocol guidance
 
 When adding or modifying packet handling:


### PR DESCRIPTION
## Summary
Add guidance to bold documentation link text.

## Rationale
Promotes consistent emphasis for documentation hyperlinks.

## Changes
- note to bold link text with example in `AGENTS.md`

## Verification
- `dotnet build Void.slnx` *(fails: The element <Solution> is unrecognized)*
- `dotnet test` *(fails: Specify a project or solution file)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if needed.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68ad745e43fc832bb0e7882ca0ee5067