### PR TITLE
fix(client): 🐛 prevented duplicate client windows

### DIFF
--- a/src/Client/Api.cs
+++ b/src/Client/Api.cs
@@ -47,10 +47,16 @@ application.MapGet("/start-vanilla", async (HttpContext httpContext, string? ver
 
     using var _ = await clientLock.LockAsync();
 
+    await EnsureDisplay();
+
     if (clientProcess is not null && !clientProcess.HasExited)
         return Results.Conflict("a client is already running");
 
-    await EnsureDisplay();
+    var display = Environment.GetEnvironmentVariable("DISPLAY") ?? defaultDisplay;
+    var existingWindowId = await FindLargestWindow(display);
+
+    if (existingWindowId is not null)
+        return Results.Conflict("a client window is already running");
 
     var minecraftDirectory = Environment.GetEnvironmentVariable("MINECRAFT_DIRECTORY") ?? defaultMinecraftDirectory;
     var portablemcVersion = $"mojang:{version}";
@@ -75,8 +81,16 @@ application.MapGet("/start-curseforge", async (HttpContext httpContext, string? 
 
     using var _ = await clientLock.LockAsync();
 
+    await EnsureDisplay();
+
     if (clientProcess is not null && !clientProcess.HasExited)
         return Results.Conflict("a client is already running");
+
+    var display = Environment.GetEnvironmentVariable("DISPLAY") ?? defaultDisplay;
+    var existingWindowId = await FindLargestWindow(display);
+
+    if (existingWindowId is not null)
+        return Results.Conflict("a client window is already running");
 
     var minecraftDirectory = Environment.GetEnvironmentVariable("MINECRAFT_DIRECTORY") ?? defaultMinecraftDirectory;
     Directory.CreateDirectory(minecraftDirectory);
@@ -109,8 +123,6 @@ application.MapGet("/start-curseforge", async (HttpContext httpContext, string? 
 
         Console.Error.WriteLine("Installation marker updated");
     }
-
-    await EnsureDisplay();
 
     Console.Error.WriteLine($"Launching Minecraft with PortableMC version: {portablemcVersion}");
     clientProcess = LaunchPortableMinecraftClient(minecraftDirectory, portablemcVersion, portableMinecraftArguments);


### PR DESCRIPTION
## Summary
Client launch endpoints now detect an already visible client window on the configured display and return a conflict instead of starting another client.

## Rationale
The stored process reference can be missing or stale, which previously allowed a second visible client window to be spawned; checking the display before launching prevents duplicate visible clients without relying solely on process state.

## Changes
- Moved `EnsureDisplay()` earlier in both the vanilla and CurseForge launch flows to guarantee display readiness before any launch logic.
- Added a lookup for the largest window on the configured `DISPLAY` and return `409 Conflict` when an existing client window is found.
- Removed the redundant late `EnsureDisplay()` call in the CurseForge path.

## Verification
- Ran `dotnet test tests/Void.UnitTests/` and observed all unit tests passed (`Passed: 71`).
- Ran `dotnet build` and observed the solution built successfully.
- Ran `git diff --check` to validate the diff; no whitespace errors.

## Performance
The added display/window lookup executes once per launch request and has no measurable performance impact.

## Risks & Rollback
Risk of false-positive window detection could prevent a legitimate launch; rollback can be done by reverting the change (commit b7f9456).

## Breaking/Migration
No migration required; callers may now receive `409 Conflict` if a client window is already visible.

## Links
None.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bc116e1dc832b8e71707b1f653862)