### PR TITLE
docs(developing-plugins): ✏️ fix caution typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/modifying-data.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/modifying-data.md
@@ -36,5 +36,5 @@ public async ValueTask OnMessageReceived(MessageReceivedEvent @event, Cancellati
 ```
 
 :::caution
-Changes to the packet properties are ignored by internal [**ILink**](/docs/developing-plugins/network/links) implementation, always ensure to call `Cancel()` and `SendPacketAsync()` to apply your changes.
+Changes to the packet properties are ignored by the internal [**ILink**](/docs/developing-plugins/network/links) implementation. Always ensure you call `Cancel()` and `SendPacketAsync()` to apply your changes.
 :::


### PR DESCRIPTION
## Summary
Corrected the caution note in the modifying data plugin guide to fix a typo.

## Rationale
Improves clarity for developers by fixing a grammatical typo in the documentation.

## Changes
- Adjusted the caution text in `modifying-data.md` to clarify the need to call `Cancel()` and `SendPacketAsync()`.

## Verification
- No tests were run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690b0d15d450832b87a53d512dfb5181)