### PR TITLE
fix(api): 🐛 fix base class property search in ObjectExtensions

### DIFF
--- a/src/Api/Extensions/Reflection/ObjectExtensions.cs
+++ b/src/Api/Extensions/Reflection/ObjectExtensions.cs
@@ -43,7 +43,7 @@ public static class ObjectExtensions
 
             while (baseType != null)
             {
-                propertyInfo = type.GetProperty(propertyName, DefaultFlags | BindingFlags.GetProperty);
+                propertyInfo = baseType.GetProperty(propertyName, DefaultFlags | BindingFlags.GetProperty);
 
                 if (propertyInfo != null)
                 {
@@ -109,7 +109,7 @@ public static class ObjectExtensions
 
             while (baseType != null)
             {
-                propertyInfo = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.GetProperty);
+                propertyInfo = baseType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.GetProperty);
 
                 if (propertyInfo != null)
                 {


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `ObjectExtensions.cs` where `GetPropertyValue` and `SetPropertyValue` methods repeatedly searched the same derived class in their base-class fallback loops instead of progressing up the type hierarchy. This prevented properties defined in base classes from being found via reflection.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/Api/Extensions/Reflection/ObjectExtensions.cs` | UPDATE | Fixed `GetPropertyValue` base-class loop: `type.GetProperty` → `baseType.GetProperty` (line 46) |
| `src/Api/Extensions/Reflection/ObjectExtensions.cs` | UPDATE | Fixed `SetPropertyValue` base-class loop: `type.GetProperty` → `baseType.GetProperty` (line 109) |

## Diff

```diff
- propertyInfo = type.GetProperty(propertyName, DefaultFlags | BindingFlags.GetProperty);
+ propertyInfo = baseType.GetProperty(propertyName, DefaultFlags | BindingFlags.GetProperty);

- propertyInfo = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.GetProperty);
+ propertyInfo = baseType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.GetProperty);
```

## Tests

No new tests written — the plan scope excluded test changes. The existing test suite (`dotnet test tests/Void.UnitTests/`) should be run to verify no regressions.

## Validation

- [x] Code review verified correct via diff inspection
- [x] Fix mirrors the existing `GetFieldValue` pattern exactly
- [ ] `dotnet build` — Cannot verify (dotnet SDK not available in this environment)
- [ ] `dotnet test tests/Void.UnitTests/` — Cannot verify (dotnet SDK not available)

**Note**: The fix is a trivial variable rename (`type` → `baseType`) which is type-safe by construction. No new types or dependencies are introduced.

## Implementation Notes

### Deviations from Plan

No deviations. Implementation matched the plan exactly.

## Acceptance Criteria

- [x] `GetPropertyValue` correctly finds properties in base class hierarchy
- [x] `SetPropertyValue` correctly sets properties in base class hierarchy
- [ ] `dotnet build` passes with exit 0 _(requires .NET SDK)_
- [ ] `dotnet test tests/Void.UnitTests/` passes _(requires .NET SDK)_
- [x] Code mirrors the existing `GetFieldValue` pattern exactly
- [x] No new files created, no new dependencies added

---

**Plan**: `plan-context.md`
**Workflow ID**: `89e398794320b182c77dad4c9078c82f`
