### PR TITLE
fix(dependencies): use concurrent plugin container map

### DIFF
--- a/src/Platform/Plugins/Dependencies/DependencyService.cs
+++ b/src/Platform/Plugins/Dependencies/DependencyService.cs
@@ -260,19 +260,21 @@ public class DependencyService(ILogger<DependencyService> logger, IContainer roo
 
     private PluginContainer GetPluginContainer(Assembly pluginAssembly)
     {
-        while (true)
-        {
-            if (_plugins.TryGetValue(pluginAssembly, out var pluginContainer))
-                return pluginContainer;
+        if (_plugins.TryGetValue(pluginAssembly, out var pluginContainer))
+            return pluginContainer;
 
-            var emptyContainer = Combine();
-            pluginContainer = new PluginContainer(Root: emptyContainer, Scopes: []);
+        var emptyContainer = Combine();
+        pluginContainer = new PluginContainer(Root: emptyContainer, Scopes: []);
 
-            if (_plugins.TryAdd(pluginAssembly, pluginContainer))
-                return pluginContainer;
+        if (_plugins.TryAdd(pluginAssembly, pluginContainer))
+            return pluginContainer;
 
-            emptyContainer.Dispose();
-        }
+        emptyContainer.Dispose();
+
+        if (_plugins.TryGetValue(pluginAssembly, out pluginContainer))
+            return pluginContainer;
+
+        throw new InvalidOperationException($"Failed to get or create plugin container for {pluginAssembly.FullName}.");
     }
 
     private Container Combine(params IServiceProvider[] containers)

--- a/src/Platform/Plugins/Dependencies/DependencyService.cs
+++ b/src/Platform/Plugins/Dependencies/DependencyService.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Concurrent;
+using System.Reflection;
 using DryIoc;
 using Void.Proxy.Api.Events;
 using Void.Proxy.Api.Events.Plugins;
@@ -13,7 +14,7 @@ namespace Void.Proxy.Plugins.Dependencies;
 
 public class DependencyService(ILogger<DependencyService> logger, IContainer rootContainer) : IDependencyService
 {
-    private readonly Dictionary<Assembly, PluginContainer> _plugins = [];
+    private readonly ConcurrentDictionary<Assembly, PluginContainer> _plugins = [];
 
     public TService CreateInstance<TService>(CancellationToken cancellationToken = default, params object[] parameters)
     {
@@ -198,7 +199,7 @@ public class DependencyService(ILogger<DependencyService> logger, IContainer roo
         var events = rootContainer.GetRequiredService<IEventService>();
         events.UnregisterListeners(events.Listeners.Where(listener => listener.GetType().Assembly == assembly));
 
-        if (!_plugins.Remove(assembly, out var container))
+        if (!_plugins.TryRemove(assembly, out var container))
             return;
 
         container.Root.Container.Dispose();
@@ -259,13 +260,19 @@ public class DependencyService(ILogger<DependencyService> logger, IContainer roo
 
     private PluginContainer GetPluginContainer(Assembly pluginAssembly)
     {
-        if (_plugins.TryGetValue(pluginAssembly, out var pluginContainer))
-            return pluginContainer;
+        while (true)
+        {
+            if (_plugins.TryGetValue(pluginAssembly, out var pluginContainer))
+                return pluginContainer;
 
-        var emptyContainer = Combine();
-        _plugins.Add(pluginAssembly, pluginContainer = new PluginContainer(Root: emptyContainer, Scopes: []));
+            var emptyContainer = Combine();
+            pluginContainer = new PluginContainer(Root: emptyContainer, Scopes: []);
 
-        return pluginContainer;
+            if (_plugins.TryAdd(pluginAssembly, pluginContainer))
+                return pluginContainer;
+
+            emptyContainer.Dispose();
+        }
     }
 
     private Container Combine(params IServiceProvider[] containers)


### PR DESCRIPTION
## Summary
- replace the plugin container dictionary with `ConcurrentDictionary`
- use `TryRemove` for plugin unloading
- use `TryAdd` when lazily creating plugin containers and dispose the losing temporary container if another thread wins

## Reason
`GetRootContainers(...)` enumerates plugin assemblies while dependency resolution may lazily add a plugin container. With `Dictionary<TKey, TValue>`, this can throw:

```text
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
at System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.MoveNext()
at Void.Proxy.Plugins.Dependencies.DependencyService.GetRootContainers(...)
```

This keeps the existing lazy behavior but makes the plugin container map safe for concurrent enumeration and mutation.