### PR TITLE
docs(essentials): ✏️ add essentials plugin page

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
                 label: 'Forwarding',
                 autogenerate: { directory: 'docs/forwardings' }
             },
+            { slug: 'docs/essentials' },
             { slug: 'docs/containers' },
             { slug: 'docs/watchdog' },
             {

--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -1,0 +1,26 @@
+---
+title: Essentials
+description: Built-in commands for server redirection, moderation, and debugging.
+sidebar:
+  order: 0
+---
+
+The Essentials plugin ships with Void and offers basic utilities for managing the proxy and connected players. You can explore the [**Essentials plugin project**](https://github.com/caunt/Void/tree/main/src/Plugins/Essentials).
+
+## Server Redirection
+
+Use `/server [server-name]` to send yourself to another backend server. If no name is given, one is chosen at random. Review your [**server configuration**](/docs/configuration/in-file/#servers) to see which names are available.
+
+## Platform Commands
+
+- `/stop` — immediately stops the proxy. When running in [**containers**](/docs/containers/), prefer orchestrator controls for clean restarts.
+- `/plugins` — lists currently loaded plugins. Learn more about [**developing plugins**](/docs/developing-plugins/development-kit/).
+- `/unload <name>` — unloads a plugin container without restarting.
+
+## Moderation
+
+`/kick <name> [reason]` removes a player from the proxy with an optional message. For broader moderation strategies, see the [**troubleshooting guide**](/docs/troubleshooting/).
+
+## Debugging
+
+Essentials logs every network message at the trace level, helping diagnose issues during development or [**testing**](/docs/getting-started/running/).


### PR DESCRIPTION
## Summary
Add documentation page for built-in Essentials plugin and expose it in sidebar.

## Rationale
Give users an overview of core management and moderation commands.

## Changes
- document Essentials plugin commands and debugging features
- link Essentials page before Containers in sidebar

## Verification
- `dotnet test` *(fails: TaskCanceledException in PlatformTests.EntryPoint_UsesPortOption)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
- https://github.com/caunt/Void/tree/main/src/Plugins/Essentials


------
https://chatgpt.com/codex/tasks/task_e_68ad8adce0f0832b92a79ace866973ee