### PR TITLE
test(integration): 🧪 required client join during setup

### DIFF
--- a/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
+++ b/tests/Void.IntegrationTests/Infrastructure/Harness/Sides/PortableMinecraftClient.cs
@@ -22,6 +22,8 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
     private const int SetupRetries = 5;
     private const int ApiPort = 8080;
     private const int ClientStatePollDelayMilliseconds = 250;
+    private const int JoinStatePollDelayMilliseconds = 100;
+    private const string ClientLogFileName = "client.log";
     private const string Display = ":99";
     private const string DockerHost = "host.docker.internal";
     private const string DockerHostGateway = "host-gateway";
@@ -34,7 +36,7 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         // These do connect to the server before the loading screen completes, causing MC-228828 crash on 1.14-1.19
         .Where(version => version < ProtocolVersion.MINECRAFT_1_14 || version > ProtocolVersion.MINECRAFT_1_19);
 
-    public string LogFileName => "client.log";
+    public string LogFileName => ClientLogFileName;
     public IEnumerable<string> Logs => ReadLogsAsync(_readLogsSince).GetAwaiter().GetResult();
 
     public void ClearLogs()
@@ -147,6 +149,7 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
                 await game.StartVanillaAsync(dockerHost, dockerPort, cancellationToken);
                 await container.ExpectTextAsync("Connecting to", cancellationToken);
                 await game.EnsureStableAsync(cancellationToken);
+                await game.EnsureJoinedServerAsync(cancellationToken);
             }
             catch
             {
@@ -207,6 +210,38 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
 
             await LogAsync($"Logs are stable after {Stopwatch.GetElapsedTime(timestamp).TotalSeconds:F2} seconds", cancellationToken);
             await MakeStepAsync("stable", cancellationToken);
+        }
+
+        private async Task EnsureJoinedServerAsync(CancellationToken cancellationToken = default)
+        {
+            var logSides = LogSides.Where(side => side.LogFileName != ClientLogFileName).ToArray();
+
+            if (logSides.Length is 0)
+                return;
+
+            var timestamp = Stopwatch.GetTimestamp();
+            await LogAsync($"Waiting for {Username} to join a server", cancellationToken);
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(Timeouts.StepTimeout);
+
+            while (!timeout.IsCancellationRequested)
+            {
+                foreach (var side in logSides)
+                {
+                    var logs = await side.ReadLogsAsync(StartedAt, timeout.Token);
+
+                    if (logs.Any(IsJoinedServerLog))
+                    {
+                        await LogAsync($"{Username} joined a server after {Stopwatch.GetElapsedTime(timestamp).TotalSeconds:F2} seconds", cancellationToken);
+                        return;
+                    }
+                }
+
+                await Task.Delay(JoinStatePollDelayMilliseconds, timeout.Token);
+            }
+
+            timeout.Token.ThrowIfCancellationRequested();
         }
 
         private async Task StartVanillaAsync(string dockerHost, int dockerPort, CancellationToken cancellationToken = default)
@@ -365,6 +400,14 @@ public record PortableMinecraftClient(IContainer Container, HttpClient HttpClien
         {
             var query = string.Join("&", queryParameters.Select(parameter => $"{Uri.EscapeDataString(parameter.Key)}={Uri.EscapeDataString(parameter.Value)}"));
             return $"{path}?{query}";
+        }
+
+        private bool IsJoinedServerLog(string line)
+        {
+            return line.Contains(Username, StringComparison.OrdinalIgnoreCase) &&
+                   (line.Contains(" joined the game", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains(" logged in with entity id", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains(" connected to ", StringComparison.OrdinalIgnoreCase));
         }
 
         private static string CreateOptionsText(ProtocolVersion protocolVersion)


### PR DESCRIPTION
## Summary
Required the portable Minecraft integration harness to observe a real server/proxy join before tests send chat.

## Rationale
The failing 1.8 artifact showed setup accepting a stable disconnected screen, then chat/redirection assertions ran against a client that had never joined. The previous broad link, transformation, redirection-test, and client API changes were removed because they masked diagnostics or were not exercised by the external client image.

## Changes
- Restored production link switching and transformation registration behavior.
- Restored the redirection test flow.
- Added a setup readiness check that polls non-client log sides for the generated username plus a strict join signal: backend `joined the game`, backend `logged in with entity id`, or proxy `connected to`.
- Kept useful packet/link exceptions visible when the actual failure path is reached.

## Verification
- `dotnet test tests/Void.UnitTests/ -m:1`
- `dotnet build -m:1`
- Initial parallel `dotnet test`/`dotnet build` attempts failed with `csc` exit code 132; sequential single-node reruns passed.
- Integration tests were not run, per repository guidance to avoid them unless explicitly requested.

## Performance
No benchmark run. The added readiness polling is test-only and runs during integration setup.

## Risks & Rollback
Risk is limited to integration harness setup: tests may now fail earlier if backend/proxy logs do not emit the expected join text. Roll back this commit to return to log-silence-only setup readiness.

## Breaking/Migration
None expected.

## Links
Follow-up to flaky proxied redirection artifacts discussed in this PR.