### PR TITLE
fix(platform): 📝 clarify file watcher comment

### DIFF
--- a/src/Platform/Configurations/ConfigurationService.cs
+++ b/src/Platform/Configurations/ConfigurationService.cs
@@ -134,7 +134,7 @@ public class ConfigurationService(ILogger<ConfigurationService> logger, IPluginS
                             if (fileSystemEventArgs.ChangeType is not WatcherChangeTypes.Changed)
                                 continue;
 
-                            // If changed directory, not a file, skip
+                            // If the changed path is a directory, not a file, skip
                             if (!File.Exists(fileSystemEventArgs.FullPath))
                                 continue;
 


### PR DESCRIPTION
## Summary
Clarified the configuration watcher comment so it clearly states that directory changes are skipped.

## Rationale
Improves readability by fixing a typo in developer-facing documentation within the code.

## Changes
- Updated the file system watcher comment in `ConfigurationService` to describe directory-change handling accurately.

## Verification
- dotnet build
- dotnet test

## Performance
- No runtime impact; comment-only change.

## Risks & Rollback
- Low risk. Revert commit if any issues arise.

## Breaking/Migration
- None.

## Links
- N/A


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cd5be3460832b99672a0683d439a4)