### PR TITLE
docs(essentials): add trace logging example link

### DIFF
--- a/docs/astro/src/content/docs/docs/essentials.md
+++ b/docs/astro/src/content/docs/docs/essentials.md
@@ -23,4 +23,4 @@ Use `/server [server-name]` to send yourself to another backend server. If no na
 
 ## Debugging
 
-Essentials logs every network message at the trace level, helping diagnose issues during development or testing.
+Essentials logs every network message at the trace level, helping diagnose issues during development or testing. See the [**logging argument example**](/docs/configuration/program-arguments/#logging) for how to start the proxy with `--logging Trace`.


### PR DESCRIPTION
## Summary
Link Essentials debugging docs to logging argument example.

## Rationale
Provides a direct reference for enabling trace-level logging via program arguments.

## Changes
- link Essentials debugging section to logging argument example

## Verification
- `npm --prefix docs/astro ci`
- `npm --prefix docs/astro run build` *(fails: connect ENETUNREACH 140.82.112.6:443)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit 53cb6a60 if needed.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68b2caae5310832ba745b1042c7f0c23