### PR TITLE
docs(developing-plugins): 📝 fix configuration snippet

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/configuration.md
@@ -27,14 +27,14 @@ Then use `GetAsync<T>()` method to get the configuration instance.
 public class MyPlugin(IConfigurationService configs) : IPlugin
 {
     [Subscribe]
-    public void OnPluginLoading(PluginLoadingEvent @event)
+    public async ValueTask OnPluginLoading(PluginLoadingEvent @event, CancellationToken cancellationToken)
     {
         // This event is fired when any plugin is being loaded
 
         // Skip all other plugin load events except ours
         if (@event.Plugin != this)
             return;
-        
+
         var settings = await configs.GetAsync<MySettings>(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
Corrected the developing-plugins configuration guide so the async loading example uses the proper signature.

## Rationale
The sample code previously omitted the async signature and cancellation token, which would not compile as written.

## Changes
- Updated the configuration loading example to declare an async ValueTask handler that accepts a cancellation token.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; documentation text change only. Revert this commit to roll back.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68ec9d7be0f8832bb9764152055df079