### PR TITLE
docs(watchdog): ✏️ clarify environment variable instruction

### DIFF
--- a/docs/astro/src/content/docs/docs/watchdog.md
+++ b/docs/astro/src/content/docs/docs/watchdog.md
@@ -7,7 +7,7 @@ The Watchdog feature in Void is designed to monitor the health of the Void Proxy
 This is particularly useful for long-running processes or when running Void in a [**production environment**](/docs/containers/).
 
 ## Enable Watchdog
-Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or [**environment variable**](/docs/configuration/environment-variables#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
+Watchdog is disabled by default. To enable it, you need to set the `Enabled` setting in the [**configuration file**](/docs/configuration/in-file#watchdog) to `true`, or set the [**environment variable**](/docs/configuration/environment-variables#watchdog) `VOID_WATCHDOG_ENABLE` to `true`.
 
 ## Health Check
 `/health` endpoint is used to check the health of the Void Proxy.


### PR DESCRIPTION
## Summary
Add missing verb to Watchdog documentation for environment variable configuration.

## Rationale
Explicitly instructs how to enable the feature via environment variable, reducing confusion.

## Changes
- Clarify Watchdog enabling instruction regarding environment variable.

## Verification
- `codespell -q 3 -L devlop,trough`

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit if needed.

## Breaking/Migration
- None.

## Links
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68c35c72bf90832bbd0f94380363db18