### PR TITLE
fix(lifecycle): 🐛 fixed legacy keep-alive ids

### DIFF
--- a/src/Plugins/Common/Services/Lifecycle/AbstractLifecycleService.cs
+++ b/src/Plugins/Common/Services/Lifecycle/AbstractLifecycleService.cs
@@ -185,7 +185,7 @@ public abstract class AbstractLifecycleService(ILogger logger, IEventService eve
                 {
                     player.Logger.LogError(exception, "Failed to send Keep Alive request {Id}", requestId);
                 }
-            }, _keepAliveInterval);
+            }, _keepAliveInterval, createRequestIdFunction: () => KeepAliveTracker.CreateRequestId(player.ProtocolVersion));
         }
 
         await tracker.PongAsync(player, id, cancellationToken);

--- a/src/Plugins/Common/Services/Lifecycle/KeepAliveTracker.cs
+++ b/src/Plugins/Common/Services/Lifecycle/KeepAliveTracker.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using ThrottleDebounce;
+using Void.Minecraft.Network;
 using Void.Minecraft.Players.Extensions;
 using Void.Proxy.Api.Players;
 using Void.Proxy.Api.Players.Extensions;
@@ -12,21 +13,42 @@ public class KeepAliveTracker : IDisposable
 
     public const int DefaultRequestId = -1;
     public delegate Task SendKeepAliveRequest(long id);
+    public delegate long CreateKeepAliveRequestId();
 
     public RateLimitedFunc<IPlayer, CancellationToken, Task<bool>> DebouncerCallback { get; }
     public System.Timers.Timer Sender { get; }
 
-    public KeepAliveTracker(SendKeepAliveRequest sendRequestFunction, TimeSpan keepAliveRequestInterval, TimeSpan keepAliveResponseTimeout = default)
+    public KeepAliveTracker(SendKeepAliveRequest sendRequestFunction, TimeSpan keepAliveRequestInterval, TimeSpan keepAliveResponseTimeout = default, CreateKeepAliveRequestId? createRequestIdFunction = null)
     {
         if (keepAliveResponseTimeout == default)
             keepAliveResponseTimeout = keepAliveRequestInterval * 3;
 
+        createRequestIdFunction ??= CreateRequestId;
+
         var timer = new System.Timers.Timer(keepAliveRequestInterval);
-        timer.Elapsed += (eventArgs, sender) => _ = sendRequestFunction(_requestId = Random.Shared.NextInt64()); // TODO: Handle exceptions?
+        timer.Elapsed += (eventArgs, sender) => _ = sendRequestFunction(_requestId = createRequestIdFunction()); // TODO: Handle exceptions?
         timer.Start();
 
         DebouncerCallback = Debouncer.Debounce<IPlayer, CancellationToken, Task<bool>>(HandleTimeoutAsync, keepAliveResponseTimeout);
         Sender = timer;
+    }
+
+    public static long CreateRequestId(ProtocolVersion protocolVersion)
+    {
+        if (UsesLegacyRequestIdWidth(protocolVersion))
+            return Random.Shared.NextInt64(int.MinValue, (long)int.MaxValue + 1);
+
+        return CreateRequestId();
+    }
+
+    public static long CreateRequestId()
+    {
+        return Random.Shared.NextInt64();
+    }
+
+    public static bool UsesLegacyRequestIdWidth(ProtocolVersion protocolVersion)
+    {
+        return protocolVersion < ProtocolVersion.MINECRAFT_1_12_2;
     }
 
     public async ValueTask PongAsync(IPlayer player, long id, CancellationToken cancellationToken)

--- a/tests/Void.UnitTests/Services/Lifecycle/KeepAliveTrackerTests.cs
+++ b/tests/Void.UnitTests/Services/Lifecycle/KeepAliveTrackerTests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Network;
+using Void.Minecraft.Network.Registries.Transformations.Mappings;
+using Void.Proxy.Plugins.Common.Network.Messages.Binary;
+using Void.Proxy.Plugins.Common.Network.Packets.Transformations.v1_12_1_to_v1_12_2;
+using Void.Proxy.Plugins.Common.Network.Registries.Transformations.Mappings;
+using Void.Proxy.Plugins.Common.Services.Lifecycle;
+using Xunit;
+
+namespace Void.UnitTests.Services.Lifecycle;
+
+public class KeepAliveTrackerTests
+{
+    [Fact]
+    public void UsesLegacyRequestIdWidth_ReturnsExpectedBoundary()
+    {
+        Assert.True(KeepAliveTracker.UsesLegacyRequestIdWidth(ProtocolVersion.MINECRAFT_1_7_2));
+        Assert.True(KeepAliveTracker.UsesLegacyRequestIdWidth(ProtocolVersion.MINECRAFT_1_12_1));
+        Assert.False(KeepAliveTracker.UsesLegacyRequestIdWidth(ProtocolVersion.MINECRAFT_1_12_2));
+        Assert.False(KeepAliveTracker.UsesLegacyRequestIdWidth(ProtocolVersion.Latest));
+    }
+
+    [Fact]
+    public void CreateRequestId_ForLegacyVersion_ReturnsSignedIntRange()
+    {
+        for (var i = 0; i < 256; i++)
+        {
+            var id = KeepAliveTracker.CreateRequestId(ProtocolVersion.MINECRAFT_1_12_1);
+
+            Assert.InRange(id, int.MinValue, int.MaxValue);
+        }
+    }
+
+    [Fact]
+    public void LegacyWidthRequestIds_SurviveKeepAliveTransformationRoundTrip()
+    {
+        var ids = new long[] { int.MinValue, -1, 0, 1962467597, int.MaxValue };
+
+        foreach (var id in ids)
+            Assert.Equal(id, TransformLongThroughLegacyWireFormat(id));
+    }
+
+    [Fact]
+    public void ArbitraryLongRequestId_DoesNotSurviveKeepAliveTransformationRoundTrip()
+    {
+        const long sentId = 1983115045386117389;
+        const long receivedId = 1962467597;
+
+        var transformedId = TransformLongThroughLegacyWireFormat(sentId);
+
+        Assert.Equal(receivedId, transformedId);
+        Assert.NotEqual(sentId, transformedId);
+    }
+
+    private static long TransformLongThroughLegacyWireFormat(long id)
+    {
+        var transformation = new KeepAliveTransformation1_12_2();
+
+        using var longStream = new MemoryStream();
+        var longBuffer = new MinecraftBuffer(longStream);
+        longBuffer.WriteLong(id);
+        longStream.Position = 0;
+
+        using var varIntStream = Transform(longStream, transformation.Downgrade);
+        using var transformedStream = Transform(varIntStream, transformation.Upgrade);
+        var transformedBuffer = new MinecraftBuffer(transformedStream);
+
+        return transformedBuffer.ReadLong();
+    }
+
+    private static MemoryStream Transform(MemoryStream inputStream, MinecraftPacketTransformation transformation)
+    {
+        var wrapper = new MinecraftBinaryPacketWrapper(new MinecraftBinaryPacket(0, inputStream));
+        transformation(wrapper);
+        wrapper.Reset();
+
+        var outputStream = new MemoryStream();
+        var outputBuffer = new MinecraftBuffer(outputStream);
+        wrapper.WriteProcessedValues(ref outputBuffer);
+        outputStream.Position = 0;
+
+        return outputStream;
+    }
+}

--- a/tests/Void.UnitTests/Void.UnitTests.csproj
+++ b/tests/Void.UnitTests/Void.UnitTests.csproj
@@ -22,6 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\src\Plugins\Common\Void.Proxy.Plugins.Common.csproj" />
 	  <ProjectReference Include="..\..\src\Platform\Void.Proxy.csproj" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Fixed proxy-generated keep-alive IDs so legacy clients no longer respond with truncated values that trigger false mismatch warnings.

## Rationale
Protocols before Minecraft 1.12.2 use a 32-bit keep-alive ID on the wire, while the proxy was storing arbitrary 64-bit IDs before the existing transformations downgraded them. Keeping generated IDs inside the legacy width avoids false mismatches without changing modern 64-bit behavior.

## Changes
Added protocol-aware keep-alive ID generation for players before 1.12.2, wired lifecycle tracker creation to use the player protocol version, and added regression tests for the legacy width boundary and observed truncation pattern.

## Verification
dotnet test tests/Void.UnitTests/ --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -p:RunAnalyzers=false -m:1 -v:minimal
dotnet build -p:UseSharedCompilation=false -p:BuildInParallel=false -p:RunAnalyzers=false -m:1 -v:minimal

Plain dotnet test and dotnet build hit local Roslyn csc exit-code 132 crashes in this environment, so the stable shared-compilation-disabled and analyzer-disabled commands were used.

## Performance
No expected performance impact; ID generation remains one random value per keep-alive interval.

## Risks & Rollback
Risk is limited to proxy-generated keep-alive requests for legacy protocol clients. Roll back by reverting this commit if unexpected keep-alive behavior appears.

## Breaking/Migration
No user-facing breaking changes or migration steps.

## Links
N/A