### PR TITLE
fix(common): 📝 correct channel registry comment

### DIFF
--- a/src/Plugins/Common/Extensions/ChannelExtensions.cs
+++ b/src/Plugins/Common/Extensions/ChannelExtensions.cs
@@ -13,7 +13,7 @@ public static class ChannelExtensions
 {
     public static async ValueTask<T> ReceivePacketAsync<T>(this INetworkChannel channel, Side origin, CancellationToken cancellationToken) where T : IMinecraftMessage
     {
-        // just for safety, ensure we do have such IMinecraftPacket implementation in channel registry
+        // Just for safety, ensure we have an IMinecraftPacket implementation in the channel registry
         if (!typeof(T).IsInterface)
         {
             var stream = channel.Get<IMinecraftPacketMessageStream>();


### PR DESCRIPTION
## Summary
Corrected a typo in the channel registry safety comment.

## Rationale
Keeps inline documentation clear for maintainers.

## Changes
- Tweaked the ChannelExtensions safety comment to fix a typo and clarify wording.

## Verification
- dotnet build
- dotnet test

## Performance
Not applicable; comment-only change.

## Risks & Rollback
Low risk; revert this commit to roll back.

## Breaking/Migration
None.

## Links
None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927af4aba84832b8a30c1b8c5b38426)