### PR TITLE
docs(developing-plugins): clarify SendPacketAsync overload wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -129,7 +129,7 @@ You can send packets to the link with `ILink.SendPacketAsync` method.
 await player.GetLink().SendPacketAsync(new SetHeldItemClientboundPacket { Slot = slot }, cancellationToken);
 ```
 
-When you want to explicitly send a packet to the server or client, `SendPacketAsync` has overload that specifies the Side of destination.
+When you want to explicitly send a packet to the server or client, `SendPacketAsync` has an overload that specifies the destination side.
 ```csharp
 await player.GetLink().SendPacketAsync(Side.Client, new SetHeldItemClientboundPacket { Slot = slot }, cancellationToken);
 ```


### PR DESCRIPTION
## Summary
Clarified the SendPacketAsync overload description in the packet documentation to fix a typo.

## Rationale
Improves readability for developers following the packet sending instructions; no alternatives considered beyond leaving the typo.

## Changes
- Reworded the SendPacketAsync overload sentence in the developing-plugins packet guide.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable for documentation updates.

## Risks & Rollback
- Low risk; revert this commit to roll back if needed.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68da7d74bd04832bbc5922b0c196c377