### PR TITLE
docs(links): 📝 remove duplicate word

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
@@ -25,7 +25,7 @@ A separate `INetworkChannel` is created for `IPlayer`, and another for `IServer`
 ## Custom Implementation
 Void uses internal implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) if not overridden by plugin.
 
-Plugin can override it by providing custom implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) with `CreateLinkEvent` event.
+Plugin can override it by providing a custom implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) with `CreateLinkEvent`.
 ```csharp
 [Subscribe]
 public void OnCreateLink(CreateLinkEvent @event)


### PR DESCRIPTION
## Summary
Fix minor typo in link documentation.

## Rationale
Improves clarity by removing a redundant word.

## Changes
- drop repeated word in `CreateLinkEvent` description.

## Verification
- `codespell docs/astro/src/content/docs/docs/developing-plugins/network/links.md`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68bdf3b46568832ba002cdffc7607726