### PR TITLE
docs(guides): 📝 fix plugin installation anchor

### DIFF
--- a/docs/astro/src/content/docs/docs/index.mdx
+++ b/docs/astro/src/content/docs/docs/index.mdx
@@ -20,7 +20,7 @@ import { CardGrid, LinkCard, Card, Steps, Aside } from '@astrojs/starlight/compo
 
     3. Install Plugins
         <CardGrid>
-            <LinkCard icon="pencil" title="Plugin Management" href="/docs/configuration/in-file/#plugins-installation" description="How to install and manage plugins." />
+            <LinkCard icon="pencil" title="Plugin Management" href="/docs/configuration/in-file/#plugin-installation" description="How to install and manage plugins." />
             <LinkCard icon="pencil" title="Plugin Development Kit" href="/docs/developing-plugins/development-kit/" description="Develop your plugin for Void." />
         </CardGrid>
 </Steps>


### PR DESCRIPTION
## Summary
Fix plugin management card link so it points at the correct section anchor.

## Rationale
The previous anchor slug included an extra "s", breaking the link target and causing link validation to fail.

## Changes
- Update the Plugin Management card to reference the `plugin-installation` anchor.

## Verification
- No automated tests were run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert commit if an unexpected docs issue appears.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68deefead9b0832bb33093d175c5b6b0