### PR TITLE
docs(essentials): 📝 remove container restart sentence for /stop

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -13,7 +13,7 @@ Use `/server [server-name]` to send yourself to another backend server. If no na
 
 ## Platform Commands
 
-- `/stop` — immediately stops the proxy. When running in [**containers**](/docs/containers/), prefer orchestrator controls for clean restarts.
+- `/stop` — immediately stops the proxy.
 - `/plugins` — lists currently loaded plugins. Learn more about [**developing plugins**](/docs/developing-plugins/development-kit/).
 - `/unload <name>` — unloads a plugin container without restarting.
 


### PR DESCRIPTION
## Summary
Drop container restart recommendation from /stop docs.

## Rationale
Simplifies description; orchestrator advice is out-of-scope.

## Changes
- Remove sentence about using orchestrator controls from /stop command description.

## Verification
- Documentation only; no tests run.

## Performance
N/A

## Risks & Rollback
Low; revert commit to restore text.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68b08e66b39c832baf8829595bf62fdc