### PR TITLE
docs(configuration): ✏️ fix server argument typo

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/program-arguments.md
+++ b/docs/astro/src/content/docs/docs/configuration/program-arguments.md
@@ -65,7 +65,7 @@ Options:
 
 ## Servers
 - `--server`
-  Registers a server in format `<host>:<port>` where the port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
+  Registers a server in the format `<host>:<port>` where the port is between `1` and `65535`. IPv6 addresses must be enclosed in square brackets.
 - `--ignore-file-servers`
   Ignore servers specified in [**configuration files**](/docs/configuration/in-file).
 


### PR DESCRIPTION
## Summary
Clarified the server argument description in the program arguments documentation.

## Rationale
Removes a wording typo so the instructions read naturally.

## Changes
- Add the missing article in the `--server` option description within the program arguments guide.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if any unintended wording issues arise.

## Breaking/Migration
- None.

## Links
- N/A.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69101b906cec832b81ec10bfeb496bab)