### PR TITLE
docs(services): ✏️ fix possessive apostrophes

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 Services are used to build a Dependency Injection (DI) container.
-Your services will be shared across all plugins, and you can inject other plugins services into your plugin, if needed.
+Your services will be shared across all plugins, and you can inject other plugins' services into your plugin, if needed.
 
 To learn more about DI, see [**Microsoft DI Documentation**](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection).
 
@@ -40,7 +40,7 @@ dependencies.Register(services =>
 ```
 
 ## Injection
-You can inject your plugin or any other plugins services that are registered in the DI container into your classes.
+You can inject your plugin's or any other plugins' services that are registered in the DI container into your classes.
 ```csharp
 public class ExampleSingletonService(ExampleTransientService transientService)
 {


### PR DESCRIPTION
## Summary
Correct possessive apostrophe typos in service documentation.

## Rationale
Improves clarity in plugin service guidance.

## Changes
- Fix possessive apostrophes in creating-a-service doc.

## Verification
- `codespell -S package-lock.json --ignore-words-list devlop,trough`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68c75405b344832ba280d572990242b6