### PR TITLE
docs(minecraft): ✏️ clarify color downsampling comment

### DIFF
--- a/src/Minecraft/Components/Text/Transformers/ComponentNbtTransformers.cs
+++ b/src/Minecraft/Components/Text/Transformers/ComponentNbtTransformers.cs
@@ -346,7 +346,7 @@ public static class ComponentNbtTransformers
     {
         if (tag is NbtCompound rootCompound)
         {
-            // Downsample colors to list of compatible
+            // Downsample colors to a list of compatible colors
             if (rootCompound["color"] is NbtString colorTag)
             {
                 var color = TextColor.FromString(colorTag.Value);


### PR DESCRIPTION
## Summary
Clarify color downsampling comment in NBT transformers.

## Rationale
Improves readability of downgrade logic.

## Changes
- Expand NBT transformer comment to mention compatible colors.

## Verification
- `dotnet build`
- `dotnet test` *(fails: EntryPoint_UsesInterfaceOption)*

## Performance
- Not applicable.

## Risks & Rollback
Low risk; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68c0a1945290832b8453bfc532d4063d