### PR TITLE
chore(api): 📝 correct console command comment

### DIFF
--- a/src/Api/Console/IConsoleService.cs
+++ b/src/Api/Console/IConsoleService.cs
@@ -7,7 +7,7 @@ namespace Void.Proxy.Api.Console;
 public interface IConsoleService : ICommandSource
 {
     /// <summary>
-    /// Asynchronously processes single incoming command in the terminal until cancellation is requested. Do not call this method directly.
+    /// Asynchronously processes a single incoming command in the terminal until cancellation is requested. Do not call this method directly.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests. The operation will stop processing current command if the token is
     /// canceled.</param>


### PR DESCRIPTION
## Summary
Fixes a grammar typo in the console service documentation comment.

## Rationale
Improves clarity in XML docs without altering runtime behavior.

## Changes
- Corrected the XML documentation comment wording for `IConsoleService.HandleCommandsAsync`.

## Verification
- `dotnet test`

## Performance
No performance-impacting changes.

## Risks & Rollback
Low risk; revert this commit to roll back.

## Breaking/Migration
None.

## Links
None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331c027440832bb9cb21aa847320c0)