### PR TITLE
docs(plugins): 📝 fix scoped service typos

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -74,13 +74,13 @@ public class MyScopedService(IPlayerContext context) : IEventListener
     [Subscribe]
     public void OnPlayerConnected(PlayerConnectedEvent @event)
     {
-        // This event will be only triggered for IPlayerContext.Player instance
+        // This event will only be triggered for the IPlayerContext.Player instance
     }
 
     [Subscribe]
     public void OnMessageReceived(MessageReceivedEvent @event)
     {
-        // This event also will be only triggered for IPlayerContext.Player instance
+        // This event will also only be triggered for the IPlayerContext.Player instance
     }
 }
 ```
@@ -136,7 +136,7 @@ public class TrackerService(IPlayerService players)
 
 Most of the events that have Player property are already implemented as `IScopedEvent`.
 While you can listen to them in Scoped services, they are still available for [**Singleton services**](/docs/developing-plugins/services/singleton).
-In Singleton context, you will receive events **not filtered**. Meaning you will receive events for all players in single service.
+In Singleton context, you will receive events **not filtered**. Meaning you will receive events for all players in a single service.
 
 If you would like to not filter events in scoped service, pass `bypassScopedFilter: true` to the `Subscribe` attribute.
 ```csharp


### PR DESCRIPTION
## Summary
Correct minor wording issues in the scoped service documentation.

## Rationale
Improves clarity for plugin authors by fixing lingering typos in the guide.

## Changes
- Clarified phrasing in scoped service event comments.
- Fixed grammar in the singleton context description.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any unintended documentation issues are noticed.

## Breaking/Migration
- Not applicable.

## Links
- Not applicable.


------
https://chatgpt.com/codex/tasks/task_e_68dcf3c5bd80832bba8d171f49b4ccbf