### PR TITLE
docs(services): ✏️ fix typo in scoped services docs

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -85,7 +85,7 @@ public class MyScopedService(IPlayerContext context) : IEventListener
 }
 ```
 
-While events being filtered, scoped services are still instantiated for each player. 
+While events are being filtered, scoped services are still instantiated for each player.
 So all players and their respective scoped services will be notified about the event.
 This helps with player-specific resource isolation.
 


### PR DESCRIPTION
## Summary
Corrected a grammar typo in the scoped services documentation.

## Rationale
Improves clarity and readability for developers consulting the scoped services guide.

## Changes
- Replace an incorrect phrase in the scoped services documentation so it reads "events are being filtered."

## Verification
- Not applicable (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if the wording is undesired.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68fd0a0784f8832bb7b7789ffa7eadd7