### PR TITLE
docs(docfx): 📝 fix custom events toc label

### DIFF
--- a/docs/docfx/src/toc.yml
+++ b/docs/docfx/src/toc.yml
@@ -23,7 +23,7 @@
       href: developing-plugins/events/player-events.md
     - name: Plugin Events
       href: developing-plugins/events/plugin-events.md
-    - name: custom-events.md
+    - name: Custom Events
       href: developing-plugins/events/custom-events.md
   - name: Commands
     href: developing-plugins/commands/commands.md


### PR DESCRIPTION
## Summary
Fix the typo in the DocFX table of contents so the Custom Events page shows a proper label.

## Rationale
Using the raw filename in navigation looked like a typo and could confuse readers.

## Changes
- Rename the DocFX TOC entry from the filename `custom-events.md` to the friendly label "Custom Events".

## Verification
- Not run; documentation-only change.

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk. Revert the commit to restore the previous label if needed.

## Breaking/Migration
- None.

## Links
- N/A


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e2937808832b8a8dd2546d00f669)