### PR TITLE
style(configurations): 📝 fix comment typo

### DIFF
--- a/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
+++ b/src/Platform/Configurations/Serializers/ConfigurationTomlSerializer.cs
@@ -17,7 +17,7 @@ public class ConfigurationTomlSerializer : IConfigurationSerializer
     private readonly TomlParser _parser = new();
     private readonly TomlSerializerOptions _options = new()
     {
-        // Allows record types constructors
+        // Allows record type constructors
         OverrideConstructorValues = true,
         IgnoreInvalidEnumValues = false,
         IgnoreNonPublicMembers = true


### PR DESCRIPTION
## Summary
Fixed a typo in the ConfigurationTomlSerializer options comment to better describe record constructor handling.

## Rationale
Improves clarity for maintainers reviewing serializer settings.

## Changes
- Corrected wording of the comment explaining record constructor allowance in ConfigurationTomlSerializer.

## Verification
- `dotnet test`

## Performance
No performance-impacting changes.

## Risks & Rollback
Low risk; revert this commit if any issues arise.

## Breaking/Migration
None.

## Links
N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69266e3dfe90832bb65540e107a92b91)