### PR TITLE
docs(api): 📝 documented XML API members

### DIFF
--- a/src/Api/IProxy.cs
+++ b/src/Api/IProxy.cs
@@ -2,6 +2,23 @@
 
 namespace Void.Proxy.Api;
 
+/// <summary>
+/// Represents the running proxy instance and exposes listener endpoint, listener state, and lifecycle control for API consumers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The proxy owns the TCP listener that accepts Minecraft client connections. <see cref="Status"/> reports the
+/// externally visible lifecycle state, while <see cref="Interface"/> and <see cref="Port"/> describe the listener
+/// endpoint selected from command-line options, settings, or the already-created listener endpoint.
+/// </para>
+/// <para>
+/// <see cref="StartAcceptingConnectionsAsync"/> and <see cref="PauseAcceptingConnections"/> control acceptance of
+/// new connections. Pausing stops the listener from accepting new clients but does not disconnect already linked
+/// players. <see cref="Stop"/> requests host shutdown; when player draining is requested, the shutdown request is
+/// deferred until the current player collection becomes empty.
+/// </para>
+/// </remarks>
+/// <seealso cref="ProxyStatus"/>
 public interface IProxy
 {
     /// <summary>

--- a/src/Api/IRunOptions.cs
+++ b/src/Api/IRunOptions.cs
@@ -1,5 +1,21 @@
 ﻿namespace Void.Proxy.Api;
 
+/// <summary>
+/// Provides immutable startup options used to configure a proxy run before the host and services are created.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are registered as a singleton service and are consumed by startup, console parsing, plugin loading,
+/// configuration loading, and dependency resolution code. The values are treated as run-scoped inputs rather than live
+/// mutable settings.
+/// </para>
+/// <para>
+/// <see cref="WorkingDirectory"/> is used as the base path for runtime files and plugin dependency probing.
+/// <see cref="Arguments"/> is parsed by the console command infrastructure to discover explicitly supplied command-line
+/// options such as listener, logging, or offline-mode overrides.
+/// </para>
+/// </remarks>
+/// <seealso cref="IProxy"/>
 public interface IRunOptions
 {
     public string WorkingDirectory { get; }


### PR DESCRIPTION
## Summary
Improved XML documentation for exactly two API documentation locations in `Void.Proxy.Api`.

## Rationale
The relevant API project generates XML documentation, and missing public XML docs should be prioritized before rewriting existing comments.

## Changes
Added precise type-level XML documentation for:
- `IProxy`, covering listener endpoint/state behavior and lifecycle control semantics.
- `IRunOptions`, covering startup/run-scoped options and how working directory and arguments are consumed.

No code behavior was changed.

## Verification
Checked the relevant project files and implementation/call sites through repository inspection.

Could not run `dotnet build` locally because the execution environment does not have the `dotnet` CLI installed, and HTTPS cloning from the container failed due DNS resolution for `github.com`.

## Performance
Documentation-only change; no runtime or allocation impact.

## Risks & Rollback
Low risk. Roll back by reverting the documentation commits.

## Breaking/Migration
None.

## Links
None.