### PR TITLE
perf(forwarding): ⚡️ cache maximum forwarding version

### DIFF
--- a/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
+++ b/src/Plugins/ForwardingSupport/Velocity/Services/ForwardingService.cs
@@ -18,6 +18,8 @@ namespace Void.Proxy.Plugins.ForwardingSupport.Velocity.Services;
 
 public class ForwardingService(IPlayerContext context, ILogger logger, IConsoleService console, Plugin plugin, Settings settings) : IEventListener
 {
+    private static readonly int MaxForwarding = Enum.GetValues<ForwardingVersion>().Cast<int>().Max();
+
     [Subscribe]
     public void OnPhaseChanged(PhaseChangedEvent @event)
     {
@@ -115,7 +117,7 @@ public class ForwardingService(IPlayerContext context, ILogger logger, IConsoleS
 
     private ForwardingVersion FindForwardingVersion(ForwardingVersion requested)
     {
-        requested = (ForwardingVersion)Math.Min((int)requested, Enum.GetValues<ForwardingVersion>().Cast<int>().Max());
+        requested = (ForwardingVersion)Math.Min((int)requested, MaxForwarding);
 
         if (requested > ForwardingVersion.Default)
         {


### PR DESCRIPTION
## Summary
Prevent recalculating forwarding protocol bounds.

## Rationale
Avoids repeated enumeration of `ForwardingVersion` values.

## Changes
- cache maximum `ForwardingVersion` value
- reuse cached maximum in version selection

## Verification
- `dotnet build`
- `dotnet test` *(fails: System.IndexOutOfRangeException in PlatformTests.EntryPoint_RunsStopsSuccessfully)*

## Performance
No measured impact; eliminates minor per-call enumeration cost.

## Risks & Rollback
Low; revert commit if issues occur.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68b880d3f7a8832b956d459d3ec7a836