### PR TITLE
docs(running): ✏️ fix Termux instruction

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/docs/getting-started/running.md
@@ -26,7 +26,7 @@ Prefer containers? See the [**Containers**](/docs/containers/) guide for Docker 
 
 ## Android
 
-Run the [**Termux**](https://play.google.com/store/apps/details?id=com.termux) or any other terminal emulator.
+Run [**Termux**](https://play.google.com/store/apps/details?id=com.termux) or any other terminal emulator.
 
 Follow the instructions for Linux, but use the "bionic" version of the binary.
 


### PR DESCRIPTION
## Summary
Fixes a minor typo in the Android instructions.

## Rationale
Clarifies the Termux setup for better readability.

## Changes
- adjust wording for Termux in Android section

## Verification
- `codespell -q 3 src docs -S "package-lock.json"`

## Performance
N/A

## Risks & Rollback
Low risk; revert commit if necessary.

## Breaking/Migration
None.

## Links
N/A

------
https://chatgpt.com/codex/tasks/task_e_68c7540719f0832bb4591f1349fb48e2