### PR TITLE
docs(readme): 📝 refine telegram link phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download :hammer_and_wrench: [**Plugin Development Kit**](https://github.com/cau
   <br>
   :globe_with_meridians: 
   <a href="https://t.me/mcVoidProxy">
-    <strong>News in Telegram</strong>
+    <strong>News on Telegram</strong>
     <br>
     <img width="221" height="223" alt="Telegram Channel" src="https://github.com/user-attachments/assets/837c1969-9511-4d51-98c2-2d2b3e58a481" />
   </a>
@@ -42,7 +42,7 @@ Download :hammer_and_wrench: [**Plugin Development Kit**](https://github.com/cau
   <br>
   :globe_with_meridians: 
   <a href="https://t.me/mcvoidproxyforum">
-    <strong>Discuss in Telegram</strong>
+    <strong>Discuss on Telegram</strong>
     <br>
     <img width="221" height="223" alt="image" src="https://github.com/user-attachments/assets/2fb48274-bc08-4544-80a9-aac3fb809ee1" />
   </a>


### PR DESCRIPTION
## Summary
Fixes wording in README Telegram links.

## Rationale
Improves grammar; "on Telegram" reads naturally.

## Changes
- Use "on Telegram" in README link captions.

## Verification
- `codespell README.md`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b54b5c4344832b8616bbcd40e2bff9