### PR TITLE
docs(essentials): 📝 clarify plugin link

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-The Essentials plugin ships with Void and offers basic utilities for managing the proxy and connected players. You can explore the [**Essentials plugin project**](https://github.com/caunt/Void/tree/main/src/Plugins/Essentials).
+The [**Essentials plugin**](https://github.com/caunt/Void/tree/main/src/Plugins/Essentials) ships with Void and offers basic utilities for managing the proxy and connected players.
 
 ## Server Redirection
 


### PR DESCRIPTION
## Summary
Simplify Essentials intro by linking plugin name directly.

## Rationale
Reduces redundant wording and surfaces plugin source path.

## Changes
- Link **Essentials plugin** in introduction.

## Verification
- `dotnet test` *(fails: element <Solution> unrecognized)*
- `dotnet build` *(fails: element <Solution> unrecognized)*

## Performance
- No impact.

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b0872dcd20832bb8ff4883c3b47dc6