### PR TITLE
docs(guide): ✏️ remove extraneous article

### DIFF
--- a/docs/astro/src/content/docs/docs/index.mdx
+++ b/docs/astro/src/content/docs/docs/index.mdx
@@ -7,7 +7,7 @@ tableOfContents: false
 import { CardGrid, LinkCard, Card, Steps, Aside } from '@astrojs/starlight/components';
 
 <Steps>
-    1. Run the Void with Docker or install it locally.
+    1. Run Void with Docker or install it locally.
         <CardGrid>
             <LinkCard icon="seti:docker" title="Docker" href="/docs/containers/#running-void-in-docker" description="Run Void using Docker containers." />
             <LinkCard icon="right-caret" title="Installation" href="/docs/getting-started/running/" description="Install Void locally." />


### PR DESCRIPTION
## Summary
Remove an unnecessary article in the quick-start guide.

## Rationale
Improves clarity in initial setup instructions; no alternatives needed.

## Changes
- Clarify Docker/local installation step wording.

## Verification
- `codespell docs/astro/src/content/docs/docs/index.mdx -L devlop,trough,lets,musl,KeyPair,keyPair`

## Performance
N/A

## Risks & Rollback
Low risk; revert if wording causes confusion.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68bf554ebcc8832b90e26136c99b4d6b