### PR TITLE
docs(astro): ✏️ fix forwarding limitation typo

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/modern.md
+++ b/docs/astro/src/content/docs/docs/forwardings/modern.md
@@ -19,7 +19,7 @@ Velocity forwarding is not supported by [**mod loaders**](/docs/getting-started/
 :::caution[Limitations]
 - Servers have to run in offline mode.
 - You have to install a plugin, mod, or server with built-in implementation.
-- Proxy must authenticate the Mojang player on proxy side.
+- Proxy must authenticate the Mojang player on the proxy side.
 :::
 
 ## Configuration


### PR DESCRIPTION
## Summary
Corrected a grammar issue in the Velocity forwarding limitations list.

## Rationale
Improves clarity of the documentation for readers configuring Modern forwarding.

## Changes
- Added the missing article in the Modern (Velocity) forwarding limitations description.

## Verification
- Not applicable; documentation-only update.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68dc357c7400832b8082f13f7868e054