### PR TITLE
docs(events): 📝 fix scoped filtering typo

### DIFF
--- a/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
+++ b/docs/astro/src/content/docs/docs/developing-plugins/events/listening-to-events.md
@@ -55,7 +55,7 @@ Just like with other services, you should implement the `IEventListener` interfa
 However, listening to events in [**scoped services**](/docs/developing-plugins/services/scoped) is a bit different.
 Scoped events are filtered by the player context, so you will only receive events that are relevant to the player that owns the service.
 All other types of events will not be filtered, since they are not scoped.
-Scoped events filter can be disabled by applying `bypassScopedFilter: true` to the `Subscribe` attribute.
+Scoped event filtering can be disabled by applying `bypassScopedFilter: true` to the `Subscribe` attribute.
 ```csharp
 public class MyScopedService(IPlayerContext context, ILogger logger) : IEventListener
 {


### PR DESCRIPTION
## Summary
Fixed a wording typo in the scoped events documentation to clarify how to disable scoped filtering.

## Rationale
Improves documentation readability so plugin authors understand the bypass flag correctly.

## Changes
- Corrected the scoped event filtering sentence in the listening-to-events guide.

## Verification
- Manual review of the updated documentation.

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk. Revert the commit if any issues are found.

## Breaking/Migration
- None.

## Links
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f790f1af0832b93ddfda22b65f5b1)