### PR TITLE
docs(watchdog): 📝 fix environment variable link

### DIFF
--- a/docs/astro/src/content/docs/docs/watchdog.md
+++ b/docs/astro/src/content/docs/docs/watchdog.md
@@ -7,7 +7,7 @@ The Watchdog feature in Void is designed to monitor the health of the Void Proxy
 This is particularly useful for long-running processes or when running Void in a [**production environment**](/docs/containers/).
 
 ## Enable Watchdog
-Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or [**environment variable**](/docs/configuration/in-file#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
+Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or [**environment variable**](/docs/configuration/environment-variables#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
 
 ## Health Check
 `/health` endpoint is used to check the health of the Void Proxy.


### PR DESCRIPTION
## Summary
Correct the Watchdog documentation link to point to environment variable configuration.

## Rationale
Readers were directed to an unrelated configuration page, leading to confusion.

## Changes
- Fix link to Watchdog environment variable section.

## Verification
- `dotnet build`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if documentation link proves incorrect.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b54b5ad098832bb106efba26a04e84