### PR TITLE
fix(example-plugin): add missing article in comment

### DIFF
--- a/src/Plugins/ExamplePlugin/ExamplePlugin.cs
+++ b/src/Plugins/ExamplePlugin/ExamplePlugin.cs
@@ -9,7 +9,7 @@ using Void.Proxy.Plugins.ExamplePlugin.Services;
 
 namespace Void.Proxy.Plugins.ExamplePlugin;
 
-// Implementing IPlugin makes class an entry point to your plugin.
+// Implementing IPlugin makes the class an entry point to your plugin.
 // Constructor arguments are used to inject any API services implemented by proxy and other plugins.
 // See ../Services/ directory for more examples.
 public class ExamplePlugin(ILogger logger, IDependencyService dependencies) : IPlugin


### PR DESCRIPTION
## Summary
Fix a typo in the example plugin comment so the description reads correctly.

## Rationale
Improves readability for developers using the example plugin as a reference.

## Changes
Corrected the example plugin entry-point comment to include the missing article.

## Verification
- dotnet build
- dotnet test --no-build

## Performance
No performance-impacting changes.

## Risks & Rollback
Low risk; revert the commit if any unexpected issues arise.

## Breaking/Migration
None.

## Links
None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692526e5db5c832ba3d8438d970e0b9c)