### PR TITLE
docs(essentials): 📝 clarify server registration instructions

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -9,7 +9,7 @@ The [**Essentials plugin**](https://github.com/caunt/Void/tree/main/src/Plugins/
 
 ## Server Redirection
 
-Use `/server [server-name]` to send yourself to another backend server. If no name is given, one is chosen at random. Review your [**server configuration**](/docs/configuration/in-file/#proxy) to see which names are available, or register new ones with the [**program argument**](/docs/configuration/program-arguments#servers) `--server`.
+Use `/server [server-name]` to send yourself to another backend server. If no name is given, one is chosen at random. Register servers in the [**server configuration**](/docs/configuration/in-file/#proxy) or with the [**program argument**](/docs/configuration/program-arguments#servers) `--server`.
 
 ## Platform Commands
 


### PR DESCRIPTION
## Summary
Clarifies server redirection documentation by focusing on registering servers via configuration or program arguments.

## Rationale
Simplifies instructions by removing reference to listing available names, making guidance more direct.

## Changes
- Rewrite server redirection note to explain registering servers through configuration or program argument.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if docs wording causes confusion.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68b08c18fa1c832b9f7ea994cbbe4859