### PR TITLE
docs(developing-plugins): ✏️ fix activation typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
@@ -29,7 +29,7 @@ dependencies.Register(services =>
 });
 ```
 Your services will be automatically activated (instantiated) and subscribed to [**events**](/docs/developing-plugins/events/listening-to-events), if not delayed explicitly.
-You can delay your services activation, by providing `activate: false` parameter to the registration method:
+You can delay your services' activation by providing the `activate: false` parameter to the registration method:
 ```csharp
 dependencies.Register(services =>
 {


### PR DESCRIPTION
## Summary
Corrected a possessive typo in the developing-plugins service activation guidance.

## Rationale
Improves the readability of the documentation without altering behavior.

## Changes
- Fixes the possessive wording for the "activate: false" guidance in the service registration section.

## Verification
- No automated tests were run (documentation-only change).

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk; revert this commit to roll back.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68d796d06a84832bafacb14db7eb728a