### PR TITLE
docs(forwardings): ✏️ clarify legacy configuration note

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/docs/forwardings/legacy.md
@@ -29,4 +29,4 @@ If you are using official Forge server, you can install [**BungeeForge**](https:
 :::
 
 ## Configuration
-Currently BungeeCord forwarding does not require configuration.
+Currently, BungeeCord forwarding does not require configuration.


### PR DESCRIPTION
## Summary
Fix a lingering typo in the legacy forwarding documentation.

## Rationale
Improves clarity by correcting an incorrect sentence termination in the docs.

## Changes
- Add the missing comma to the configuration sentence.
- Ensure the page ends with a proper newline.

## Verification
- Not applicable (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68d164b35138832ba04198654bbf6120