### PR TITLE
docs(events): ✏️ fix wording typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/creating-your-events.md
@@ -15,7 +15,7 @@ public record MyEvent(string Value1, int Value2, byte[] Value3) : IEvent;
 ```
 
 ## Event with Result
-Event with result is a special type of event that allows you to return a result from the event handlers.
+An event with a result is a special type of event that allows you to return a result from the event handlers.
 If multiple handlers set the result, you will get the last one.
 ```csharp
 public record MyEvent(string SomeValue) : IEventWithResult<int>


### PR DESCRIPTION
## Summary
Clarify the description of result-bearing events by fixing a wording typo.

## Rationale
Improves documentation readability for plugin developers.

## Changes
- Adjusted the explanation of events that return a result in the events guide to use correct grammar.

## Verification
- Not run (documentation-only change).

## Performance
- Not applicable.

## Risks & Rollback
- Low risk; revert this commit to roll back.

## Breaking/Migration
- None.

## Links
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a0ccf624c832b840f95011b92672f)