### PR TITLE
test(integration): ✅ updated portable client HTTP integration

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -15,7 +15,7 @@ on:
       shard-count:
         type: number
         required: false
-        default: 32
+        default: 16
 
 jobs:
   test-matrix:
@@ -93,19 +93,81 @@ jobs:
         shell: bash
         if: ${{ matrix.test-kind == 'integration' }}
         run: |
-          filter=$(
-            dotnet test tests/Void.IntegrationTests --configuration Release --list-tests \
-              | awk '/The following Tests are available:/{started=1; next} started {gsub(/^[ \t]+/, ""); if ($0) print}' \
-              | sort -u \
-              | awk -v shard=${{ matrix.shard }} -v total=${{ inputs.shard-count }} '((NR - 1) % total) == shard { print "FullyQualifiedName=" $0 }' \
-              | paste -sd '|' -
-          )
+          set -euo pipefail
 
+          shard=${{ matrix.shard }}
+          total=${{ inputs.shard-count }}
+          assignment_dir="$(mktemp -d)"
+          tests_file="$assignment_dir/tests.txt"
+          assignments_file="$assignment_dir/assignments.tsv"
+          trap 'rm -rf "$assignment_dir"' EXIT
+
+          dotnet test tests/Void.IntegrationTests --configuration Release --list-tests \
+            | awk '/The following Tests are available:/{started=1; next} started {gsub(/^[ \t]+/, ""); if ($0) print}' \
+            | LC_ALL=C sort -u > "$tests_file"
+
+          total_tests=$(wc -l < "$tests_file" | tr -d ' ')
+
+          if [ "$total_tests" -eq 0 ]; then
+            echo "No integration tests were discovered."
+            echo "HAS_INTEGRATION_TESTS=false" >> "$GITHUB_ENV"
+            echo "TEST_FILTER=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          for (( current_shard = 0; current_shard < total; current_shard++ )); do
+            : > "$assignment_dir/shard-$current_shard.txt"
+          done
+
+          while IFS= read -r test_name; do
+            checksum=$(printf '%s' "$test_name" | cksum | awk '{ print $1 }')
+            assigned_shard=$(( checksum % total ))
+
+            printf '%s\t%s\n' "$assigned_shard" "$test_name" >> "$assignments_file"
+            printf '%s\n' "$test_name" >> "$assignment_dir/shard-$assigned_shard.txt"
+          done < "$tests_file"
+
+          assigned_tests=$(wc -l < "$assignments_file" | tr -d ' ')
+          unique_assigned_tests=$(cut -f2- "$assignments_file" | LC_ALL=C sort -u | wc -l | tr -d ' ')
+
+          if [ "$assigned_tests" -ne "$total_tests" ] || [ "$unique_assigned_tests" -ne "$total_tests" ]; then
+            echo "Shard assignment check failed."
+            echo "Discovered tests: $total_tests"
+            echo "Assigned tests: $assigned_tests"
+            echo "Unique assigned tests: $unique_assigned_tests"
+            echo "Duplicate assignments:"
+            cut -f2- "$assignments_file" | LC_ALL=C sort | uniq -d
+            exit 1
+          fi
+
+          echo "Discovered $total_tests integration tests."
+
+          for (( current_shard = 0; current_shard < total; current_shard++ )); do
+            shard_tests=$(wc -l < "$assignment_dir/shard-$current_shard.txt" | tr -d ' ')
+            echo "Shard $current_shard/$total: $shard_tests tests"
+          done
+
+          current_shard_file="$assignment_dir/shard-$shard.txt"
+
+          if [ ! -s "$current_shard_file" ]; then
+            echo "No integration tests assigned to shard $shard/$total."
+            echo "HAS_INTEGRATION_TESTS=false" >> "$GITHUB_ENV"
+            echo "TEST_FILTER=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          filter=$(awk '{ print "FullyQualifiedName=" $0 }' "$current_shard_file" | paste -sd '|' -)
+
+          echo "HAS_INTEGRATION_TESTS=true" >> "$GITHUB_ENV"
           echo "TEST_FILTER=$filter" >> "$GITHUB_ENV"
 
       - name: Run integration shard
-        if: ${{ matrix.test-kind == 'integration' }}
+        if: ${{ matrix.test-kind == 'integration' && env.HAS_INTEGRATION_TESTS == 'true' }}
         run: dotnet test tests/Void.IntegrationTests --configuration Release --filter "$TEST_FILTER" --logger "console;verbosity=detailed"
+
+      - name: Skip empty integration shard
+        if: ${{ matrix.test-kind == 'integration' && env.HAS_INTEGRATION_TESTS != 'true' }}
+        run: echo "No integration tests assigned to this shard."
 
       - name: Upload integration steps
         if: ${{ always() && matrix.test-kind == 'integration' }}

--- a/src/Client/Api.cs
+++ b/src/Client/Api.cs
@@ -16,7 +16,10 @@ using File = System.IO.File;
 
 const string defaultMinecraftDirectory = "/root/.minecraft";
 const string defaultDisplay = ":99";
-const string displayScreen = "1280x720x24";
+const string displayScreenWidth = "854";
+const string displayScreenHeight = "480";
+const string displayScreenDepth = "24";
+const string displayScreen = $"{displayScreenWidth}x{displayScreenHeight}x{displayScreenDepth}";
 const int minecraftGameId = 432;
 const int curseForgeFilesBatchSize = 50;
 const int brightnessThreshold = 5;
@@ -167,6 +170,7 @@ application.MapGet("/send-chat", async (string? message) =>
     if (windowId is null)
         return Results.Problem("no visible window found");
 
+    await ResizeWindowToDisplayAsync(windowId);
     await RunOrThrow("xdotool", "windowfocus", windowId);
     var chatOpened = await OpenChatAsync(windowId, display);
 
@@ -190,12 +194,7 @@ application.MapGet("/screen", async () =>
     if (windowId is null)
         return Results.Problem("no visible window found");
 
-    var displaySizeParts = displayScreen.Split('x');
-    var displayWidth = displaySizeParts[0];
-    var displayHeight = displaySizeParts[1];
-
-    await RunOrThrow("xdotool", "windowmove", "--sync", windowId, "0", "0");
-    await RunOrThrow("xdotool", "windowsize", "--sync", windowId, displayWidth, displayHeight);
+    await ResizeWindowToDisplayAsync(windowId);
 
     var captureProcessInfo = new ProcessStartInfo("import") { RedirectStandardOutput = true, RedirectStandardError = true, Environment = { ["DISPLAY"] = display } };
 
@@ -225,6 +224,7 @@ application.Run();
 Process LaunchPortableMinecraftClient(string directory, string version, string?[]? portableMinecraftArguments = null)
 {
     portableMinecraftArguments ??= [];
+    var requestedPortableMinecraftArguments = portableMinecraftArguments.OfType<string>().ToArray();
 
     var process = StartCriticalProcess("portablemc", processInfo =>
     {
@@ -233,7 +233,19 @@ Process LaunchPortableMinecraftClient(string directory, string version, string?[
         processInfo.ArgumentList.Add("start");
         processInfo.ArgumentList.Add(version);
 
-        foreach (var argument in portableMinecraftArguments.OfType<string>())
+        if (!HasPortableMinecraftArgument(requestedPortableMinecraftArguments, "--width"))
+        {
+            processInfo.ArgumentList.Add("--width");
+            processInfo.ArgumentList.Add(displayScreenWidth);
+        }
+
+        if (!HasPortableMinecraftArgument(requestedPortableMinecraftArguments, "--height"))
+        {
+            processInfo.ArgumentList.Add("--height");
+            processInfo.ArgumentList.Add(displayScreenHeight);
+        }
+
+        foreach (var argument in requestedPortableMinecraftArguments)
             processInfo.ArgumentList.Add(argument);
     });
 
@@ -241,6 +253,17 @@ Process LaunchPortableMinecraftClient(string directory, string version, string?[
         Environment.FailFast($"portablemc exited immediately with code {process.ExitCode}");
 
     return process;
+}
+
+bool HasPortableMinecraftArgument(IEnumerable<string> arguments, string argumentName)
+{
+    return arguments.Any(argument => string.Equals(argument, argumentName, StringComparison.Ordinal) || argument.StartsWith($"{argumentName}=", StringComparison.Ordinal));
+}
+
+async Task ResizeWindowToDisplayAsync(string windowId)
+{
+    await RunOrThrow("xdotool", "windowmove", "--sync", windowId, "0", "0");
+    await RunOrThrow("xdotool", "windowsize", "--sync", windowId, displayScreenWidth, displayScreenHeight);
 }
 
 async Task EnsureDisplay()

--- a/tests/Void.IntegrationTests/Connections/DirectConnectionTestBase.cs
+++ b/tests/Void.IntegrationTests/Connections/DirectConnectionTestBase.cs
@@ -25,7 +25,7 @@ public abstract class DirectConnectionTestBase(PaperFixture paperFixture, Portab
 
         await LoggedExecutorAsync(async () =>
         {
-            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(DirectConnectionTestBase), _serverEndPoint, protocolVersion, Timeouts.SetupTimeoutToken))
+            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(DirectConnectionTestBase), _serverEndPoint, protocolVersion, [paperFixture.Server1], Timeouts.SetupTimeoutToken))
             {
                 await game.SendTextMessageAsync(expectedText, Timeouts.StepTimeoutToken);
                 await paperFixture.Server1.ExpectTextAsync(expectedText, lookupHistory: true, Timeouts.StepTimeoutToken);

--- a/tests/Void.IntegrationTests/Connections/ProxiedConnectionTestBase.cs
+++ b/tests/Void.IntegrationTests/Connections/ProxiedConnectionTestBase.cs
@@ -25,7 +25,7 @@ public abstract class ProxiedConnectionTestBase(PaperFixture paperFixture, VoidF
 
         await LoggedExecutorAsync(async () =>
         {
-            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(ProxiedConnectionTestBase), _proxyEndPoint, protocolVersion, Timeouts.SetupTimeoutToken))
+            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(ProxiedConnectionTestBase), _proxyEndPoint, protocolVersion, [voidFixture.VoidProxy, paperFixture.Server1], Timeouts.SetupTimeoutToken))
             {
                 await game.SendTextMessageAsync(expectedText, Timeouts.StepTimeoutToken);
                 await paperFixture.Server1.ExpectTextAsync(expectedText, lookupHistory: true, Timeouts.StepTimeoutToken);

--- a/tests/Void.IntegrationTests/Connections/ProxiedServerRedirectionTestBase.cs
+++ b/tests/Void.IntegrationTests/Connections/ProxiedServerRedirectionTestBase.cs
@@ -25,7 +25,7 @@ public abstract class ProxiedServerRedirectionTestBase(PaperFixture paperFixture
 
         await LoggedExecutorAsync(async () =>
         {
-            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(ProxiedServerRedirectionTestBase), _proxyEndPoint, protocolVersion, Timeouts.SetupTimeoutToken))
+            await using (var game = await portableMinecraftClientFixture.Api.RunGameAsync(nameof(ProxiedServerRedirectionTestBase), _proxyEndPoint, protocolVersion, [voidFixture.VoidProxy, paperFixture.Server1, paperFixture.Server2], Timeouts.SetupTimeoutToken))
             {
                 await game.SendTextMessageAsync(firstMessage, Timeouts.StepTimeoutToken);
                 await paperFixture.Server1.ExpectTextAsync(firstMessage, lookupHistory: true, Timeouts.StepTimeoutToken);

--- a/tests/Void.IntegrationTests/Infrastructure/Extensions/EndPointExtensions.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Extensions/EndPointExtensions.cs
@@ -11,11 +11,16 @@ public static class EndPointExtensions
     {
         public (string Host, int Port) AsDockerHostPort => endPoint switch
         {
-            DnsEndPoint dnsEndPoint when !OperatingSystem.IsLinux() && string.Equals(dnsEndPoint.Host, "localhost", StringComparison.OrdinalIgnoreCase) => (DockerHost, dnsEndPoint.Port),
+            DnsEndPoint dnsEndPoint when IsLocalHost(dnsEndPoint.Host) => (DockerHost, dnsEndPoint.Port),
             DnsEndPoint dnsEndPoint => (dnsEndPoint.Host, dnsEndPoint.Port),
-            IPEndPoint ipEndPoint when !OperatingSystem.IsLinux() && IPAddress.IsLoopback(ipEndPoint.Address) => (DockerHost, ipEndPoint.Port),
+            IPEndPoint ipEndPoint when IPAddress.IsLoopback(ipEndPoint.Address) => (DockerHost, ipEndPoint.Port),
             IPEndPoint ipEndPoint => (ipEndPoint.Address.ToString(), ipEndPoint.Port),
             _ => throw new NotSupportedException($"Unsupported endpoint type: {endPoint.GetType()}")
         };
+
+        private static bool IsLocalHost(string host)
+        {
+            return string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/tests/Void.IntegrationTests/Infrastructure/Fixtures/PaperFixture.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Fixtures/PaperFixture.cs
@@ -13,8 +13,8 @@ public class PaperFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        var paperServer1 = PaperServer.CreateAsync(Timeouts.SetupTimeoutToken);
-        var paperServer2 = PaperServer.CreateAsync(Timeouts.SetupTimeoutToken);
+        var paperServer1 = PaperServer.CreateAsync("server-1.log", Timeouts.SetupTimeoutToken);
+        var paperServer2 = PaperServer.CreateAsync("server-2.log", Timeouts.SetupTimeoutToken);
 
         Server1 = await paperServer1;
         Server2 = await paperServer2;

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/IIntegrationSide.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/IIntegrationSide.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Void.IntegrationTests.Infrastructure.Harness;
 
 public interface IIntegrationSide : IAsyncDisposable
 {
+    public string LogFileName { get; }
     public IEnumerable<string> Logs { get; }
+
+    public Task<IEnumerable<string>> ReadLogsAsync(DateTime since, CancellationToken cancellationToken = default);
 
     public void ClearLogs();
 }

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PaperServer.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PaperServer.cs
@@ -9,12 +9,12 @@ using Void.IntegrationTests.Infrastructure.Extensions;
 
 namespace Void.IntegrationTests.Infrastructure.Harness.Sides;
 
-public record PaperServer(IContainer Container) : IIntegrationSide
+public record PaperServer(IContainer Container, string LogFileName) : IIntegrationSide
 {
     private DateTime _readLogsSince = DateTime.UtcNow;
     public int Port => Container.GetMappedPublicPort(containerPort: 25565);
 
-    public IEnumerable<string> Logs => Container.ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
+    public IEnumerable<string> Logs => ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
 
     public void ClearLogs()
     {
@@ -29,6 +29,11 @@ public record PaperServer(IContainer Container) : IIntegrationSide
     }
 
     public static async Task<PaperServer> CreateAsync(CancellationToken cancellationToken = default)
+    {
+        return await CreateAsync("server.log", cancellationToken);
+    }
+
+    public static async Task<PaperServer> CreateAsync(string logFileName, CancellationToken cancellationToken = default)
     {
         var container = new ContainerBuilder("itzg/minecraft-server:latest")
             .WithImagePullPolicy(PullPolicy.Always)
@@ -67,7 +72,12 @@ public record PaperServer(IContainer Container) : IIntegrationSide
 
         await container.StartAsync(cancellationToken);
 
-        return new PaperServer(container);
+        return new PaperServer(container, logFileName);
+    }
+
+    public async Task<IEnumerable<string>> ReadLogsAsync(DateTime since, CancellationToken cancellationToken = default)
+    {
+        return await Container.ReadLogsAsync(since, cancellationToken);
     }
 
     public async Task ExpectTextAsync(string text, bool lookupHistory = false, CancellationToken cancellationToken = default)

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
@@ -4,20 +4,25 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using Void.IntegrationTests.Infrastructure.Exceptions;
 using Void.IntegrationTests.Infrastructure.Extensions;
 using Void.Minecraft.Network;
 
 namespace Void.IntegrationTests.Infrastructure.Harness.Sides;
 
-public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
+public record PortableMinecraftClient(IContainer Container, HttpClient HttpClient) : IIntegrationSide
 {
     private const int SetupRetries = 5;
+    private const int ApiPort = 8080;
     private const string Display = ":99";
-    private const string RedirectOutput = ">/proc/1/fd/1 2>/proc/1/fd/2";
+    private const string DockerHost = "host.docker.internal";
+    private const string DockerHostGateway = "host-gateway";
     private const string LogMessagePrefix = $"[{nameof(Void)}.{nameof(IntegrationTests)}]";
 
     private DateTime _readLogsSince = DateTime.UtcNow;
@@ -36,6 +41,7 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
 
     public async ValueTask DisposeAsync()
     {
+        HttpClient.Dispose();
         await Container.DisposeAsync();
 
         GC.SuppressFinalize(this);
@@ -45,17 +51,26 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
     {
         var builder = new ContainerBuilder("ghcr.io/caunt/portable-minecraft-client:offline")
             .WithEnvironment("DISPLAY", Display)
+            .WithPortBinding(port: ApiPort, assignRandomHostPort: true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request
+                    .ForPort(ApiPort)
+                    .ForPath("/health"), options => options.WithTimeout(TimeSpan.FromMinutes(1))))
             .WithCreateParameterModifier(parameters => parameters.Platform = "linux/amd64");
 
         if (OperatingSystem.IsLinux())
-            builder = builder.WithCreateParameterModifier(parameters => parameters.HostConfig?.NetworkMode = "host");
+            builder = builder.WithExtraHost(DockerHost, DockerHostGateway);
 
         var container = builder.Build();
 
         await container.StartAsync(cancellationToken);
-        await container.RunCommandAsync(["start-display"], cancellationToken);
 
-        return new PortableMinecraftClient(container);
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri($"http://{container.Hostname}:{container.GetMappedPublicPort(ApiPort)}")
+        };
+
+        return new PortableMinecraftClient(container, httpClient);
     }
 
     public async Task<Game> RunGameAsync(string testName, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
@@ -64,7 +79,7 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
         {
             try
             {
-                return await Game.RunAsync(testName, Container, logsDateTimeGetter: () => _readLogsSince, endPoint, protocolVersion, cancellationToken);
+                return await Game.RunAsync(testName, Container, HttpClient, logsDateTimeGetter: () => _readLogsSince, endPoint, protocolVersion, cancellationToken);
             }
             catch (OperationCanceledException) when (attempt < SetupRetries)
             {
@@ -75,7 +90,7 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
         throw new TimeoutException($"Failed to setup {protocolVersion} after {SetupRetries} attempts");
     }
 
-    public record Game(string TestName, IContainer Container, Func<DateTime> LogsDateTimeGetter, ProtocolVersion ProtocolVersion, string Username, Task RunTask, CancellationTokenSource CancellationTokenSource) : IAsyncDisposable
+    public record Game(string TestName, IContainer Container, HttpClient HttpClient, Func<DateTime> LogsDateTimeGetter, ProtocolVersion ProtocolVersion, string Username) : IAsyncDisposable
     {
         private readonly string _workingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "steps", TestName, ProtocolVersion.ToString(), Username);
         private int _step;
@@ -86,51 +101,40 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
         {
             await LogAsync($"Stopping Minecraft {ProtocolVersion.FirstRelease}", Timeouts.StepTimeoutToken);
 
-            await MakeStepAsync("exit", Timeouts.StepTimeoutToken);
-            await File.WriteAllLinesAsync(Path.Combine(_workingDirectory, "logs.txt"), await Container.ReadLogsAsync(ReadLogsSince, Timeouts.StepTimeoutToken), Timeouts.StepTimeoutToken);
-
-            await CancellationTokenSource.CancelAsync();
-
             try
             {
-                await RunTask;
-            }
-            catch (OperationCanceledException)
-            {
-                // Ignored
+                await MakeStepAsync("exit", Timeouts.StepTimeoutToken);
+                await File.WriteAllLinesAsync(Path.Combine(_workingDirectory, "logs.txt"), await Container.ReadLogsAsync(ReadLogsSince, Timeouts.StepTimeoutToken), Timeouts.StepTimeoutToken);
             }
             finally
             {
-                CancellationTokenSource.Dispose();
+                await StopClientAsync(Timeouts.StepTimeoutToken);
             }
 
             GC.SuppressFinalize(this);
         }
 
-        public static async Task<Game> RunAsync(string testName, IContainer container, Func<DateTime> logsDateTimeGetter, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
+        public static async Task<Game> RunAsync(string testName, IContainer container, HttpClient httpClient, Func<DateTime> logsDateTimeGetter, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
         {
             var (dockerHost, dockerPort) = endPoint.AsDockerHostPort;
             var username = Convert.ToHexString(BitConverter.GetBytes(Random.Shared.Next()));
-            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            // Reset whole options.txt
-            await container.RunCommandAsync(
-                $"""
-                 printf "
-                 maxFps:15
-                 renderDistance:2
-                 {(protocolVersion >= ProtocolVersion.MINECRAFT_1_19_4 ? "onboardAccessibility:false" : string.Empty)}
-                 pauseOnLostFocus:false
-                 " > "$HOME/.minecraft/options.txt"
-                 """,
-                cancellationToken);
+            await container.CopyAsync(Encoding.UTF8.GetBytes(CreateOptionsText(protocolVersion)), "/root/.minecraft/options.txt", ct: cancellationToken);
 
-            var task = container.RunCommandAsync($"portablemc start --fetch-exclude-all --username \"{username}\" --join-server \"{dockerHost}\" --join-server-port \"{dockerPort}\" --jvm-arg=-Djava.awt.headless=false \"{protocolVersion.FirstRelease}\" {RedirectOutput}", cancellationToken, cancellationTokenSource.Token);
-            var game = new Game(testName, container, logsDateTimeGetter, protocolVersion, username, task, cancellationTokenSource);
+            var game = new Game(testName, container, httpClient, logsDateTimeGetter, protocolVersion, username);
 
-            await game.LogAsync($"Starting Minecraft {protocolVersion.FirstRelease}", cancellationToken);
-            await container.ExpectTextAsync("Connecting to", cancellationToken);
-            await game.EnsureStableAsync(cancellationToken);
+            try
+            {
+                await game.LogAsync($"Starting Minecraft {protocolVersion.FirstRelease}", cancellationToken);
+                await game.StartVanillaAsync(dockerHost, dockerPort, cancellationToken);
+                await container.ExpectTextAsync("Connecting to", cancellationToken);
+                await game.EnsureStableAsync(cancellationToken);
+            }
+            catch
+            {
+                await game.StopClientAsync(Timeouts.StepTimeoutToken);
+                throw;
+            }
 
             return game;
         }
@@ -150,7 +154,7 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
                     : Container.ExpectTextAsync(text, cancellationToken); // Expect the text to appear in logs
 
                 await LogAsync($"Sending chat input: {text}", cancellationToken);
-                await Container.RunCommandAsync(["send-chat", text], cancellationToken);
+                await SendChatAsync(text, cancellationToken);
                 await expectTask;
 
                 await MakeStepAsync("chat", cancellationToken);
@@ -186,15 +190,90 @@ public record PortableMinecraftClient(IContainer Container) : IIntegrationSide
             await MakeStepAsync("stable", cancellationToken);
         }
 
-        private async Task LogAsync(string message, CancellationToken cancellationToken = default)
+        private async Task StartVanillaAsync(string dockerHost, int dockerPort, CancellationToken cancellationToken = default)
         {
-            await Container.RunCommandAsync($"printf '{LogMessagePrefix} %s\n' '{message.Replace("'", "'\"'\"'")}' {RedirectOutput}", cancellationToken);
+            var queryParameters = new List<KeyValuePair<string, string>>
+            {
+                new("version", ProtocolVersion.FirstRelease),
+                new("argument", "--fetch-exclude-all"),
+                new("argument", "--username"),
+                new("argument", Username),
+                new("argument", "--join-server"),
+                new("argument", dockerHost),
+                new("argument", "--join-server-port"),
+                new("argument", dockerPort.ToString()),
+                new("argument", "--jvm-arg=-Djava.awt.headless=false")
+            };
+
+            using var response = await HttpClient.GetAsync(CreateRequestUri("/start-vanilla", queryParameters), cancellationToken);
+            await EnsureSuccessAsync(response, $"Starting Minecraft {ProtocolVersion.FirstRelease}", cancellationToken);
+        }
+
+        private async Task SendChatAsync(string text, CancellationToken cancellationToken = default)
+        {
+            using var response = await HttpClient.GetAsync(CreateRequestUri("/send-chat", [new KeyValuePair<string, string>("message", text)]), cancellationToken);
+            await EnsureSuccessAsync(response, $"Sending chat input: {text}", cancellationToken);
+        }
+
+        private async Task StopClientAsync(CancellationToken cancellationToken = default)
+        {
+            using var response = await HttpClient.GetAsync("/stop-client", cancellationToken);
+
+            if (response.StatusCode is HttpStatusCode.NotFound)
+                return;
+
+            await EnsureSuccessAsync(response, $"Stopping Minecraft {ProtocolVersion.FirstRelease}", cancellationToken);
+        }
+
+        private async Task<byte[]> TakeScreenshotAsync(CancellationToken cancellationToken = default)
+        {
+            using var response = await HttpClient.GetAsync("/screen", cancellationToken);
+            await EnsureSuccessAsync(response, "Taking Minecraft screenshot", cancellationToken);
+
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        }
+
+        private static async Task EnsureSuccessAsync(HttpResponseMessage response, string operation, CancellationToken cancellationToken = default)
+        {
+            if (response.IsSuccessStatusCode)
+                return;
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new IntegrationTestException($"{operation} failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase}\n{content}");
+        }
+
+        private Task LogAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Console.WriteLine($"{LogMessagePrefix} {message}");
+            return Task.CompletedTask;
         }
 
         private async Task MakeStepAsync(string action, CancellationToken cancellationToken = default)
         {
             _ = Directory.CreateDirectory(_workingDirectory);
-            await File.WriteAllBytesAsync(Path.Combine(_workingDirectory, $"step-{++_step}-{action}.png"), await Container.TakeScreenshotAsync(windowName: "Minecraft", cancellationToken), cancellationToken);
+            await File.WriteAllBytesAsync(Path.Combine(_workingDirectory, $"step-{++_step}-{action}.png"), await TakeScreenshotAsync(cancellationToken), cancellationToken);
+        }
+
+        private static string CreateRequestUri(string path, IEnumerable<KeyValuePair<string, string>> queryParameters)
+        {
+            var query = string.Join("&", queryParameters.Select(parameter => $"{Uri.EscapeDataString(parameter.Key)}={Uri.EscapeDataString(parameter.Value)}"));
+            return $"{path}?{query}";
+        }
+
+        private static string CreateOptionsText(ProtocolVersion protocolVersion)
+        {
+            var options = new List<string>
+            {
+                "maxFps:15",
+                "renderDistance:2",
+                "pauseOnLostFocus:false"
+            };
+
+            if (protocolVersion >= ProtocolVersion.MINECRAFT_1_19_4)
+                options.Insert(2, "onboardAccessibility:false");
+
+            return string.Join('\n', options) + "\n";
         }
     }
 }

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
@@ -32,7 +32,7 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         // These do connect to the server before the loading screen completes, causing MC-228828 crash on 1.14-1.19
         .Where(version => version < ProtocolVersion.MINECRAFT_1_14 || version > ProtocolVersion.MINECRAFT_1_19);
 
-    public string LogFileName => "logs.txt";
+    public string LogFileName => "client.log";
     public IEnumerable<string> Logs => ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
 
     public void ClearLogs()

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
@@ -32,7 +32,8 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         // These do connect to the server before the loading screen completes, causing MC-228828 crash on 1.14-1.19
         .Where(version => version < ProtocolVersion.MINECRAFT_1_14 || version > ProtocolVersion.MINECRAFT_1_19);
 
-    public IEnumerable<string> Logs => Container.ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
+    public string LogFileName => "logs.txt";
+    public IEnumerable<string> Logs => ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
 
     public void ClearLogs()
     {
@@ -75,11 +76,16 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
 
     public async Task<Game> RunGameAsync(string testName, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
     {
+        return await RunGameAsync(testName, endPoint, protocolVersion, [], cancellationToken);
+    }
+
+    public async Task<Game> RunGameAsync(string testName, EndPoint endPoint, ProtocolVersion protocolVersion, IEnumerable<IIntegrationSide> additionalLogSides, CancellationToken cancellationToken = default)
+    {
         for (var attempt = 1; attempt <= SetupRetries; attempt++)
         {
             try
             {
-                return await Game.RunAsync(testName, Container, HttpClient, logsDateTimeGetter: () => _readLogsSince, endPoint, protocolVersion, cancellationToken);
+                return await Game.RunAsync(testName, Container, HttpClient, [this, .. additionalLogSides], endPoint, protocolVersion, cancellationToken);
             }
             catch (OperationCanceledException) when (attempt < SetupRetries)
             {
@@ -90,12 +96,15 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         throw new TimeoutException($"Failed to setup {protocolVersion} after {SetupRetries} attempts");
     }
 
-    public record Game(string TestName, IContainer Container, HttpClient HttpClient, Func<DateTime> LogsDateTimeGetter, ProtocolVersion ProtocolVersion, string Username) : IAsyncDisposable
+    public async Task<IEnumerable<string>> ReadLogsAsync(DateTime since, CancellationToken cancellationToken = default)
+    {
+        return await Container.ReadLogsAsync(since, cancellationToken);
+    }
+
+    public record Game(string TestName, IContainer Container, HttpClient HttpClient, IReadOnlyList<IIntegrationSide> LogSides, DateTime StartedAt, ProtocolVersion ProtocolVersion, string Username) : IAsyncDisposable
     {
         private readonly string _workingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "steps", TestName, ProtocolVersion.ToString(), Username);
         private int _step;
-
-        public DateTime ReadLogsSince => LogsDateTimeGetter();
 
         public async ValueTask DisposeAsync()
         {
@@ -103,8 +112,14 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
 
             try
             {
-                await MakeStepAsync("exit", Timeouts.StepTimeoutToken);
-                await File.WriteAllLinesAsync(Path.Combine(_workingDirectory, "logs.txt"), await Container.ReadLogsAsync(ReadLogsSince, Timeouts.StepTimeoutToken), Timeouts.StepTimeoutToken);
+                try
+                {
+                    await MakeStepAsync("exit", Timeouts.StepTimeoutToken);
+                }
+                finally
+                {
+                    await TryWriteLogsAsync(Timeouts.StepTimeoutToken);
+                }
             }
             finally
             {
@@ -114,14 +129,15 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
             GC.SuppressFinalize(this);
         }
 
-        public static async Task<Game> RunAsync(string testName, IContainer container, HttpClient httpClient, Func<DateTime> logsDateTimeGetter, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
+        public static async Task<Game> RunAsync(string testName, IContainer container, HttpClient httpClient, IReadOnlyList<IIntegrationSide> logSides, EndPoint endPoint, ProtocolVersion protocolVersion, CancellationToken cancellationToken = default)
         {
             var (dockerHost, dockerPort) = endPoint.AsDockerHostPort;
             var username = Convert.ToHexString(BitConverter.GetBytes(Random.Shared.Next()));
+            var startedAt = DateTime.UtcNow;
 
             await container.CopyAsync(Encoding.UTF8.GetBytes(CreateOptionsText(protocolVersion)), "/root/.minecraft/options.txt", ct: cancellationToken);
 
-            var game = new Game(testName, container, httpClient, logsDateTimeGetter, protocolVersion, username);
+            var game = new Game(testName, container, httpClient, logSides, startedAt, protocolVersion, username);
 
             try
             {
@@ -132,6 +148,7 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
             }
             catch
             {
+                await game.TryWriteLogsAsync(Timeouts.StepTimeoutToken);
                 await game.StopClientAsync(Timeouts.StepTimeoutToken);
                 throw;
             }
@@ -253,6 +270,29 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         {
             _ = Directory.CreateDirectory(_workingDirectory);
             await File.WriteAllBytesAsync(Path.Combine(_workingDirectory, $"step-{++_step}-{action}.png"), await TakeScreenshotAsync(cancellationToken), cancellationToken);
+        }
+
+        private async Task TryWriteLogsAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await WriteLogsAsync(cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                await LogAsync($"Failed to write step logs: {exception.Message}", CancellationToken.None);
+            }
+        }
+
+        private async Task WriteLogsAsync(CancellationToken cancellationToken = default)
+        {
+            _ = Directory.CreateDirectory(_workingDirectory);
+
+            foreach (var side in LogSides)
+            {
+                var logs = await side.ReadLogsAsync(StartedAt, cancellationToken);
+                await File.WriteAllLinesAsync(Path.Combine(_workingDirectory, side.LogFileName), logs, cancellationToken);
+            }
         }
 
         private static string CreateRequestUri(string path, IEnumerable<KeyValuePair<string, string>> queryParameters)

--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/VoidProxy.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/VoidProxy.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 public record VoidProxy(CollectingTextWriter LogWriter, VoidEntryPoint.RunResult RunResult, CancellationTokenSource CancellationTokenSource) : IIntegrationSide
 {
+    public string LogFileName => "void-proxy.log";
     public IEnumerable<string> Logs => LogWriter.Lines;
     public int Port => RunResult.ListeningPort;
 
@@ -69,6 +70,12 @@ public record VoidProxy(CollectingTextWriter LogWriter, VoidEntryPoint.RunResult
     public void ClearLogs()
     {
         LogWriter.Clear();
+    }
+
+    public Task<IEnumerable<string>> ReadLogsAsync(DateTime since, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IEnumerable<string>>(LogWriter.GetLinesSince(since));
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Void.IntegrationTests/Infrastructure/IO/CollectingTextWriter.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/IO/CollectingTextWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -8,11 +9,19 @@ namespace Void.IntegrationTests.Infrastructure.IO;
 
 public class CollectingTextWriter : TextWriter
 {
-    private readonly List<string> _lines = [];
+    private readonly List<CollectedLine> _lines = [];
     private readonly StringBuilder _currentLineBuilder = new();
     private readonly Lock _lock = new();
 
-    public IReadOnlyList<string> Lines => [.. _lines];
+    public IReadOnlyList<string> Lines
+    {
+        get
+        {
+            using var _ = _lock.EnterScope();
+            return [.. _lines.Select(line => line.Text)];
+        }
+    }
+
     public string Text => string.Join('\n', Lines);
     public event Action<string>? OnLine;
     public override Encoding Encoding { get; } = Encoding.UTF8;
@@ -23,6 +32,12 @@ public class CollectingTextWriter : TextWriter
 
         _lines.Clear();
         _currentLineBuilder.Clear();
+    }
+
+    public IReadOnlyList<string> GetLinesSince(DateTime since)
+    {
+        using var _ = _lock.EnterScope();
+        return [.. _lines.Where(line => line.Timestamp >= since).Select(line => line.Text)];
     }
 
     public override void Write(char value)
@@ -75,7 +90,7 @@ public class CollectingTextWriter : TextWriter
                 if (completedLine.Length == 0)
                     continue;
 
-                _lines.Add(completedLine);
+                _lines.Add(new CollectedLine(DateTime.UtcNow, completedLine));
                 completedLines ??= [];
                 completedLines.Add(completedLine);
                 continue;
@@ -86,4 +101,6 @@ public class CollectingTextWriter : TextWriter
 
         return completedLines?.ToArray() ?? [];
     }
+
+    private readonly record struct CollectedLine(DateTime Timestamp, string Text);
 }


### PR DESCRIPTION
## Summary
Integration tests now use the portable Minecraft client HTTP API, default the client to an 854x480 interactive window, write richer step artifacts, and shard CI integration tests deterministically.

## Rationale
The client Docker image was rebuilt around HTTP endpoints, so the existing shell-command harness could no longer launch clients, send chat, capture screenshots, or stop clients. The smaller display default keeps captured artifacts lighter while making the API enforce consistent interaction sizing. Failed integration artifacts also need Paper server and Void proxy logs for the current game window. CI shards must not overlap or accidentally run the full suite when a shard receives no tests.

## Changes
- Bound the client API port 8080 to a random host port and waited on /health.
- Replaced shell launch, chat, screenshot, and stop flows with /start-vanilla, /send-chat, /screen, and /stop-client calls.
- Rewrote loopback Minecraft endpoints to host.docker.internal for the bridged client container and added the Linux host-gateway alias.
- Changed the portable client display from 1280x720x24 to 854x480x24.
- Added default --width 854 and --height 480 launch arguments in the client API unless the HTTP query already supplied width or height overrides.
- Resized the Minecraft window to the display size before chat input and screen capture.
- Added time-windowed step artifact logs for the current client, relevant Paper servers, and Void proxy; client logs are now written as client.log.
- Reduced integration shard count from 32 to 16 and assigned tests to shards by a stable hash over a sorted unique test list.
- Added shard assignment diagnostics and skipped empty shards instead of running dotnet test with an empty filter.

## Verification
- Installed .NET SDK 10.0.108 from Ubuntu packages.
- Dry-ran the shard assignment logic locally with 16 buckets: discovered=10, assigned=10, unique=10, duplicate_assignments=0, empty_shards=6.
- Ran `DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 dotnet test tests/Void.UnitTests/ --no-restore -v:minimal -m:1 /p:UseSharedCompilation=false`.
- Ran `DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 dotnet build --no-restore -m:1 /p:UseSharedCompilation=false`.
- Did not run integration tests, per repository guidance.

## Performance
No runtime proxy performance impact. Test harness startup now waits on the HTTP health endpoint and avoids long-lived docker exec processes for the client. Screenshots use a smaller 854x480 capture size. CI integration fan-out is reduced from 32 to 16 shards.

## Risks & Rollback
Risk is limited to integration-test harness networking, portable client launch/window sizing, test artifact log collection, and CI shard filtering. Step artifact logs are isolated by time window, so local parallel integration runs can still include concurrent-test noise. Roll back by reverting the PR commits to restore the previous shell-command harness, 1280x720 client display, and previous shard filter.

## Breaking/Migration
No public proxy API migration. The integration harness now requires the portable client image to expose the documented HTTP endpoints on port 8080. Client API callers can still override width and height through repeated query argument values.

## Links
N/A