### PR TITLE
chore(tests): 🧹 fix typo in comment

### DIFF
--- a/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
+++ b/src/Tests/Integration/Sides/Clients/MineflayerClient.cs
@@ -61,7 +61,7 @@ public class MineflayerClient : IntegrationSideBase
               'flying'
             ]);
 
-            // physics has a bug that sends position packet in configuration phase, when such phase requested by server from previous play phase
+            // physics has a bug that sends position packet in configuration phase, when such phase is requested by server from previous play phase
             const originalWrite = bot._client.write.bind(bot._client);
             bot._client.write = (packetName, packetPayload) => {
               if (suppressedPackets.has(packetName))


### PR DESCRIPTION
## Summary
Correct a typo in an integration test comment to clarify intent.

## Rationale
Improves readability of the test script comment without altering behavior.

## Changes
Fixes wording in the Mineflayer integration client JavaScript snippet comment.

## Verification
Not run (comment-only change).

## Performance
Not applicable; no runtime impact.

## Risks & Rollback
Low risk; revert this commit to roll back.

## Breaking/Migration
None required.

## Links
None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a6c5dbe24832bb0cb397159db4682)