### PR TITLE
docs(developing-plugins): ✏️ fix typo in packet comment

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/packets.md
@@ -81,7 +81,7 @@ public void OnMessageReceived(MessageReceivedEvent @event)
     if (@event.Message is not SetHeldItemClientboundPacket packet)
         return;
         
-    // Print the slot value sent by server
+    // Print the slot value sent by the server
     Console.WriteLine($"Received {nameof(SetHeldItemClientboundPacket)} with Slot: {packet.Slot}");
 }
 ```


### PR DESCRIPTION
## Summary
Fixes a typo in the packet-handling documentation example.

## Rationale
Improves clarity when reading the packet logging example.

## Changes
- Adds the missing article in the SetHeldItem clientbound packet example comment.

## Verification
Documentation-only change; no automated tests were run.

## Performance
Not applicable.

## Risks & Rollback
Low risk; revert this commit if any issues surface.

## Breaking/Migration
None.

## Links
N/A.


------
https://chatgpt.com/codex/tasks/task_e_68feba0e7598832b8287eab76d6ee3be