### PR TITLE
docs(events): clarify Result type wording in event guide

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
@@ -25,7 +25,7 @@ public record MyEvent(string SomeValue) : IEventWithResult<int>
 ```
 
 ## Cancellable Event
-You can define your events as cancellable by making Result type boolean.
+You can define your events as cancellable by making the `Result` type boolean.
 ```csharp
 public record MyEvent(string SomeValue) : IEventWithResult<bool>
 {


### PR DESCRIPTION
## Summary
Fix grammar in cancellable event docs.

## Rationale
Clarifies expected `Result` type for cancellable events.

## Changes
- clarify wording for cancellable events

## Verification
- `codespell -S package-lock.json`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b7b666d600832ba697704f6aa76889