### PR TITLE
docs(developing-plugins): ✏️ clarify event listener wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -9,7 +9,7 @@ Events are a great way to communicate between different plugins and the proxy.
 They allow you to respond to specific actions or changes in the game, such as [**a player joining or leaving**](/docs/developing-plugins/events/player-events).
 
 ## Subscribing to events
-You can subscribe to events by applying the `Subscribe` attribute to a method in your class that inherits `IEventListener` interface.
+You can subscribe to events by applying the `Subscribe` attribute to a method in your class that implements the `IEventListener` interface.
 ```csharp
 public class MyPlugin : IPlugin
 {
@@ -23,7 +23,7 @@ public class MyPlugin : IPlugin
 
 :::tip
 The `IPlugin` interface inherits `IEventListener` itself, so you can subscribe to events directly in your plugin class.
-However, in most cases, you must apply `IEventListener` interface to your classes.
+However, in most cases, you must implement the `IEventListener` interface on your classes.
 :::
 
 ## Async Events
@@ -51,7 +51,7 @@ public class MySingletonService : IEventListener
 ```
 
 ## Listening to events in Scoped services
-Just like with other services, you should apply `IEventListener` interface to your scoped service class.
+Just like with other services, you should implement the `IEventListener` interface on your scoped service class.
 However, listening to events in [**scoped services**](/docs/developing-plugins/services/scoped) is a bit different.
 Scoped events are filtered by the player context, so you will only receive events that are relevant to the player that owns the service.
 All other types of events will not be filtered, since they are not scoped.


### PR DESCRIPTION
## Summary
Clarify how plugins reference the event listener interface.

## Rationale
Fixing the misuse of inheritance terminology makes the documentation more accurate for C# developers.

## Changes
- Explain that plugin classes implement the `IEventListener` interface when subscribing to events.
- Update scoped service guidance to use the correct "implement" wording.

## Verification
Not run (documentation change only).

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert this change if the new wording is confusing.

## Breaking/Migration
None.

## Links
None.


------
https://chatgpt.com/codex/tasks/task_e_68f50fa18d80832b9510cdad1f9c7465