### PR TITLE
docs(docs): 📝 fix forwarding heading typo

### DIFF
--- a/docs/astro/src/content/docs/docs/getting-started/features.mdx
+++ b/docs/astro/src/content/docs/docs/getting-started/features.mdx
@@ -28,7 +28,7 @@ import { Badge } from '@astrojs/starlight/components';
 | Pocket Edition       | &#x274C; | &#x274C;  | &#x274C; | &#x274C; |
 | Pocket Edition Alpha | &#x274C; | &#x274C;  | &#x274C; | &#x274C; |
 
-## Forwardings
+## Forwarding
 | Forwarding                                                  | Supported | WIP      |
 | :---------------------------------------------------------- | :------:  | :------: |
 | [**None (Offline)**](/docs/forwardings/forwarding-overview) | &#x2705;  | &#x2705; |


### PR DESCRIPTION
## Summary
Correct a typo in the forwarding section heading within the getting started guide.

## Rationale
Keeps the documentation polished and grammatically accurate for readers.

## Changes
- Rename the "Forwardings" heading to "Forwarding" in the getting started features page.

## Verification
- No tests were run (documentation-only change).

## Performance
- Not applicable; documentation change only.

## Risks & Rollback
- Low risk. Revert this commit to roll back if needed.

## Breaking/Migration
- None.

## Links
- N/A.

------
https://chatgpt.com/codex/tasks/task_e_6900ec86afa0832b8cf150c0e92ba23e