### PR TITLE
docs(agents): 📝 clarify 4-space indentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository is a .NET solution composed of the following sections:
 
 Follow the existing C# style rules:
 
+- Indentation uses four spaces, with tab width set to four.
 - Private fields prefixed with an underscore and method parameters use camelCase.
 - Braces sit on their own lines with a blank line before loops and conditional statements.
 - Method signatures remain on a single line.


### PR DESCRIPTION
## Summary
Document 4-space indentation in repository guidelines.

## Rationale
Clarifies expected indentation width for contributors.

## Changes
- Note that indentation uses four spaces in AGENTS.

## Verification
- `dotnet test`

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit to undo.

## Breaking/Migration
- None.

## Links
- None.

------
https://chatgpt.com/codex/tasks/task_e_68b872042ac8832b8e2e48f9549d2145