### PR TITLE
docs(player-events): 📝 clarify event descriptions

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/player-events.md
@@ -3,7 +3,7 @@ title: Player Events
 description: Learn types of Player Events.
 ---
 
-The very first event that is triggered when a player connects to the server.
+`PlayerConnectingEvent` is the very first event that is triggered when a player connects to the server.
 It is used to create a new player instance and set up the player context with [**scoped services**](/docs/developing-plugins/services/scoped).
 Do not change the `Result` property of this event until you are very sure what you are doing.
 You can use this event to modify the player instance implementation.
@@ -11,24 +11,24 @@ You can use this event to modify the player instance implementation.
 class PlayerConnectingEvent(TcpClient Client, Func<IPlayer, IServiceProvider> GetServices) : IEventWithResult<IPlayer>;
 ```
 
-Tells when a player is connected to the proxy.
+`PlayerConnectedEvent` tells when a player is connected to the proxy.
 ```csharp
 class PlayerConnectedEvent(IPlayer Player) : IScopedEvent;
 ```
 
-Tells when a player is disconnected from the proxy.
+`PlayerDisconnectedEvent` tells when a player is disconnected from the proxy.
 ```csharp
 class PlayerDisconnectedEvent(IPlayer Player) : IScopedEvent;
 ```
 
-Triggers protocol plugins to send the `Disconnect` packet to the client.
+`PlayerKickEvent` triggers protocol plugins to send the `Disconnect` packet to the client.
 Property `Result` tells whether the packet was sent successfully.
 Do not change the `Result` property of this event until you are very sure what you are doing.
 ```csharp
 class PlayerKickEvent(IPlayer Player, string? Text = null) : IScopedEventWithResult<bool>;
 ```
 
-Helps to determine the server that the player should connect to.  
+`PlayerSearchServerEvent` helps determine the server that the player should connect to.
 You can rely on this event to redirect the player to a different server.  
 Just close the `ILink.ServerChannel` network channel, and the player instance will start searching for a new server.
 ```csharp


### PR DESCRIPTION
## Summary
Clarify the player event descriptions by explicitly naming each event.

## Rationale
Improves readability by removing ambiguous sentences in the player events guide.

## Changes
- Reworded each player event description to start with the corresponding event name for clarity.

## Verification
- Not run (docs-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit to restore previous wording.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68f3b6edc2ac832b8b15fab0d2e39ed7