### PR TITLE
docs(network): ✏️ clarify packet cancellation guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -140,7 +140,7 @@ Check out [**complete example**](https://github.com/caunt/Void/blob/main/src/Plu
 
 ## Cancelling Packets
 You can cancel packets in the `MessageReceivedEvent`.
-Set `IEvent.Result` value to `true` to prevent sending packet to receiver.
+Set the `IEvent.Result` value to `true` to prevent sending the packet to the receiver.
 ```csharp
 [Subscribe]
 public void OnMessageReceived(MessageReceivedEvent @event)


### PR DESCRIPTION
## Summary
Clarify the packet cancellation sentence in the packets documentation.

## Rationale
Improves readability by correcting a grammatical typo.

## Changes
- Update the packet cancellation guidance sentence to include the missing articles.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; documentation wording can be reverted if necessary.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_68fe0613665c832b9a7271d5197e7172