### PR TITLE
docs(agents): 📝 forbid code in link captions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Follow the existing C# style rules:
 ## Documentation
 
 - When adding links to documentation, make the link text bold. For example: `[**link text**](https://example.com)`.
+- Never include inline code or backticks inside a link caption; keep code formatting outside the link text.
 
 ## Protocol guidance
 


### PR DESCRIPTION
## Summary
Add guidance to avoid inline code in markdown link captions.

## Rationale
Prevents formatting issues and keeps documentation style consistent.

## Changes
- Document rule to keep code outside link captions in `AGENTS.md`.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
No impact.

## Risks & Rollback
Low risk; revert commit if problems arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68af50370cc4832ba29bb0b115992359