### PR TITLE
docs(links): 📝 clarify ILink lifetime

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
@@ -9,11 +9,9 @@ sidebar:
 They define a connection between the player and server.
 
 ## Lifetime
-Instance of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) is created whenever a player finds a server to connect to.  
-Players do not have any [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) at `PlayerConnectingEvent` event or `PlayerSearchServerEvent` event.
-
-It is disposed when the player disconnects from the server.  
-However, the player might be just redirecting to another server, so **new** [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) will be created for each server connection player makes.
+An [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) is created when a player connects to a server and destroyed when they disconnect.
+Switching to another server replaces the existing link with a new [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs).
+Players do not have an [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) during `PlayerConnectingEvent` or `PlayerSearchServerEvent`.
 
 ## Channels
 Channels are used to send or receive data from **one** side of the [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs).


### PR DESCRIPTION
## Summary
Clarify ILink lifetime in plugin docs.

## Rationale
Ensures developers know when links are created, destroyed, and replaced.

## Changes
- Rephrased lifetime paragraph to state creation on connect, destruction on disconnect, and replacement when switching servers.

## Verification
- `npm --prefix docs/astro ci`
- `npm --prefix docs/astro run build` *(fails: connect ENETUNREACH 140.82.112.5:443)*

## Performance
N/A

## Risks & Rollback
Low; revert commit.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68b824c9b914832ba03fb0a31916de24