### PR TITLE
docs(developing-plugins): ✏️ fix scoped services typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/services/scoped.md
@@ -138,7 +138,7 @@ Most of the events that have Player property are already implemented as `IScoped
 While you can listen to them in Scoped services, they are still available for [**Singleton services**](/docs/developing-plugins/services/singleton).
 In Singleton context, you will receive events **not filtered**. Meaning you will receive events for all players in a single service.
 
-If you would like to not filter events in scoped service, pass `bypassScopedFilter: true` to the `Subscribe` attribute.
+If you would like to not filter events in a scoped service, pass `bypassScopedFilter: true` to the `Subscribe` attribute.
 ```csharp
 public class MyScopedService(IPlayerContext context) : IEventListener
 {


### PR DESCRIPTION
## Summary
Fixes a grammatical typo in the scoped services documentation.

## Rationale
Improves readability so the instructions flow naturally.

## Changes
- Add the missing article to the scoped services guide sentence.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit if any issues arise.

## Breaking/Migration
- None.

## Links
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173cf9c5a4832b8dcfdccaf7a1e4e6)