### PR TITLE
docs(developing-plugins): 📝 clarify scoped service wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -11,7 +11,7 @@ Scoped services are useful for managing player-specific state or resources that 
 
 ## Example Definition
 `IPlayerContext` may be injected into your scoped service to access the player context.
-You can get player instance, other player-scoped services, or network channel from it.
+You can get the player instance, other player-scoped services, or the network channel from it.
 
 ```csharp
 public class MyScopedService(IPlayerContext context)


### PR DESCRIPTION
## Summary
Improve the scoped service documentation wording to clarify the sentence structure.

## Rationale
A small grammar fix improves readability while users follow the scoped service guidance.

## Changes
- Add missing articles to the scoped service documentation sentence for clearer grammar.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if any issues arise.

## Breaking/Migration
- None.

## Links
- None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6b49ca88832bbd9ebb1c1792abbd)