### PR TITLE
docs(developing-plugins): ✏️ fix wording typos

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/commands.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/commands.md
@@ -7,7 +7,7 @@ Commands help users and administrators interact with the proxy and plugins.
 
 ## Defining a command
 Inject `ICommandService` service to begin working with commands.  
-Commands are registered with `Register` method in [Mojang Brigadier](https://github.com/Mojang/brigadier/)-like style.
+Commands are registered with the `Register` method in [Mojang Brigadier](https://github.com/Mojang/brigadier/)-like style.
 
 ```csharp
 class MyService(ICommandService commands)

--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -113,7 +113,7 @@ public class PlayerPositionService(IPlayerContext context) : IEventListener
 }
 ```
 
-Now all players have their own instance of `PlayerPositionService` and each one contains current player position.
+Now all players have their own instance of `PlayerPositionService`, and each one contains the current player position.
 You can get this service directly from the player to access the actual player position.
 ```csharp
 public class TrackerService(IPlayerService players)


### PR DESCRIPTION
## Summary
Corrected minor wording issues in the developing plugins documentation to fix typos.

## Rationale
Improves clarity and professionalism of the public documentation.

## Changes
- Add the missing article when describing command registration.
- Clarify wording in the scoped service description to include the definite article and comma.

## Verification
Documentation-only change; no automated verification required.

## Performance
Not applicable; documentation update only.

## Risks & Rollback
Low risk. Revert this commit to roll back.

## Breaking/Migration
None.

## Links
N/A.


------
https://chatgpt.com/codex/tasks/task_e_69038a7ec578832bb5c5c28422ef9f0e