### PR TITLE
docs(legacy): ✏️ fix Forge capitalization

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/docs/forwardings/legacy.md
@@ -13,7 +13,7 @@ BungeeCord, also known as Legacy forwarding, is a type of forwarding player data
 
 :::tip
 It is the easiest way to pass player information from the proxy to the server in the handshake packet, supported by many server implementations.
-Legacy forwarding may include additional data, such as forge FML markers.
+Legacy forwarding may include additional data, such as Forge FML markers.
 :::
 
 :::note[Mods]


### PR DESCRIPTION
## Summary
Capitalized "Forge" in the legacy forwarding documentation.

## Rationale
Maintains proper noun capitalization so the documentation reads professionally.

## Changes
- Updated the legacy forwarding page to capitalize the Forge acronym.

## Verification
- Not applicable; documentation-only change.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if any unintended issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68d63e6784f0832bae9c0d996106c2be