### PR TITLE
docs(running): 📝 fix typos in running guide

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/running.md
+++ b/docs/astro/src/content/docs/docs/getting-started/running.md
@@ -10,7 +10,7 @@ Download [**latest version here**](/download).
 
 ## Linux
 
-Set the executable permission
+Set the executable permissions
 ```bash
 chmod +x void-linux-x64
 ```
@@ -40,4 +40,4 @@ Follow the instructions for Linux, but use the "osx" version of the binary.
 
 ## Windows
 
-Run the executable, simple as that.
+Run the executable—simple as that.


### PR DESCRIPTION
## Summary
Corrects minor typos in the running guide to improve clarity.

## Rationale
Improves reader comprehension and fulfills the request to resolve typos.

## Changes
- Pluralized the executable permission instruction.
- Reworded the Windows note for smoother phrasing.

## Verification
Docs-only change; no automated tests were run.

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert this commit if any issues arise.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68e5dabb87e8832ba217ed5f6a539feb