### PR TITLE
docs(events): 📝 fix event listening typos

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -5,8 +5,8 @@ sidebar:
   order: 1
 ---
 
-Events are a great way to communicate between different plugins and proxy. 
-They allow you to respond to specific actions or changes in the game, such as a [**player joining or leaving**](/docs/developing-plugins/events/player-events).
+Events are a great way to communicate between different plugins and the proxy.
+They allow you to respond to specific actions or changes in the game, such as [**a player joining or leaving**](/docs/developing-plugins/events/player-events).
 
 ## Subscribing to events
 You can subscribe to events by applying the `Subscribe` attribute to a method in your class that inherits `IEventListener` interface.


### PR DESCRIPTION
## Summary
Clarify the event-listening introduction so it reads cleanly.

## Rationale
Polish the documentation by removing distracting wording mistakes.

## Changes
- Add the missing article when referencing the proxy.
- Move the article for the linked player example inside the emphasis for smoother reading.

## Verification
- No tests were required for documentation-only changes.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the documentation change if needed.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68ef416d61d4832b827c3706d080a77e