### PR TITLE
docs(developing-plugins): 📝 fix link lifetime grammar

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/network/links.md
@@ -9,7 +9,7 @@ sidebar:
 They define a connection between the player and server.
 
 ## Lifetime
-An [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) is created when a player connects to a server and destroyed when they disconnect.
+An [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) is created when a player connects to a server and is destroyed when they disconnect.
 Switching to another server replaces the existing link with a new [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs).
 Players do not have an [**ILink**](https://github.com/caunt/Void/blob/main/src/Api/Links/ILink.cs) during `PlayerConnectingEvent` or `PlayerSearchServerEvent`.
 


### PR DESCRIPTION
## Summary
Correct documentation wording for the ILink lifetime description.

## Rationale
Improves clarity by fixing a grammatical typo so the lifecycle sentence reads naturally.

## Changes
- Insert the missing verb in the ILink lifetime description within the developing plugins documentation.

## Verification
- Not applicable; documentation-only change.

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert the doc change if issues arise.

## Breaking/Migration
- None.

## Links
- N/A.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173b617364832b87a5b12e0be53f42)