### PR TITLE
docs(configuration): 📝 fix configuration typo

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -85,7 +85,7 @@ $ ./void-linux-x64 --plugin "/home/YourPlugin1.dll" --plugin "https://example.or
 $ VOID_PLUGINS="https://example.org/download/YourPlugin1.dll;/home/YourPlugin2.dll" ./void-linux-x64
 ```
 
-## Plugins Configurations (configs/\<Plugin\>/*.toml)
+## Plugin Configurations (configs/\<Plugin\>/*.toml)
 
 Each plugin may [**define one or a subset of keyed configuration files**](/docs/developing-plugins/configuration/) in its own directory. 
 Plugins are not required to save or load configurations manually. 

--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -43,7 +43,7 @@ Options:
   ./void-linux-x64 --offline
   ```
 
-## File-configuration
+## File Configuration
 - `--read-only`  
   Disables automatically saving changes to the [**configuration files**](/docs/configuration/in-file).
 


### PR DESCRIPTION
## Summary
Fix typos in configuration documentation headings.

## Rationale
Improve clarity in user-facing documentation by correcting typographical errors.

## Changes
- Rename the "File-configuration" section heading to "File Configuration".
- Rename the "Plugins Configurations" section heading to "Plugin Configurations".

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if unintended issues arise.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68cdbf9a4044832b968626cf9c7e12cc