### PR TITLE
style(entrypoint): ✏️ clarify working directory comment

### DIFF
--- a/src/Platform/EntryPoint.cs
+++ b/src/Platform/EntryPoint.cs
@@ -66,7 +66,7 @@ public static class EntryPoint
 
     public static async Task<int> RunAsync(RunOptions options, CancellationToken cancellationToken = default)
     {
-        // If you set custom working directory, you are responsible for everyone to follow it.
+        // If you set a custom working directory, you are responsible for ensuring everything follows it.
         // We are using the default working directory for only normal runs.
         // This was done to allow Tests to not conflict when running in parallel.
 


### PR DESCRIPTION
## Summary
Clarify the working directory responsibility comment in the proxy entry point.

## Rationale
Improves readability by fixing a typo in a developer-facing comment.

## Changes
- Updated the RunAsync comment in `EntryPoint` to use correct wording about custom working directories.

## Verification
- `dotnet build`
- `dotnet test`

## Performance
No performance impact.

## Risks & Rollback
Low risk; revert the comment change if needed.

## Breaking/Migration
None.

## Links
-

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c4326ba4832ba8076838be6883f4)