### PR TITLE
docs(developing-plugins): ✏️ correct dependency service name

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/creating-a-service.md
@@ -12,14 +12,14 @@ To learn more about DI, see [**Microsoft DI Documentation**](https://docs.micros
 
 ## Registration
 
-Inject `DependencyService` into your main plugin constructor:
+Inject `IDependencyService` into your main plugin constructor:
 ```csharp
 public class MyPlugin(IDependencyService dependencies) : IPlugin
 {
 
 }
 ```
-Register your services with injected `DependencyService`:
+Register your services with injected `IDependencyService`:
 ```csharp
 dependencies.Register(services =>
 {


### PR DESCRIPTION
## Summary
Fix a typo in the plugin service creation guide.

## Rationale
Keeps the documentation consistent with the actual interface name developers consume.

## Changes
- Correct the dependency injection interface name in the service creation documentation.

## Verification
Not run (documentation-only change).

## Performance
Not applicable.

## Risks & Rollback
Low risk. Revert the commit if the wording should be adjusted differently.

## Breaking/Migration
None.

## Links
None.

------
https://chatgpt.com/codex/tasks/task_e_68f683a5c5b8832b9f3f359509afd84f