### PR TITLE
docs(essentials): 📝 remove troubleshooting reference

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -19,7 +19,7 @@ Use `/server [server-name]` to send yourself to another backend server. If no na
 
 ## Moderation
 
-`/kick <name> [reason]` removes a player from the proxy with an optional message. For broader moderation strategies, see the [**troubleshooting guide**](/docs/troubleshooting/).
+`/kick <name> [reason]` removes a player from the proxy with an optional message.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary
Remove troubleshooting reference from `/kick` command description.

## Rationale
Streamlines docs by eliminating redundant guidance.

## Changes
- Trim extra sentence pointing to troubleshooting guide from Essentials moderation section.

## Verification
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: connect ENETUNREACH 140.82.113.6:443)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b0d7433d2c832bb0c08d5ba3736b0a