### PR TITLE
docs(astro): 📝 clarify packet ID version ranges

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -68,8 +68,7 @@ public void OnPhaseChanged(PhaseChangedEvent @event)
 ```
 
 :::note
-ProtocolVersions are specified in 'starting from' context.
-So the 0x4F packet id for `ProtocolVersion.MINECRAFT_1_20_2` means that this packet id is used starting from that version included and up to next version in this mapping definition excluded - `ProtocolVersion.MINECRAFT_1_20_3`, so basically just one 1.20.2 version.
+Each packet ID takes effect at its listed protocol version and remains valid until the next version in the table replaces it.
 :::
 
 ## Receiving Packets


### PR DESCRIPTION
## Summary
Clarify how packet ID version ranges are interpreted.

## Rationale
Helps plugin authors understand when packet IDs apply across versions.

## Changes
- Clarified note explaining packet ID range semantics.

## Verification
- `npm --prefix docs/astro ci`
- `npm --prefix docs/astro run build` *(fails: connect ENETUNREACH 140.82.113.5:443)*

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b824c386a4832b879c687dc2c89858