### PR TITLE
docs(scoped-service): ✏️ fix typo in player position sentence

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -114,7 +114,7 @@ public class PlayerPositionService(IPlayerContext context) : IEventListener
 ```
 
 Now all players have their own instance of `PlayerPositionService` and each one contains current player position.
-You can get this service from player directly to access actual player position.
+You can get this service directly from the player to access the actual player position.
 ```csharp
 public class TrackerService(IPlayerService players)
 {


### PR DESCRIPTION
## Summary
Fix typo in scoped service documentation.

## Rationale
Improves clarity for developers.

## Changes
- Clarify player position sentence in scoped service guide.

## Verification
- `codespell -q 3 -S "*/package-lock.json"`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68bb0c039c94832ba82c5f1b043fc279