### PR TITLE
chore(terminal): 🧹 fix prompt redraw comment typo

### DIFF
--- a/src/Terminal/PromptReader.cs
+++ b/src/Terminal/PromptReader.cs
@@ -56,7 +56,7 @@ public class PromptReader : IDisposable
         {
             do
             {
-                // TODO: Currently the prompt is not redrawn when enter is рудв
+                // TODO: Currently the prompt is not redrawn when enter is pressed
                 // If uncommented, it will be redrawn but multithreaded writes will be drawn over each other
                 // _writer.UpdateBuffer();
 


### PR DESCRIPTION
## Summary
Fixed the prompt reader TODO comment to clarify when the prompt redraw issue occurs.

## Rationale
Improve code readability by correcting a typo in developer notes.

## Changes
- Corrected the TODO comment describing prompt redraw behavior when Enter is pressed.

## Verification
- dotnet build
- dotnet test

## Performance
No performance impact; comment-only change.

## Risks & Rollback
Low risk; revert this commit if unexpected issues appear.

## Breaking/Migration
None.

## Links
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fbad9a974832b95ae2e91ebe7bb42)