### PR TITLE
docs(packets): 📝 fix typo in cancellation guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -139,7 +139,7 @@ Check out [**complete example**](https://github.com/caunt/Void/blob/main/src/Plu
 
 
 ## Cancelling Packets
-You can cancel packets in `MessageReceivedEvent` event.  
+You can cancel packets in the `MessageReceivedEvent`.
 Set `IEvent.Result` value to `true` to prevent sending packet to receiver.
 ```csharp
 [Subscribe]


### PR DESCRIPTION
## Summary
Fixed a grammatical typo in the packet cancellation documentation.

## Rationale
Clarifies the documentation phrasing so readers understand the event reference without ambiguity.

## Changes
- Update the `MessageReceivedEvent` sentence to include the missing article.

## Verification
- No automated tests were required for documentation-only changes.

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk. Revert the commit if any issues are found.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68f3b5f7e48c832badcf8bbc677bdfc1