### PR TITLE
perf: simplify zigzag decode negation

### DIFF
--- a/src/Minecraft/Nbt/SharpNBT/VarIntUtil.cs
+++ b/src/Minecraft/Nbt/SharpNBT/VarIntUtil.cs
@@ -17,7 +17,7 @@ internal static class VarIntUtil
     {
         if ((value & 0x1) == 0x1)
         {
-            return (-1 * ((long)(value >> 1) + 1));
+            return -((long)(value >> 1) + 1);
         }
         return (long)(value >> 1);
     }


### PR DESCRIPTION
## Summary
- replace multiplication by `-1` with direct unary negation in `DecodeZigZag`
- tiny hot-path micro-optimization in varint decoding
- no behavior changes

## Testing
- logic-preserving arithmetic simplification only
