### PR TITLE
docs(developing-plugins): ✏️ fix typo in ILink override guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
@@ -23,9 +23,9 @@ A separate `INetworkChannel` is created for `IPlayer`, and another for `IServer`
 [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) saves references to both sides: `ILink.Player` and `ILink.Server`.
 
 ## Custom Implementation
-Void uses internal implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) if not overridden by plugin.
+Void uses an internal implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) if not overridden by a plugin.
 
-Plugin can override it by providing a custom implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) with `CreateLinkEvent`.
+Plugins can override it by providing a custom implementation of [**`ILink`**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) with `CreateLinkEvent`.
 ```csharp
 [Subscribe]
 public void OnCreateLink(CreateLinkEvent @event)


### PR DESCRIPTION
## Summary
Corrects the grammar for the ILink customization guidance in the plugin development docs.

## Rationale
Improves clarity so plugin authors understand that any plugin can override the default implementation.

## Changes
- Updated wording in the ILink custom implementation section to use the proper article and plural form.

## Verification
- Not applicable (documentation change only).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if any documentation concern arises.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68def068cb5c832b88ff5de2875085e5