### PR TITLE
docs(forwardings): ✏️ fix grammar in forwarding overview

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/forwarding-overview.md
+++ b/docs/astro/src/content/docs/docs/forwardings/forwarding-overview.md
@@ -12,12 +12,12 @@ Without any forwarding enabled, the server will use the player's offline UUID an
 
 ## Legacy (BungeeCord)
 One of the oldest forwarding modes, developed by [SpigotMC](https://github.com/SpigotMC/BungeeCord).  
-Learn how to configure it in the [**Legacy forwarding**](/docs/forwardings/legacy) page.
+Learn how to configure it on the [**Legacy forwarding**](/docs/forwardings/legacy) page.
 
 ## Modern (Velocity)
 Next generation of forwarding, developed by [PaperMC](https://docs.papermc.io/velocity/player-information-forwarding/).  
-Learn how to configure it in the [**Modern forwarding**](/docs/forwardings/modern) page.
+Learn how to configure it on the [**Modern forwarding**](/docs/forwardings/modern) page.
 
 ## Online (Private Key)
 The newest forwarding mode, being developed by [Void](https://github.com/caunt/Void).  
-Learn how to configure it in the [**Online forwarding**](/docs/forwardings/online) page.
+Learn how to configure it on the [**Online forwarding**](/docs/forwardings/online) page.


### PR DESCRIPTION
## Summary
Corrects preposition usage in forwarding overview documentation.

## Rationale
Improves readability by using the appropriate preposition.

## Changes
- Use "on" instead of "in" when referring to forwarding pages.

## Verification
- Viewed rendered markdown to confirm updated wording.

## Performance
N/A

## Risks & Rollback
Low risk; revert this commit if issues arise.

## Breaking/Migration
None

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68b54b5c1484832b84240b971bc15050