### PR TITLE
docs(plugins): 📝 clarify SNBT numeric type example

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/serializers.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/serializers.md
@@ -22,19 +22,19 @@ Helpful to convert Json or Snbt to Nbt and vice versa.
   - Converts **[Nbt](/docs/developing-plugins/nbt) to [Snbt](/docs/developing-plugins/nbt/#snbt)** or **[Snbt](/docs/developing-plugins/nbt/#snbt) to [Nbt](/docs/developing-plugins/nbt)**.
 
 :::caution[Prefer deserializing from Snbt]
-Json is not recommended because its properties' type conversion is guessed by bounds of the value.  
+JSON can't guarantee numeric types. In JSON, `{"value": 1}` leaves the number's type unspecified.
 
 ```json
 {
-	"value": 1
+    "value": 1
 }
 ```
-This 'value' number does not specify if it is a byte, short, int or long. So in deserialization time, parser checks if it fits in byte, short, int or long, and uses the first Nbt Tag Type that fits.
 
-On the other hand, Snbt specifies concrete type of the value. 
+In SNBT, `value: 1b` explicitly sets it as a byte.
+
 ```json
 {
-	value: 1b
+    value: 1b
 }
 ```
 :::


### PR DESCRIPTION
## Summary
Clarify SNBT vs. JSON numeric type example with correct 4-space indentation.

## Rationale
JSON can't guarantee numeric types; demonstrating SNBT's explicit typing helps plugin authors avoid deserialization mistakes.

## Changes
- Rewrite caution block in serializer docs to show ambiguous JSON vs explicit SNBT numeric types.
- Normalize code sample indentation to four spaces.

## Verification
- `npm test` *(fails: Missing script: "test")*

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit if documentation causes confusion.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b824b71e30832ba3d31209af81b54d