### PR TITLE
docs(configuration): 📝 correct DLL extension formatting

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -71,7 +71,7 @@ Secret = "YourSecretKeyHere"
 
 ## Plugins Installation
 
-Plugins are compiled with the *.dll extension in any .NET compatible language.
+Plugins are compiled with the `.dll` extension in any .NET compatible language.
 See the [**Plugin Development Kit**](/docs/developing-plugins/development-kit) section for more details.
 
 - Directory `plugins` is the default location to install plugins.


### PR DESCRIPTION
## Summary
Fix documentation typo by specifying the `.dll` extension without wildcard notation.

## Rationale
Clarifies plugin installation instructions to avoid confusion over required file extension.

## Changes
- Correct `.dll` extension formatting in configuration docs.

## Verification
- `codespell docs/astro/src/content/docs/docs/configuration/in-file.md -q 3`

## Performance
N/A

## Risks & Rollback
Low risk; revert the commit if any issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b54b507a2c832ba01d3e6afe13c6ef