### PR TITLE
docs(developing-plugins): 📝 clarify cancellation token guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -32,8 +32,8 @@ Most player interactions happen asynchronously. Mark your event handlers `async`
 [Subscribe]
 public async ValueTask OnPlayerConnected(PlayerConnectedEvent @event, CancellationToken cancellationToken)
 {
-    // It is highly recommended to pass cancellation token in all async methods you call.
-    // This helps proxy to correctly manage player network lifetime.
+    // It is highly recommended to pass the cancellation token to all async methods you call.
+    // This helps the proxy correctly manage the player network lifetime.
     await @event.Player.KickAsync("You are not allowed to join this server.", cancellationToken);
 }
 ```


### PR DESCRIPTION
## Summary
Clarified cancellation token guidance in the async event handling example.

## Rationale
The previous phrasing omitted articles, which could be misread when passing the provided cancellation token to helper methods.

## Changes
- Updated the async event handler comment to explicitly mention forwarding the cancellation token and why it matters.

## Verification
No automated tests were run because the change only affects documentation.

## Performance
Not applicable.

## Risks & Rollback
Low risk. Revert this commit if the previous wording is preferred.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68d49720d588832ba6b4d9fd90df153c