### PR TITLE
docs(devkit): 📝 reference pdk.slnx solution

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -19,7 +19,7 @@ Some of them include:
 ## Installation
 1) [**Download**](https://github.com/caunt/Void/releases/latest/download/plugin-devkit.zip) the latest **Plugin Development Kit**.
 2) Extract the downloaded zip file to your desired location.
-3) Open the ***.slnx** file with your IDE.
+3) Open the **pdk.slnx** file with your IDE.
 
 ## Running
 Press **F5** to run the project. This will start the Void Proxy with your plugin loaded.


### PR DESCRIPTION
## Summary
Clarify which solution file to open when using the Plugin Development Kit.

## Rationale
Ensures developers load the correct project without confusion; no alternate approaches were needed.

## Changes
- Replace placeholder `*.slnx` mention with the explicit `pdk.slnx` file in the development kit guide.

## Verification
- `dotnet build`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit to undo documentation change.

## Breaking/Migration
None.

## Links
N/A


------
https://chatgpt.com/codex/tasks/task_e_68c698919f48832b824f802338b96b2e