### PR TITLE
docs(api): 📝 fix link stop reason comments

### DIFF
--- a/src/Api/Links/LinkStopReason.cs
+++ b/src/Api/Links/LinkStopReason.cs
@@ -8,7 +8,7 @@ public enum LinkStopReason
     PlayerDisconnected,
 
     /// <summary>
-    /// Specifies that the player was kicked from the server or server closed connection abnormally.
+    /// Specifies that the player was kicked from the server or the server closed the connection abnormally.
     /// </summary>
     ServerDisconnected,
 
@@ -18,7 +18,7 @@ public enum LinkStopReason
     InternalException,
 
     /// <summary>
-    /// Manually requested to stop the <see cref="ILink"/> implementation, e.g. by calling <see cref="ILink.StopAsync"/> method.
+    /// Manually requested to stop the <see cref="ILink"/> implementation, e.g., by calling the <see cref="ILink.StopAsync"/> method.
     /// </summary>
     Requested
 }


### PR DESCRIPTION
## Summary
Fixed typos in `LinkStopReason` XML documentation comments.

## Rationale
Keeps the public API comments polished for developers consuming proxy enums.

## Changes
- Clarified the server disconnection XML summary.
- Added missing articles and punctuation to the manual stop XML summary.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
Not applicable; documentation-only adjustments.

## Risks & Rollback
Low risk. Revert the commit if any comment wording is undesirable.

## Breaking/Migration
None.

## Links
None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e38b0b01c832b91b85d49b5ab7c0f)