### PR TITLE
docs(environment-variables): ✏️ clarify terminal usage guidance

### DIFF
--- a/docs/astro/src/content/docs/docs/configuration/environment-variables.md
+++ b/docs/astro/src/content/docs/docs/configuration/environment-variables.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 Environment variables make configuration in [**container environments**](/docs/containers/) easier.
-However, they might be used from the terminal directly as well.
+However, you can also use them directly from the terminal.
 
 ## Plugins
 - `VOID_PLUGINS`
@@ -33,6 +33,6 @@ However, they might be used from the terminal directly as well.
   Defines the Mojang session server to use.  
   Example: `https://sessionserver.mojang.com/session/minecraft/hasJoined`
 
-- `VOID_MOJANG_PREVENT_PROXY_CONNECTIONS`  
-  Tells Mojang to disallow player proxy connections.  
+- `VOID_MOJANG_PREVENT_PROXY_CONNECTIONS`
+  Tells Mojang to disallow player proxy connections.
   Example: `true`


### PR DESCRIPTION
## Summary
Clarify how environment variables can be used and fix the formatting of the last example.

## Rationale
Improves the readability of the environment variable documentation while correcting a formatting typo.

## Changes
- Reword the introductory sentence to mention direct terminal usage.
- Restore the missing newline so the final example renders correctly.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the commit if there are concerns.

## Breaking/Migration
- None.

## Links
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129ed4e75c832b9b07188cd0d937c1)