### PR TITLE
docs(forwarding): 📝 fix grammar in legacy forwarding guide

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/legacy.md
+++ b/docs/astro/src/content/docs/docs/forwardings/legacy.md
@@ -17,9 +17,9 @@ Legacy forwarding may include additional data, such as Forge FML markers.
 :::
 
 :::note[Mods]
-BungeeCord forwarding is not supported by mod loaders, however community has created modded server implementations with BungeeCord forwarding, such as [Mohist](https://github.com/MohistMC/Mohist).  
+BungeeCord forwarding is not supported by mod loaders; however, the community has created modded server implementations with BungeeCord forwarding, such as [Mohist](https://github.com/MohistMC/Mohist).
 
-If you are using official Forge server, you can install [**BungeeForge**](https://github.com/caunt/BungeeForge) mod, which adds BungeeCord forwarding support to Forge server.
+If you are using an official Forge server, you can install the [**BungeeForge**](https://github.com/caunt/BungeeForge) mod, which adds BungeeCord forwarding support to the Forge server.
 :::
 
 :::caution[Limitations]


### PR DESCRIPTION
## Summary
Fix grammar issues in the legacy forwarding documentation to remove typos.

## Rationale
Improves the accuracy and clarity of user-facing documentation.

## Changes
- Adjusted wording in the legacy forwarding guide to add missing articles and proper punctuation.

## Verification
- Not run; documentation-only change.

## Performance
- Not applicable for documentation updates.

## Risks & Rollback
- Low risk; revert this commit if any issues arise.

## Breaking/Migration
- No breaking changes or migration steps required.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68e2afc4bdfc832b9a2e460b6d20c6f7