### PR TITLE
docs(configuration): 📝 clarify primary configuration wording

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-File configurations are the main way of configuration.
+File configurations are the primary way to configure Void.
 However, many options can be overridden at runtime using the API in plugins.
 
 ## Proxy


### PR DESCRIPTION
## Summary
Clarified the in-file configuration documentation to fix a wording typo.

## Rationale
Improves documentation readability by correcting awkward phrasing in the configuration guide.

## Changes
- Reworded the introductory sentence in the in-file configuration guide for clarity.

## Verification
- No tests were run (not applicable).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk documentation-only change; rollback by reverting the commit if needed.

## Breaking/Migration
- None.

## Links
- None.

------
https://chatgpt.com/codex/tasks/task_e_68d162712488832b8a807050a8fd9bf6