### PR TITLE
chore(exampleplugin): ✏️ fix comment typo

### DIFF
--- a/src/Plugins/ExamplePlugin/Services/ChatService.cs
+++ b/src/Plugins/ExamplePlugin/Services/ChatService.cs
@@ -32,7 +32,7 @@ public class ChatService(ExamplePlugin plugin, ILogger<ChatService> logger, ICon
     [Subscribe]
     public async ValueTask OnProxyStarting(ProxyStartingEvent @event, CancellationToken cancellationToken)
     {
-        // Once configuration loaded, any changes made to them will be automatically saved to disk. 
+        // Once configuration is loaded, any changes made to them will be automatically saved to disk.
         // Vice versa, any changes made to the configuration file on disk will be automatically loaded into that instance.
         // You do not need to worry about saving or loading the configuration manually, it is done implicitly.
         _settings = await configs.GetAsync<ChatSettings>(cancellationToken);


### PR DESCRIPTION
## Summary
Corrected a typo in the example plugin's chat configuration comment.

## Rationale
Improves readability of inline guidance for loading plugin configuration.

## Changes
- Adjusted ChatService comment to clarify configuration loading wording.

## Verification
- dotnet build
- dotnet test --no-build --logger "console;verbosity=minimal"

## Performance
- Not applicable; documentation-only change.

## Risks & Rollback
- Low risk; revert commit if issues arise.

## Breaking/Migration
- None.

## Links
- None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bc6f371f4832ba200df4359ad3e4c)