### PR TITLE
docs(forwardings): ✏️ clarify authentication comment

### DIFF
--- a/docs/astro/src/content/docs/docs/forwardings/online.md
+++ b/docs/astro/src/content/docs/docs/forwardings/online.md
@@ -92,8 +92,8 @@ public void OnAuthenticationStarting(AuthenticationStartingEvent @event)
     if (@event.Link.Server.Name is not "lobby")
         return;
 
-    // Ensure Void targets authentication to server side,
-    // So it allows player to authenticate with server.
+    // Ensure Void targets authentication to the server side,
+    // allowing the player to authenticate with the server.
     @event.Result = AuthenticationSide.Server;
 }
 


### PR DESCRIPTION
## Summary
Correct a grammatical typo in the Online forwarding example comment.

## Rationale
Improves readability by clarifying the purpose of the authentication comment.

## Changes
- Reword the Online forwarding example comment to include the missing articles and clearer phrasing.

## Verification
- Not run (docs change)

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
https://chatgpt.com/codex/tasks/task_e_690162aabf24832b9d789a47df8b2057