### PR TITLE
chore(minecraft): 🔤 fix color downsample comment

### DIFF
--- a/src/Minecraft/Components/Text/Transformers/ComponentJsonTransformers.cs
+++ b/src/Minecraft/Components/Text/Transformers/ComponentJsonTransformers.cs
@@ -164,7 +164,7 @@ public static class ComponentJsonTransformers
     {
         if (node is JsonObject rootObject)
         {
-            // Downsample colors to list of compatible
+            // Downsample colors to a list of compatible colors
             if (rootObject["color"] is { } colorTag)
             {
                 var color = TextColor.FromString(colorTag.GetValue<string>());


### PR DESCRIPTION
## Summary
Clarified a text color downgrade comment to better describe the downsampling behavior.

## Rationale
Improved comment readability helps future maintainers understand the intent of the color downgrade logic.

## Changes
- Reworded the v1.16-to-v1.15.2 text color downgrade comment for clarity.

## Verification
- `dotnet build`
- `dotnet test` *(fails: Void.Tests.Integration.Hosting.PlatformTests.EntryPoint_UsesPortOption throws NullReferenceException in ConsoleService.Parse; integration tests for proxied redirection show cleanup failure)*

## Performance
- Not applicable; comment-only change.

## Risks & Rollback
- Low risk; revert this commit to undo.

## Breaking/Migration
- None.

## Links
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c13627dc832ba56ed58188ac008c)