### PR TITLE
docs(developing-plugins): 📝 fix event wording typos

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -72,7 +72,7 @@ Each packet ID takes effect at its listed protocol version and remains valid unt
 :::
 
 ## Receiving Packets
-Now that we have defined our packet, we can receive it with `MessageReceivedEvent` [**event**](/docs/developing-plugins/events/listening-to-events/).
+Now that we have defined our packet, we can receive it with the `MessageReceivedEvent` [**event**](/docs/developing-plugins/events/listening-to-events/).
 ```csharp
 [Subscribe]
 public void OnMessageReceived(MessageReceivedEvent @event)
@@ -86,7 +86,7 @@ public void OnMessageReceived(MessageReceivedEvent @event)
 }
 ```
 
-There is also a `MessageSentEvent` event that is triggered when the packet is already sent to the receiver.
+There is also a `MessageSentEvent` that is triggered when the packet is already sent to the receiver.
 ```csharp
 [Subscribe]
 public void OnMessageSent(MessageSentEvent @event)


### PR DESCRIPTION
## Summary
Correct redundant wording in the packet events documentation.

## Rationale
Improve clarity by removing repeated words from event descriptions.

## Changes
- Clarified the MessageReceivedEvent description in the packets guide.
- Simplified the MessageSentEvent description in the same guide.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if any issues arise.

## Breaking/Migration
- None.

## Links
- N/A.


------
https://chatgpt.com/codex/tasks/task_e_68f9c8390fb4832b9b913125ed6bb4de