### PR TITLE
docs(developing-plugins): ✏️ fix plugin distribution typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -45,4 +45,4 @@ This includes NuGet packages, local DLLs, and runtime lookups.
 NuGet dependencies will be automatically downloaded and cached in the **packages** directory.
 
 ## Distribution
-Share your ***.dll** file, without any other files from the **bin** directory.
+Share your **.dll** file, without any other files from the **bin** directory.


### PR DESCRIPTION
## Summary
Correct a formatting typo so the plugin distribution instructions render properly.

## Rationale
This improves the clarity of the development kit documentation without impacting runtime behavior.

## Changes
- Fix the Markdown emphasis for the `.dll` extension in the Development Kit distribution section.

## Verification
- No automated tests were run (documentation-only change).

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk; rollback by reverting this commit if needed.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68cb12fb43c0832ba6a89c510268b95d