### PR TITLE
docs(guide): 📝 fix capitalization typo

### DIFF
--- a/docs/astro/src/content/docs/docs/index.mdx
+++ b/docs/astro/src/content/docs/docs/index.mdx
@@ -13,7 +13,7 @@ import { CardGrid, LinkCard, Card, Steps, Aside } from '@astrojs/starlight/compo
             <LinkCard icon="right-caret" title="Installation" href="/docs/getting-started/running/" description="Install Void locally." />
         </CardGrid>
 
-    2. Optionally, Configure Void to suit your needs.
+    2. Optionally, configure Void to suit your needs.
         <LinkCard icon="settings" title="Program Arguments" href="/docs/configuration/program-arguments/" description="Command line arguments." />
         <LinkCard icon="settings" title="Environment Variables" href="/docs/configuration/environment-variables/" description="Environment variables." />
         <LinkCard icon="settings" title="In-file Configuration" href="/docs/configuration/in-file/" description="File configuration." />


### PR DESCRIPTION
## Summary
Fixes a capitalization typo in the docs index step.

## Rationale
Ensures consistent sentence casing in the documentation and improves readability.

## Changes
- Lowercases "configure" in docs index step.

## Verification
- `npm test` *(fails: Missing script "test")*

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert the commit if issues arise.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68bbcbef2af4832b850ce9ff313e4bec