### PR TITLE
docs(developing-plugins): 📝 fix typo in service registration guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
@@ -78,4 +78,4 @@ Services in the DI container can have different lifetimes, which determine how l
 See the detailed description of each lifetime in the [**Microsoft Documentation**](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#service-lifetimes).
 
 ## Example
-See the [**ExamplePlugin.cs**](https://github.com/caunt/Void/blob/main/src/Plugins/ExamplePlugin/ExamplePlugin.cs) for services registrations and [**Services**](https://github.com/caunt/Void/tree/main/src/Plugins/ExamplePlugin/Services) directory for services usage and implementations.
+See the [**ExamplePlugin.cs**](https://github.com/caunt/Void/blob/main/src/Plugins/ExamplePlugin/ExamplePlugin.cs) for service registrations and [**Services**](https://github.com/caunt/Void/tree/main/src/Plugins/ExamplePlugin/Services) directory for services usage and implementations.


### PR DESCRIPTION
## Summary
Corrects a typo in the service registration documentation page.

## Rationale
Improves clarity in the plugin development documentation by fixing a wording mistake.

## Changes
- Replace the phrase "services registrations" with "service registrations" in the service creation guide.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable; documentation change only.

## Risks & Rollback
- Very low risk. Revert the commit if issues are discovered.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68e41cb2f120832b8ed5ea2dd31d1a10