### PR TITLE
docs(developing-plugins): ✏️ fix scoped service typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -87,7 +87,7 @@ public class MyScopedService(IPlayerContext context) : IEventListener
 
 While events being filtered, scoped services are still instantiated for each player. 
 So all players and their respective scoped services will be notified about the event.
-This helps in player-specific resources isolation.
+This helps with player-specific resource isolation.
 
 ## Filtered Events usage example
 ```csharp


### PR DESCRIPTION
## Summary
Fix a grammatical typo in the scoped services guide.

## Rationale
Improves clarity in the documentation for scoped service behavior.

## Changes
- Replace an incorrect phrase describing resource isolation with the correct wording.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any issues arise.

## Breaking/Migration
- None.

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68cf9a183874832bbd14633047ecdd80