### PR TITLE
docs(config): 📝 fix missing article in plugin config docs

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -87,7 +87,7 @@ $ VOID_PLUGINS="https://example.org/download/YourPlugin1.dll;/home/YourPlugin2.d
 
 ## Plugins Configurations (configs/\<Plugin\>/*.toml)
 
-Each plugin may [**define one or subset of keyed configuration files**](/docs/developing-plugins/configuration/) in its own directory. 
+Each plugin may [**define one or a subset of keyed configuration files**](/docs/developing-plugins/configuration/) in its own directory. 
 Plugins are not required to save or load configurations manually. 
 
 All changes on the disk are automatically loaded into existing instance in the memory.


### PR DESCRIPTION
## Summary
Adds a missing article in plugin configuration docs for clarity.

## Rationale
Clarifies documentation phrasing; alternatives considered were leaving as-is.

## Changes
- Add missing article in plugin configuration guide.

## Verification
- `npm test` (no test script)

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if needed.

## Breaking/Migration
None.

## Links


------
https://chatgpt.com/codex/tasks/task_e_68b39fb61530832b961e0a0ca15e5ae5