### PR TITLE
feat: Add greeting message when player joins play phase

### DIFF
--- a/src/Plugins/Essentials/GreetingPlugin.cs
+++ b/src/Plugins/Essentials/GreetingPlugin.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging;
+using Void.Minecraft.Components.Text;
+using Void.Proxy.Api.Events;
+using Void.Proxy.Api.Events.Player;
+using Void.Proxy.Api.Players;
+using Void.Proxy.Plugins.Common.Services.Lifecycle;
+
+namespace Void.Proxy.Plugins.Essentials;
+
+public class GreetingPlugin(ILogger<GreetingPlugin> logger) : IProtocolPlugin
+{
+    public static IEnumerable<ProtocolVersion> SupportedVersions => ProtocolVersion.Range(ProtocolVersion.MINECRAFT_1_7_2, ProtocolVersion.Latest);
+
+    public string Name => "GreetingPlugin";
+
+    [Subscribe]
+    public async ValueTask OnPlayerJoinedServer(PlayerJoinedServerEvent @event, CancellationToken cancellationToken)
+    {
+        var player = @event.Player;
+        logger.LogInformation("Player {Player} joined server {Server}", player, @event.Server);
+
+        // Send greeting message to the player
+        var greeting = new Component("Welcome to the server, ")
+            .Append(player.Name, TextColor.LightPurple)
+            .Append("!", TextColor.White);
+
+        // Use the LifecycleService's SendChatMessageAsync method to send the message
+        var channel = await player.GetChannelAsync(cancellationToken);
+        if (channel != null)
+        {
+            await channel.SendPacketAsync(new ChatMessagePacket { Message = greeting, Position = 1 }, cancellationToken);
+        }
+    }
+}

--- a/src/Plugins/Essentials/Plugin.cs
+++ b/src/Plugins/Essentials/Plugin.cs
@@ -31,6 +31,7 @@ public class Plugin(IDependencyService dependencies, IConsoleService console) : 
             services.AddSingleton<ModerationService>();
             services.AddSingleton<PlatformService>();
             services.AddSingleton<TraceService>();
+            services.AddSingleton<GreetingPlugin>(); // Register the new greeting plugin
         });
 
         var overrides = dependencies.GetRequiredService<OverridesService>();


### PR DESCRIPTION
This PR adds a greeting message that displays when players join the play phase.

The implementation: 
- Creates a GreetingPlugin that listens for PlayerJoinedServerEvent
- Sends a colored welcome message: "Welcome to the server, [PlayerName]!" with player name in light purple
- Registers the plugin in Essentials

The feature follows existing patterns in the codebase and uses Minecraft chat packets for messaging.