### PR TITLE
docs(agents): 📝 clarify test requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Follow the existing C# style rules:
 ## Development
 
 - Commit only hunks with actual code changes. All code should use CRLF line endings and existing whitespace should be preserved; never reformat untouched lines.
-- Run `dotnet test` to ensure all tests pass.
+- Run `dotnet test` to ensure all tests pass whenever C# source files (`*.cs`) are modified. Skip this step if no C# files change.
 - Be patient with long-running tests and avoid aborting them early; some may take several minutes to complete.
 - After changing source code, run `dotnet build` from the repository root.
 - Conventional Commits are required for commit messages.


### PR DESCRIPTION
## Summary
Clarify when dotnet test must be executed.

## Rationale
Avoid unnecessary test runs when making non-C# changes.

## Changes
- document skipping tests when no C# files change

## Verification
No tests run; documentation-only update.

## Performance
N/A

## Risks & Rollback
Minimal risk; revert commit if guidance proves incorrect.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68b08c8a80e4832bb571465d5c051a75