### PR TITLE
docs(configuration): ✏️ fix local path capitalization

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -75,8 +75,8 @@ Plugins are compiled with the `.dll` extension in any .NET compatible language.
 See the [**Plugin Development Kit**](/docs/developing-plugins/development-kit) section for more details.
 
 - Directory `plugins` is the default location to install plugins.
-- [**Environment variable**](/docs/configuration/environment-variables/#plugins) `VOID_PLUGINS` might be used to add URLs or Local Paths to run plugins, separated by comma or semicolon.
-- [**Program argument**](/docs/configuration/program-arguments#plugins) `--plugin` (alias `-p`) might be used to add URL or Local Path to a plugin.
+- [**Environment variable**](/docs/configuration/environment-variables/#plugins) `VOID_PLUGINS` might be used to add URLs or local paths to run plugins, separated by comma or semicolon.
+- [**Program argument**](/docs/configuration/program-arguments#plugins) `--plugin` (alias `-p`) might be used to add URL or local path to a plugin.
 
 ```bash title="Program Argument Example"
 $ ./void-linux-x64 --plugin "/home/YourPlugin1.dll" --plugin "https://example.org/download/YourPlugin2.dll"


### PR DESCRIPTION
## Summary
Corrects capitalization of "local path" references in plugin installation docs.

## Rationale
Ensures consistent sentence case and improves readability; leaving it mis-capitalized might confuse readers.

## Changes
- Normalize "local path" wording in configuration documentation.

## Verification
- `codespell -S "package-lock.json"`

## Performance
N/A

## Risks & Rollback
Low; revert commit if issues arise.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68c749ebfcf0832b8e0c28a98460c957