### PR TITLE
style(plugins): ✏️ clarify phase description comment

### DIFF
--- a/src/Plugins/ExamplePlugin/Services/InventoryService.cs
+++ b/src/Plugins/ExamplePlugin/Services/InventoryService.cs
@@ -34,7 +34,7 @@ public class InventoryService(IPlayerContext context, ILogger<InventoryService> 
     [Subscribe]
     public void OnPhaseChanged(PhaseChangedEvent @event)
     {
-        // Minecraft Phase indicate state of the game. Common Phases are Handshake, Login, Configuration and Play.
+        // Minecraft phases indicate the state of the game. Common phases are Handshake, Login, Configuration and Play.
         // They are NOT synced between server and player instantly. When player is in Play phase, server might be still in Login phase.
         // This means you should decide which side Phase change you want to handle here. In this case, both sides are handled.
 


### PR DESCRIPTION
## Summary
Fixed a typo in the ExamplePlugin inventory service comment about Minecraft phases.

## Rationale
Improves in-repo guidance for plugin authors by correcting the pluralization typo in the explanatory comment.

## Changes
- Reworded the ExamplePlugin inventory service comment to describe Minecraft phases in the plural form.

## Verification
- dotnet test

## Performance
No runtime-affecting changes; documentation comment only.

## Risks & Rollback
Low risk: comment-only change. Roll back by reverting the commit if necessary.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68ef3714ce48832b879f779a6d5ee12e