### PR TITLE
ci(workflows): 🤖 target macos-15-intel runner

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -45,7 +45,7 @@ jobs:
           - os: macos-latest
             runtime: osx-arm64
             run-tests: true
-          - os: macos-13 # macos-latest
+          - os: macos-15-intel # macos-latest
             runtime: osx-x64
             run-tests: true
           - os: windows-11-arm # windows-latest


### PR DESCRIPTION
## Summary
Update the CI workflow to target the macos-15-intel runner for the Intel macOS build.

## Rationale
The macos-13 runner is being deprecated, so the workflow should use the supported macos-15-intel image.

## Changes
- Replace the macos-13 GitHub Actions runner with macos-15-intel for the Intel macOS build matrix entry.

## Verification
CI workflow definition change only; no runtime verification performed.

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert the workflow change if the new runner causes issues.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68deefaa8780832ba46a6e84a7dd0033