### PR TITLE
docs(configuration): ✏️ fix plugin installation heading

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/in-file.md
+++ b/docs/astro/src/content/docs/docs/configuration/in-file.md
@@ -69,7 +69,7 @@ Enabled = true
 Secret = "YourSecretKeyHere"
 ```
 
-## Plugins Installation
+## Plugin Installation
 
 Plugins are compiled with the `.dll` extension in any .NET compatible language.
 See the [**Plugin Development Kit**](/docs/developing-plugins/development-kit) section for more details.


### PR DESCRIPTION
## Summary
Corrected a documentation heading that was using the wrong plural form.

## Rationale
Keeps the configuration guide polished by removing a lingering typo in section titles.

## Changes
- Rename the "Plugins Installation" heading to "Plugin Installation" in the in-file configuration guide.

## Verification
- Not run; documentation-only change.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk. Revert the commit if the previous heading text is preferred.

## Breaking/Migration
- None.

## Links
- None.

------
https://chatgpt.com/codex/tasks/task_e_68d498f5cae8832bbc86d7bef9b9da08