### PR TITLE
docs(scoped-services): ✏️ clarify player context wording

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -67,7 +67,7 @@ public class MySingletonService(IPlayerService players)
 
 ## Events
 Scoped services subscribed to events that implement `IScopedEvent` interface will be automatically filtered to the current player context.
-For example, if you listen to `PlayerConnectedEvent`, the event will be automatically filtered to the current player only context.
+For example, if you listen to `PlayerConnectedEvent`, the event will be automatically filtered to the current player's context only.
 ```csharp
 public class MyScopedService(IPlayerContext context) : IEventListener
 {


### PR DESCRIPTION
## Summary
Fix a typo in the scoped services documentation to improve readability.

## Rationale
The previous phrasing in the scoped services guide had an incorrect possessive form that could confuse readers.

## Changes
- Corrected the player context sentence in the scoped services documentation.

## Verification
- No tests were run; documentation change only.

## Performance
- Not applicable; documentation change only.

## Risks & Rollback
- Low risk. Revert the commit if the wording needs further adjustment.

## Breaking/Migration
- None.

## Links
- None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a45bab68832bbe0582c466860c72)