### PR TITLE
docs(essentials): 📝 remove testing link

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -23,4 +23,4 @@ Use `/server [server-name]` to send yourself to another backend server. If no na
 
 ## Debugging
 
-Essentials logs every network message at the trace level, helping diagnose issues during development or [**testing**](/docs/getting-started/running/).
+Essentials logs every network message at the trace level, helping diagnose issues during development or testing.


### PR DESCRIPTION
## Summary
Removes an unnecessary hyperlink from the Essentials debugging documentation.

## Rationale
Keeps documentation focused by removing a misleading link from "testing."

## Changes
- Drop link from the final word in the Essentials debugging description

## Verification
- `dotnet test` *(fails: Void.Tests.Integration.Hosting.PlatformTests.EntryPoint_RunsStopsSuccessfully, EntryPoint_UsesPortOption, EntryPoint_UsesInterfaceOption)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68b0d80d9de8832bb859ef880a511107