### PR TITLE
docs(development-kit): ✏️ clarify Rider debugging wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/development-kit.md
@@ -27,7 +27,7 @@ Press **F5** to run the project. This will start the Void Proxy with your plugin
 ## Debugging
 :::caution
 Debugging is currently not supported by JetBrains Rider.
-Proxy is distributed with PublishSingleFile=true flag, which makes Rider unable to attach debugger to the process.
+Proxy is distributed with the `PublishSingleFile=true` flag, which makes Rider unable to attach the debugger to the process.
 See [Rider Debugging](https://www.jetbrains.com/help/rider/Debugging_Code.html) for more details.
 :::
 


### PR DESCRIPTION
## Summary
Fixed wording around the PublishSingleFile flag in the Rider debugging instructions.

## Rationale
Clarifies the documentation and prevents confusion for plugin authors following the debugging guide.

## Changes
- Added the missing article and code formatting to the PublishSingleFile flag reference in the development kit guide.

## Verification
- Documentation-only change; no automated tests were run.

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk. If issues arise, revert the documentation change.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68f11ebfe210832bbe47f6fa4fe41f17