### PR TITLE
fix(plugins): 📝 correct NuGet resolver comment

### DIFF
--- a/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
+++ b/src/Platform/Plugins/Dependencies/Nuget/NuGetDependencyResolver.cs
@@ -93,7 +93,7 @@ public partial class NuGetDependencyResolver(ILogger<NuGetDependencyResolver> lo
             {
                 logger.LogTrace("Dependency {DependencyName} not found in the offline NuGet cache", assemblyName.Name);
 
-                // some packages easily resolved with just removed suffixes
+                // some packages are easily resolved with just removed suffixes
                 if (!assemblyName.Name.Contains('.'))
                     return null;
 


### PR DESCRIPTION
## Summary
Corrected a typo in the offline NuGet resolution comment.

## Rationale
Keeps inline documentation clear and professional for maintainers.

## Changes
Clarified the offline NuGet cache comment to fix a grammatical typo.

## Verification
- dotnet test

## Performance
No impact; documentation-only change.

## Risks & Rollback
Low risk; revert the commit if any issues arise.

## Breaking/Migration
None.

## Links
N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692386b2ba94832bb9d7eca14bb2b4a0)