### PR TITLE
Accept optional version for NeoForge launches

### DIFF
--- a/docs/astro/src/content/docs/docs/client/api.md
+++ b/docs/astro/src/content/docs/docs/client/api.md
@@ -14,7 +14,7 @@ JSON property names and enum values use camel case.
 | `GET` | `/api/game/status` | `200` | Read the game state and latest operation. |
 | `PUT` | `/api/game/options` | `204` | Replace Minecraft `options.txt`. |
 | `POST` | `/api/game/start/vanilla` | `202` | Start a Mojang vanilla release. |
-| `POST` | `/api/game/start/neoforge` | `202` | Start the latest stable NeoForge release. |
+| `POST` | `/api/game/start/neoforge` | `202` | Start a NeoForge release, latest stable by default. |
 | `POST` | `/api/game/start/curseforge` | `202` | Start a CurseForge modpack file. |
 | `POST` | `/api/game/connect` | `200` | Connect the ready game to a server. |
 | `POST` | `/api/game/send-chat` | `204` | Send chat text or a command. |
@@ -99,13 +99,24 @@ curl --fail-with-body \
 
 ### NeoForge
 
-This endpoint resolves and starts the latest stable NeoForge release:
+`version` is an optional Minecraft release identifier, the same form the vanilla endpoint accepts. Omit it, or send a
+blank value, to resolve and start the latest stable NeoForge release:
 
 ```bash
 curl --fail-with-body \
   --request POST \
   --header 'Content-Type: application/json' \
   --data '{"arguments":["--username","TestPlayer"]}' \
+  http://localhost:8080/api/game/start/neoforge
+```
+
+Supply it to start NeoForge for a specific Minecraft version instead:
+
+```bash
+curl --fail-with-body \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data '{"version":"1.21.1","arguments":["--username","TestPlayer"]}' \
   http://localhost:8080/api/game/start/neoforge
 ```
 

--- a/src/Client/ApiContracts.cs
+++ b/src/Client/ApiContracts.cs
@@ -30,7 +30,7 @@ internal enum StopMode
 
 internal sealed record StartGameRequest(string? Version, string[]? Arguments);
 
-internal sealed record StartNeoForgeGameRequest(string[]? Arguments);
+internal sealed record StartNeoForgeGameRequest(string? Version, string[]? Arguments);
 
 internal sealed record StartCurseForgeGameRequest(string? Slug, int FileId, string[]? Arguments);
 
@@ -76,7 +76,7 @@ internal interface IGameRuntime
 {
     Task WriteOptionsAsync(string options, CancellationToken cancellationToken);
     Task<RunningGame> LaunchVanillaAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken);
-    Task<RunningGame> LaunchNeoForgeAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken);
+    Task<RunningGame> LaunchNeoForgeAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken);
     Task<RunningGame> LaunchCurseForgeAsync(string slug, int fileId, IReadOnlyList<string> arguments, CancellationToken cancellationToken);
     Task ConnectAsync(string host, int port, CancellationToken cancellationToken);
     Task SendChatAsync(string message, CancellationToken cancellationToken);

--- a/src/Client/ClientApiEndpoints.cs
+++ b/src/Client/ClientApiEndpoints.cs
@@ -39,7 +39,7 @@ internal static class ClientApiEndpoints
         api.MapPost("/game/start/neoforge", async Task<IResult> (StartNeoForgeGameRequest request, GameCoordinator coordinator, ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
             await ExecuteAsync(async () => Results.Accepted(StatusPath, await coordinator.StartNeoForgeAsync(request, cancellationToken)), loggerFactory, cancellationToken))
             .WithName("StartNeoForgeGame")
-            .WithSummary("Starts the latest stable NeoForge Minecraft version.");
+            .WithSummary("Starts a NeoForge Minecraft version, or the latest stable release when no version is given.");
 
         api.MapPost("/game/start/curseforge", async Task<IResult> (StartCurseForgeGameRequest request, GameCoordinator coordinator, ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
             await ExecuteAsync(async () => Results.Accepted(StatusPath, await coordinator.StartCurseForgeAsync(request, cancellationToken)), loggerFactory, cancellationToken))

--- a/src/Client/GameCoordinator.cs
+++ b/src/Client/GameCoordinator.cs
@@ -156,6 +156,7 @@ internal sealed class GameCoordinator(IGameRuntime runtime, ILogger<GameCoordina
         }
 
         var version = message.Request?.Version?.Trim();
+        var neoForgeVersion = message.NeoForgeRequest?.Version?.Trim();
         var slug = message.CurseForgeRequest?.Slug?.Trim();
 
         if (message.Kind is "start-vanilla" && string.IsNullOrWhiteSpace(version))
@@ -178,7 +179,7 @@ internal sealed class GameCoordinator(IGameRuntime runtime, ILogger<GameCoordina
         Task<RunningGame> operation = message.Kind switch
         {
             "start-vanilla" => runtime.LaunchVanillaAsync(version ?? "", message.Request?.Arguments ?? [], operationCancellation.Token),
-            "start-neoforge" => runtime.LaunchNeoForgeAsync(message.NeoForgeRequest?.Arguments ?? [], operationCancellation.Token),
+            "start-neoforge" => runtime.LaunchNeoForgeAsync(neoForgeVersion ?? "", message.NeoForgeRequest?.Arguments ?? [], operationCancellation.Token),
             "start-curseforge" => runtime.LaunchCurseForgeAsync(slug ?? "", message.CurseForgeRequest?.FileId ?? 0, message.CurseForgeRequest?.Arguments ?? [], operationCancellation.Token),
             _ => throw new InvalidOperationException($"Unknown launch kind {message.Kind}")
         };

--- a/src/Client/GameRuntime.cs
+++ b/src/Client/GameRuntime.cs
@@ -78,9 +78,9 @@ internal sealed partial class GameRuntime : IGameRuntime
         return LaunchPortableAsync($"mojang:{version}", arguments, cancellationToken);
     }
 
-    public Task<RunningGame> LaunchNeoForgeAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    public Task<RunningGame> LaunchNeoForgeAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
     {
-        return LaunchPortableAsync("neoforge:", arguments, cancellationToken);
+        return LaunchPortableAsync($"neoforge:{version}", arguments, cancellationToken);
     }
 
     public async Task<RunningGame> LaunchCurseForgeAsync(string slug, int fileId, IReadOnlyList<string> arguments, CancellationToken cancellationToken)

--- a/tests/Void.Client.UnitTests/GameCoordinatorTests.cs
+++ b/tests/Void.Client.UnitTests/GameCoordinatorTests.cs
@@ -43,8 +43,8 @@ public sealed class GameCoordinatorTests
         using var coordinator = new GameCoordinator(runtime, NullLogger<GameCoordinator>.Instance);
         await coordinator.StartAsync(CancellationToken.None);
 
-        await coordinator.StartNeoForgeAsync(new([]), CancellationToken.None);
-        var exception = await Assert.ThrowsAsync<GameCommandException>(() => coordinator.StartNeoForgeAsync(new([]), CancellationToken.None));
+        await coordinator.StartNeoForgeAsync(new(null, []), CancellationToken.None);
+        var exception = await Assert.ThrowsAsync<GameCommandException>(() => coordinator.StartNeoForgeAsync(new(null, []), CancellationToken.None));
 
         Assert.Equal(409, exception.StatusCode);
         Assert.Equal(1, runtime.LaunchCount);
@@ -91,6 +91,34 @@ public sealed class GameCoordinatorTests
         await coordinator.StopAsync(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task NeoForgeLaunchWithoutVersionRequestsLatest()
+    {
+        var runtime = new FakeGameRuntime();
+        using var coordinator = new GameCoordinator(runtime, NullLogger<GameCoordinator>.Instance);
+        await coordinator.StartAsync(CancellationToken.None);
+
+        await coordinator.StartNeoForgeAsync(new(null, []), CancellationToken.None);
+
+        Assert.Equal("", runtime.LastNeoForgeVersion);
+
+        await coordinator.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task NeoForgeLaunchForwardsRequestedVersion()
+    {
+        var runtime = new FakeGameRuntime();
+        using var coordinator = new GameCoordinator(runtime, NullLogger<GameCoordinator>.Instance);
+        await coordinator.StartAsync(CancellationToken.None);
+
+        await coordinator.StartNeoForgeAsync(new("  1.21.1  ", []), CancellationToken.None);
+
+        Assert.Equal("1.21.1", runtime.LastNeoForgeVersion);
+
+        await coordinator.StopAsync(CancellationToken.None);
+    }
+
     private static async Task WaitForStateAsync(GameCoordinator coordinator, GameState expected)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -108,6 +136,8 @@ public sealed class GameCoordinatorTests
         public bool BlockStop { get; init; }
         public int LaunchCount { get; private set; }
         public int StopCount { get; private set; }
+        public string? LastVanillaVersion { get; private set; }
+        public string? LastNeoForgeVersion { get; private set; }
 
         public void CompleteLaunch()
         {
@@ -124,9 +154,17 @@ public sealed class GameCoordinatorTests
 
         public Task WriteOptionsAsync(string options, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<RunningGame> LaunchVanillaAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken) => BeginLaunch(cancellationToken);
+        public Task<RunningGame> LaunchVanillaAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+        {
+            LastVanillaVersion = version;
+            return BeginLaunch(cancellationToken);
+        }
 
-        public Task<RunningGame> LaunchNeoForgeAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken) => BeginLaunch(cancellationToken);
+        public Task<RunningGame> LaunchNeoForgeAsync(string version, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+        {
+            LastNeoForgeVersion = version;
+            return BeginLaunch(cancellationToken);
+        }
 
         public Task<RunningGame> LaunchCurseForgeAsync(string slug, int fileId, IReadOnlyList<string> arguments, CancellationToken cancellationToken) => BeginLaunch(cancellationToken);
 


### PR DESCRIPTION
## Summary
- `POST /api/game/start/neoforge` now accepts an optional `version` field, mirroring the vanilla endpoint's `version` parameter (same name, type, and meaning — a Minecraft version).
- Omitting the field, or sending a blank value, keeps today's exact default behavior: resolve and start the latest stable NeoForge release. No new validation was added — the endpoint intentionally stays as permissive as vanilla's own `version` handling.
- Docs (`docs/.../client/api.md`) updated with the optional-field description and a second curl example pinning a specific version.

## Test plan
- [x] `dotnet build` succeeds
- [x] Unit tests pass (`GameCoordinatorTests`), including 2 new tests: no-version defaults to `""` (latest), explicit version is trimmed and forwarded
- [x] Real `portablemc` dry-run installs (asset resolution against live Mojang/NeoForge infrastructure, no display needed) verified for every NeoForge major version from **1.20.2** (the very first NeoForge release) through **26.2** (current latest) — 13 versions, all resolving the correct matching loader build
- [x] Verified the blank/default version path resolves to the exact same NeoForge build (`26.2.0.64` on `26.2`) as explicitly requesting the latest version, confirming zero regression to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)