### PR TITLE
docs(watchdog): ✏️ clarify bound vs health tip

### DIFF
--- a/docs/astro/src/content/docs/docs/watchdog.md
+++ b/docs/astro/src/content/docs/docs/watchdog.md
@@ -44,8 +44,7 @@ OK
 Responses are the same as for the `/health` endpoint.
 
 :::tip
-While `/bound` may look similar to `/health`, it is important to note that the Void Proxy may be healthy but not accepting connections.
-In such a case, the `/bound` endpoint will return `503 Service Unavailable`, while the `/health` endpoint will return `200 OK`.
+Use `/bound` to see if the proxy accepts connections; `/health` only checks if the proxy is running. A running but unbound proxy returns `503` on `/bound` and `200` on `/health`.
 :::
 
 ## Pause


### PR DESCRIPTION
## Summary
Clarify how `/bound` and `/health` endpoints differ.

## Rationale
Prevents confusion between connection readiness and process status checks.

## Changes
- Replace verbose tip with concise explanation of `/bound` vs `/health` behavior.

## Verification
- No tests were run; documentation wording only.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None.

## Links
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b824d2da80832ba8cdf76033e648d3